### PR TITLE
The ConfigureFisher(...) lambda extensions over IConfigureFisher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2224,6 +2224,20 @@ registration surface was missing.
 - **`IConfigureFisher<T>` exists because which store a contribution is about has to be sayable.** An
   untargeted contribution reaches the primary store only; without the distinction, a library's
   configuration would reach stores it has never heard of.
+- **`ConfigureFisher(...)` is the lambda form, and it is what makes the three stores' integration code
+  read alike** (fisher#70, over JasperFx/wolverine#3907). Four overloads mirroring
+  `PolecatStoreServiceCollectionExtensions`: a primary and a targeted pair, each with and without the
+  container. Wolverine's ancillary integration uses exactly this to layer its own `StoreOptions`
+  contributions onto a store somebody else registered.
+- **Both registration styles are swept, and the second silently did nothing.** Fisher resolves
+  `IConfigureFisher` and filters by the contribution's own interfaces; Marten and Polecat resolve the
+  closed `IConfigure*<T>` directly, so code ported from either registers against `IConfigureFisher<T>`
+  — which `GetServices<IConfigureFisher>()` does not return, because the container matches on the
+  service type a registration *named* rather than on what it implements. A contribution that compiles,
+  registers and never runs. `Configured` now sweeps both and deduplicates **by reference**, which is
+  what lets `ConfigureFisher<T>` register its lambda against both service types and still configure
+  once. `a_contribution_registered_against_the_closed_interface_is_applied` and
+  `a_targeted_lambda_configures_once` pin the two halves, each verified by reverting it.
 - `StoreName` defaults to the marker's name, so two stores are distinguishable in a monitoring tool and
   in a trace with nothing said.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.5.3</Version>
+        <Version>0.6.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/docs/configuration/hostbuilder.md
+++ b/docs/configuration/hostbuilder.md
@@ -137,6 +137,36 @@ builder.Services.AddFisher(options => options.Connection("Data Source=app.db"));
 An untargeted `IConfigureFisher` reaches the **primary** store only. To contribute to a secondary
 store, use the targeted `IConfigureFisher<T>` — see [Multiple Stores](/configuration/multiple-stores).
 
+### ConfigureFisher(...)
+
+For a contribution that does not warrant a class of its own, `ConfigureFisher(...)` is the lambda
+form of the same seam — and the same surface Marten's `ConfigureMarten` and Polecat's
+`ConfigurePolecat` present, so integration code that layers its own options onto a store somebody
+else registered reads alike across the three stores:
+
+<!-- snippet: sample_configure_fisher_lambda -->
+<a id='snippet-sample_configure_fisher_lambda'></a>
+```cs
+// Layered onto whatever store the application configured, either side of the AddFisher call.
+services.ConfigureFisher(options =>
+{
+    options.Schema.For<Report>().Duplicate(x => x.RunAt);
+    options.Projections.Snapshot<Report>(SnapshotLifecycle.Async);
+});
+
+// The overload taking the container as well, for configuration that needs a resolved service.
+services.ConfigureFisher((serviceProvider, options) =>
+{
+    options.Projections.Add(
+        serviceProvider.GetRequiredService<SalesProjection>(), ProjectionLifecycle.Async);
+});
+```
+<sup><a href='https://github.com/JasperFx/fisher/blob/main/src/Fisher.Tests/Documentation/configuration_samples.cs#L29-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configure_fisher_lambda' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Contributions run after the `AddFisher(...)` lambda, in registration order, and may be registered
+either side of it — they are resolved when the store is built, not when the call is made.
+
 ## Session Factories
 
 By default, the scoped `IDocumentSession` is a lightweight session. Supply your own `ISessionFactory`

--- a/docs/configuration/multiple-stores.md
+++ b/docs/configuration/multiple-stores.md
@@ -90,6 +90,28 @@ public class ReportingProjections : IConfigureFisher<IReportingStore>
 An untargeted `IConfigureFisher` reaches the primary store only. Without the distinction, a library's
 configuration would reach stores it has never heard of.
 
+`ConfigureFisher<T>(...)` is the lambda form, for a contribution that does not warrant a class:
+
+<!-- snippet: sample_configure_fisher_lambda_targeted -->
+<a id='snippet-sample_configure_fisher_lambda_targeted'></a>
+```cs
+// Reaches the store registered as IReportingStore, and no other.
+services.ConfigureFisher<IReportingStore>(options =>
+    options.Projections.Add(new SalesProjection(), ProjectionLifecycle.Async));
+
+services.ConfigureFisher<IReportingStore>((serviceProvider, options) =>
+    options.Projections.Add(
+        serviceProvider.GetRequiredService<SalesProjection>(), ProjectionLifecycle.Async));
+```
+<sup><a href='https://github.com/JasperFx/fisher/blob/main/src/Fisher.Tests/Documentation/configuration_samples.cs#L48-L56' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configure_fisher_lambda_targeted' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: tip
+Either registration style works. Fisher sweeps both `IConfigureFisher` and the closed
+`IConfigureFisher<T>`, so code ported from Marten or Polecat — which register against the closed
+interface — behaves the same way here. A contribution registered against both is still applied once.
+:::
+
 ## How the marker is implemented
 
 The marker is implemented with `System.Reflection.DispatchProxy` — in the BCL, so no proxy library

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -23,6 +23,7 @@ builder.Services.AddFisher(opts => opts.Connection("Data Source=app.db"));
 | :--- | :--- |
 | `AddMarten` / `AddPolecat` | `AddFisher` |
 | `IConfigureMarten` / `IConfigurePolecat` | `IConfigureFisher` |
+| `ConfigureMarten` / `ConfigurePolecat` | `ConfigureFisher` |
 | `AddMartenStore<T>` / `AddPolecatStore<T>` | `AddFisherStore<T>` |
 | `DocumentMetadata` (the read result) | `StoredDocumentMetadata` |
 | `IChangeSet.Deleted` is `IEnumerable<IDeletion>` | `IEnumerable<IDocumentDeletion>` |

--- a/src/Fisher.Tests/Configuration/multi_store_registration.cs
+++ b/src/Fisher.Tests/Configuration/multi_store_registration.cs
@@ -302,6 +302,147 @@ public class multi_store_registration : IAsyncLifetime
         await host.StopAsync(Token);
     }
 
+    // ---- ConfigureFisher(...) — the lambda form (fisher#70) ----
+
+    /// <remarks>
+    ///     The lambda convenience both siblings ship, so integration code that layers its own options
+    ///     onto a store somebody else registered reads alike across the three stores.
+    /// </remarks>
+    [Fact]
+    public async Task a_lambda_contribution_reaches_the_primary_store()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.ConfigureFisher(options =>
+                    options.Projections.Add(new CourseProjection(), ProjectionLifecycle.Inline));
+
+                services.AddFisher(options => options.ConnectionString = _first.ConnectionString);
+            })
+            .StartAsync(Token);
+
+        host.Services.GetRequiredService<IDocumentStore>()
+            .Options.Projections.All.Any(x => x is CourseProjection).ShouldBeTrue();
+
+        await host.StopAsync(Token);
+    }
+
+    [Fact]
+    public async Task a_lambda_contribution_can_read_a_service()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton(new ProjectionSwitch(true));
+
+                services.ConfigureFisher((sp, options) =>
+                {
+                    if (sp.GetRequiredService<ProjectionSwitch>().Enabled)
+                    {
+                        options.Projections.Add(new CourseProjection(), ProjectionLifecycle.Inline);
+                    }
+                });
+
+                services.AddFisher(options => options.ConnectionString = _first.ConnectionString);
+            })
+            .StartAsync(Token);
+
+        host.Services.GetRequiredService<IDocumentStore>()
+            .Options.Projections.All.Any(x => x is CourseProjection).ShouldBeTrue();
+
+        await host.StopAsync(Token);
+    }
+
+    /// <remarks>
+    ///     The targeted form, which is what an ancillary-store integration needs — a contribution that
+    ///     reached every store in the application, including ones the library has never heard of, would
+    ///     not be configuration but a surprise.
+    /// </remarks>
+    [Fact]
+    public async Task a_targeted_lambda_reaches_only_the_store_it_names()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.ConfigureFisher<IArchiveStore>(options =>
+                    options.Projections.Add(new CourseProjection(), ProjectionLifecycle.Inline));
+
+                services.AddFisher(options => options.ConnectionString = _first.ConnectionString);
+
+                services.AddFisherStore<IArchiveStore>(options =>
+                    options.ConnectionString = _second.ConnectionString);
+            })
+            .StartAsync(Token);
+
+        host.Services.GetRequiredService<IDocumentStore>()
+            .Options.Projections.All.Any(x => x is CourseProjection).ShouldBeFalse();
+
+        host.Services.GetRequiredService<IArchiveStore>()
+            .Options.Projections.All.Any(x => x is CourseProjection).ShouldBeTrue();
+
+        await host.StopAsync(Token);
+    }
+
+    /// <remarks>
+    ///     <c>ConfigureFisher&lt;T&gt;</c> registers its lambda against both service types, so the
+    ///     dedup in <c>Configured</c> is what keeps one call from configuring twice. Counted rather than
+    ///     asserted on the options, because adding the same projection twice would look identical to
+    ///     adding it once through most assertions.
+    /// </remarks>
+    [Fact]
+    public async Task a_targeted_lambda_configures_once()
+    {
+        var calls = 0;
+
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.ConfigureFisher<IArchiveStore>(_ => Interlocked.Increment(ref calls));
+
+                services.AddFisherStore<IArchiveStore>(options =>
+                    options.ConnectionString = _second.ConnectionString);
+            })
+            .StartAsync(Token);
+
+        _ = host.Services.GetRequiredService<IArchiveStore>().Options;
+
+        calls.ShouldBe(1);
+
+        await host.StopAsync(Token);
+    }
+
+    /// <remarks>
+    ///     <b>This registration style silently did nothing</b> (fisher#70). Polecat and Marten resolve
+    ///     the closed <c>IConfigure*&lt;T&gt;</c>, so code ported from either registers against
+    ///     <c>IConfigureFisher&lt;T&gt;</c> — which <c>GetServices&lt;IConfigureFisher&gt;()</c> does not
+    ///     return, because the container matches on the service type a registration named rather than on
+    ///     what it implements. A contribution that compiles, registers and never runs.
+    /// </remarks>
+    [Fact]
+    public async Task a_contribution_registered_against_the_closed_interface_is_applied()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton(new ProjectionSwitch(true));
+                services.AddSingleton<IConfigureFisher<IArchiveStore>, EnableTheProjectionOnTheArchive>();
+
+                services.AddFisher(options => options.ConnectionString = _first.ConnectionString);
+
+                services.AddFisherStore<IArchiveStore>(options =>
+                    options.ConnectionString = _second.ConnectionString);
+            })
+            .StartAsync(Token);
+
+        host.Services.GetRequiredService<IDocumentStore>()
+            .Options.Projections.All.Any(x => x is CourseProjection).ShouldBeFalse();
+
+        host.Services.GetRequiredService<IArchiveStore>()
+            .Options.Projections.All.Any(x => x is CourseProjection).ShouldBeTrue();
+
+        await host.StopAsync(Token);
+    }
+
     /// <remarks>
     ///     One daemon per store, which is the shape that gets two concurrent writers out of SQLite.
     /// </remarks>

--- a/src/Fisher.Tests/Documentation/configuration_samples.cs
+++ b/src/Fisher.Tests/Documentation/configuration_samples.cs
@@ -1,0 +1,58 @@
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Fisher.Tests.Documentation;
+
+/*
+ * The compiled source behind docs/configuration/hostbuilder.md and
+ * docs/configuration/multiple-stores.md.
+ *
+ * See "Documentation samples" in CLAUDE.md: every sample a reader would copy lives in a
+ * #region here and is pulled into the markdown by mdsnippets, so a sample that stops compiling
+ * fails the build rather than going stale in a page nobody rebuilds.
+ */
+
+public interface IReportingStore : IDocumentStore;
+
+public class Report
+{
+    public Guid Id { get; set; }
+    public DateTimeOffset RunAt { get; set; }
+}
+
+public class SalesProjection : Fisher.Projections.SingleStreamProjection<Report, Guid>;
+
+public static class configuration_samples
+{
+    public static void configure_fisher_lambda(IServiceCollection services)
+    {
+        #region sample_configure_fisher_lambda
+        // Layered onto whatever store the application configured, either side of the AddFisher call.
+        services.ConfigureFisher(options =>
+        {
+            options.Schema.For<Report>().Duplicate(x => x.RunAt);
+            options.Projections.Snapshot<Report>(SnapshotLifecycle.Async);
+        });
+
+        // The overload taking the container as well, for configuration that needs a resolved service.
+        services.ConfigureFisher((serviceProvider, options) =>
+        {
+            options.Projections.Add(
+                serviceProvider.GetRequiredService<SalesProjection>(), ProjectionLifecycle.Async);
+        });
+        #endregion
+    }
+
+    public static void configure_fisher_lambda_targeted(IServiceCollection services)
+    {
+        #region sample_configure_fisher_lambda_targeted
+        // Reaches the store registered as IReportingStore, and no other.
+        services.ConfigureFisher<IReportingStore>(options =>
+            options.Projections.Add(new SalesProjection(), ProjectionLifecycle.Async));
+
+        services.ConfigureFisher<IReportingStore>((serviceProvider, options) =>
+            options.Projections.Add(
+                serviceProvider.GetRequiredService<SalesProjection>(), ProjectionLifecycle.Async));
+        #endregion
+    }
+}

--- a/src/Fisher/FisherServiceCollectionExtensions.cs
+++ b/src/Fisher/FisherServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Fisher.Internal;
 using JasperFx;
 using JasperFx.Descriptors;
@@ -163,19 +164,106 @@ public static class FisherServiceCollectionExtensions
     }
 
     /// <summary>
+    ///     Contribute configuration to the primary store's options from a lambda (fisher#70).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The lambda convenience over <see cref="IConfigureFisher" />, and the same surface both
+    ///         siblings ship (<c>ConfigureMarten</c>, <c>ConfigurePolecat</c>) — so integration code that
+    ///         layers its own <see cref="StoreOptions" /> contributions onto a store somebody else
+    ///         registered reads alike across the three stores. That unification is what
+    ///         JasperFx/wolverine#3907 asked for.
+    ///     </para>
+    ///     <para>
+    ///         Runs after the <c>AddFisher(...)</c> lambda, in registration order, and may be called
+    ///         either side of it — the contributions are resolved when the store is built, not when this
+    ///         is called.
+    ///     </para>
+    /// </remarks>
+    public static IServiceCollection ConfigureFisher(this IServiceCollection services,
+        Action<StoreOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        return services.ConfigureFisher((_, options) => configure(options));
+    }
+
+    /// <inheritdoc cref="ConfigureFisher(IServiceCollection,Action{StoreOptions})" />
+    public static IServiceCollection ConfigureFisher(this IServiceCollection services,
+        Action<IServiceProvider, StoreOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.AddSingleton<IConfigureFisher>(new LambdaConfigureFisher(configure));
+        return services;
+    }
+
+    /// <summary>
+    ///     Contribute configuration to one secondary store's options from a lambda (fisher#70).
+    /// </summary>
+    /// <remarks>
+    ///     The targeted form, reaching the store registered as <typeparamref name="T" /> and no other.
+    ///     An untargeted <see cref="ConfigureFisher(IServiceCollection,Action{StoreOptions})" /> is about
+    ///     the primary store, which is the one an application that never registers a second has.
+    /// </remarks>
+    public static IServiceCollection ConfigureFisher<T>(this IServiceCollection services,
+        Action<StoreOptions> configure) where T : IDocumentStore
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        return services.ConfigureFisher<T>((_, options) => configure(options));
+    }
+
+    /// <inheritdoc cref="ConfigureFisher{T}(IServiceCollection,Action{StoreOptions})" />
+    public static IServiceCollection ConfigureFisher<T>(this IServiceCollection services,
+        Action<IServiceProvider, StoreOptions> configure) where T : IDocumentStore
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        // Registered against both service types, which is what makes either resolution style find it —
+        // see Configured for why there are two.
+        var lambda = new LambdaConfigureFisher<T>(configure);
+
+        services.AddSingleton<IConfigureFisher>(lambda);
+        services.AddSingleton<IConfigureFisher<T>>(lambda);
+
+        return services;
+    }
+
+    /// <summary>
     ///     Apply every matching <see cref="IConfigureFisher" /> to a store's options.
     /// </summary>
     /// <remarks>
-    ///     After the registration lambda, so the lambda states the store's shape and these adjust it —
-    ///     and filtered by store, because a contribution registered by one library reaching every store
-    ///     in the application, including ones it has never heard of, is not configuration but a
-    ///     surprise.
+    ///     <para>
+    ///         After the registration lambda, so the lambda states the store's shape and these adjust it —
+    ///         and filtered by store, because a contribution registered by one library reaching every store
+    ///         in the application, including ones it has never heard of, is not configuration but a
+    ///         surprise.
+    ///     </para>
+    ///     <para>
+    ///         <b>Both registration styles are swept, and the second was silently ignored</b> (fisher#70).
+    ///         Fisher resolves <see cref="IConfigureFisher" /> and filters by the contribution's own
+    ///         interfaces; Polecat and Marten resolve the closed <c>IConfigure*&lt;T&gt;</c> directly, so
+    ///         code ported from either registers against <see cref="IConfigureFisher{T}" /> — which
+    ///         <c>GetServices&lt;IConfigureFisher&gt;()</c> does not return, because the container matches
+    ///         on the service type a registration named rather than on what it implements. That is a
+    ///         contribution that compiles, registers, and never runs. Both are swept and deduplicated by
+    ///         reference, so registering against both service types (as
+    ///         <see cref="ConfigureFisher{T}(IServiceCollection,Action{StoreOptions})" /> does) still
+    ///         configures once.
+    ///     </para>
     /// </remarks>
     private static StoreOptions Configured(IServiceProvider services, StoreOptions options, Type? forStore)
     {
-        foreach (var configure in services.GetServices<IConfigureFisher>())
+        var applied = new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        foreach (var configure in services.GetServices<IConfigureFisher>().Concat(TargetedAt(services, forStore)))
         {
-            if (AppliesTo(configure, forStore))
+            if (AppliesTo(configure, forStore) && applied.Add(configure))
             {
                 configure.Configure(services, options);
             }
@@ -183,6 +271,15 @@ public static class FisherServiceCollectionExtensions
 
         return options;
     }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2055:MakeGenericType",
+        Justification = "IConfigureFisher<T> is closed over a marker interface the caller supplied to "
+            + "AddFisherStore<T> at registration time, so the trimmer already sees the instantiation.")]
+    private static IEnumerable<IConfigureFisher> TargetedAt(IServiceProvider services, Type? forStore)
+        => forStore is null
+            ? []
+            : services.GetServices(typeof(IConfigureFisher<>).MakeGenericType(forStore))
+                .OfType<IConfigureFisher>();
 
     private static bool AppliesTo(IConfigureFisher configure, Type? forStore)
     {

--- a/src/Fisher/IConfigureFisher.cs
+++ b/src/Fisher/IConfigureFisher.cs
@@ -36,3 +36,33 @@ public interface IConfigureFisher
 public interface IConfigureFisher<T> : IConfigureFisher where T : IDocumentStore
 {
 }
+
+/// <summary>
+///     The lambda form of <see cref="IConfigureFisher" />, behind
+///     <c>services.ConfigureFisher(...)</c> (fisher#70).
+/// </summary>
+internal sealed class LambdaConfigureFisher : IConfigureFisher
+{
+    private readonly Action<IServiceProvider, StoreOptions> _configure;
+
+    internal LambdaConfigureFisher(Action<IServiceProvider, StoreOptions> configure) => _configure = configure;
+
+    public void Configure(IServiceProvider services, StoreOptions options) => _configure(services, options);
+}
+
+/// <summary>
+///     The lambda form of <see cref="IConfigureFisher{T}" />, behind
+///     <c>services.ConfigureFisher&lt;T&gt;(...)</c> (fisher#70).
+/// </summary>
+/// <remarks>
+///     The type parameter is what <c>AddFisherStore&lt;T&gt;</c>'s filter reads, off this type's own
+///     interfaces — so a lambda targeted at one store reaches that store and no other.
+/// </remarks>
+internal sealed class LambdaConfigureFisher<T> : IConfigureFisher<T> where T : IDocumentStore
+{
+    private readonly Action<IServiceProvider, StoreOptions> _configure;
+
+    internal LambdaConfigureFisher(Action<IServiceProvider, StoreOptions> configure) => _configure = configure;
+
+    public void Configure(IServiceProvider services, StoreOptions options) => _configure(services, options);
+}


### PR DESCRIPTION
Closes #70.

## The ask

Four extension methods mirroring `PolecatStoreServiceCollectionExtensions` — a primary and a targeted pair, each with and without the container:

```csharp
services.ConfigureFisher(options => ...);
services.ConfigureFisher((serviceProvider, options) => ...);
services.ConfigureFisher<IReportingStore>(options => ...);
services.ConfigureFisher<IReportingStore>((serviceProvider, options) => ...);
```

Plus `LambdaConfigureFisher` / `LambdaConfigureFisher<T>` behind them. This is what Wolverine's ancillary-store integration uses to layer its own `StoreOptions` contributions onto a store somebody else registered — the surface unification JasperFx/wolverine#3907 asked for.

## One bug found while wiring it

**A contribution registered against the closed `IConfigureFisher<T>` silently did nothing.** Fisher resolves `IConfigureFisher` and filters by the contribution's own interfaces; Marten and Polecat resolve the closed `IConfigure*<T>` directly — so code ported from either registers against a service type `GetServices<IConfigureFisher>()` does not return, because the container matches on the service type a registration *named* rather than on what it implements. A contribution that compiles, registers and never runs.

That is exactly the path the issue says Wolverine already takes for one of its contributions ("Wolverine can register its own `IConfigureFisher<T>` implementations instead of using a lambda helper — it already does for one of them"), so it would have bitten the integration.

`Configured` now sweeps both service types and deduplicates **by reference** — which is also what lets `ConfigureFisher<T>` register its lambda against both and still configure once.

## Tests

Five added to `multi_store_registration`, and the two that pin the bug fix were each verified by reverting the production change:

- `a_lambda_contribution_reaches_the_primary_store`
- `a_lambda_contribution_can_read_a_service`
- `a_targeted_lambda_reaches_only_the_store_it_names`
- `a_targeted_lambda_configures_once` — fails without the dedup
- `a_contribution_registered_against_the_closed_interface_is_applied` — fails without the sweep

1247 tests green on both TFMs; docs build clean.

## Also

Version bumped to **0.6.0**. Docs: `configuration/hostbuilder`, `configuration/multiple-stores`, the migration-guide name table, and a new compiled `configuration_samples.cs` behind the two new snippets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rj9a6fs3zmARNatnTaMxbv