### PR TITLE
IEvent.StreamKey reaches an inline projection (closes #72)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3011,6 +3011,20 @@ the same method compare that value against itself and pass unconditionally. Keep
 assignment and metadata application apart is what keeps the guard real; the cost is that a new
 metadata field in JasperFx will not reach Fisher's events until this method learns about it.
 
+**The same method stamps the stream's own identity onto each event, and that is not redundant**
+(fisher#72). `StreamAction.AddEvent` stamps `StreamId`/`StreamKey`/`TenantId`, and the `Guid` append
+factory goes through it — but `StreamAction.Append(graph, string, …)` appends straight to the backing
+list and does not, and `PrepareEvents` does not close the gap either (it sets `TenantId`, `Timestamp`,
+`Version` and `Sequence`, never the stream identity). So **every event appended to a string-identified
+stream reached an inline projection with an empty `StreamKey`** — which is exactly how a
+string-identified projection learns which entity it is projecting. Nothing threw: the projection ran
+and wrote a document with a blank field, and the first visible symptom was a query returning nothing.
+Filed upstream as [jasperfx#663](https://github.com/JasperFx/jasperfx/issues/663); stamping here is
+idempotent, so it stays correct when that ships. **The async daemon was never affected** —
+`FisherEventLoader` hydrates through `FisherEventsRowReader.ReadEventAcrossStreams`, which takes the
+identity off the row. `event_envelope_metadata_in_projections` pins both identities, because the
+asymmetry is upstream's and a release closing it must not silently change which half is covered.
+
 `ComplianceEventProjection` binds to `Fisher.Projections.EventProjection`. Its one required member,
 `storeEntity`, is now an ordinary `IDocumentSession.Store` onto the session the events are committing
 in, so a `Create`/`Project` method's return value lands in the same transaction as the event that

--- a/src/Fisher.Tests/Projections/event_envelope_metadata_in_projections.cs
+++ b/src/Fisher.Tests/Projections/event_envelope_metadata_in_projections.cs
@@ -1,0 +1,150 @@
+using Fisher.Projections;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+
+namespace Fisher.Tests.Projections;
+
+/// <summary>
+///     What an <see cref="IEvent" /> envelope carries when an inline projection folds it (fisher#72).
+/// </summary>
+/// <remarks>
+///     <para>
+///         The string case is the one that was broken. <c>StreamAction.AddEvent</c> stamps
+///         <c>StreamId</c> / <c>StreamKey</c> / <c>TenantId</c> onto every event it takes, and the
+///         <c>Guid</c> append overload goes through it — but
+///         <c>StreamAction.Append(graph, string, …)</c> appends straight to the backing list and does
+///         not, so an event appended to a string-identified stream reached a projection with an empty
+///         key. Nothing threw; the projection wrote a document with a blank field. Both identities are
+///         pinned here because the fix stamps them uniformly and the asymmetry is upstream's, not
+///         Fisher's — a future JasperFx release closing jasperfx#663 must not silently change which
+///         half is covered.
+///     </para>
+///     <para>
+///         The async daemon was never affected: <c>FisherEventLoader</c> hydrates through
+///         <c>FisherEventsRowReader.ReadEventAcrossStreams</c>, which takes the identity off the row.
+///     </para>
+/// </remarks>
+public class event_envelope_metadata_in_projections : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("envelope-metadata");
+    private DocumentStore _guidStore = null!;
+    private DocumentStore _stringStore = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _stringStore = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.DatabaseSchemaName = "strings";
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.StreamIdentity = StreamIdentity.AsString;
+            options.Schema.For<EnvelopeSnapshot>();
+            options.Projections.Add(new EnvelopeProjection(), ProjectionLifecycle.Inline);
+        });
+
+        _guidStore = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.DatabaseSchemaName = "guids";
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<EnvelopeSnapshot>();
+            options.Projections.Add(new EnvelopeProjection(), ProjectionLifecycle.Inline);
+        });
+
+        await _stringStore.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+        await _guidStore.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _stringStore.DisposeAsync();
+        await _guidStore.DisposeAsync();
+        _database.Dispose();
+    }
+
+    [Fact]
+    public async Task an_appended_event_carries_its_stream_key_into_an_inline_projection()
+    {
+        await using (var session = _stringStore.LightweightSession())
+        {
+            session.Events.Append("TestService", new EnvelopeRecorded("first"), new EnvelopeRecorded("second"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _stringStore.LightweightSession();
+
+        var first = await query.LoadAsync<EnvelopeSnapshot>("first", TestContext.Current.CancellationToken);
+        var second = await query.LoadAsync<EnvelopeSnapshot>("second", TestContext.Current.CancellationToken);
+
+        first.ShouldNotBeNull();
+        second.ShouldNotBeNull();
+
+        first.StreamKey.ShouldBe("TestService");
+        second.StreamKey.ShouldBe("TestService");
+
+        first.TenantId.ShouldBe(StorageConstants.DefaultTenantId);
+        first.Version.ShouldBe(1);
+        second.Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task a_started_stream_carries_its_stream_key_into_an_inline_projection()
+    {
+        await using (var session = _stringStore.LightweightSession())
+        {
+            session.Events.StartStream("StartedService", new EnvelopeRecorded("started"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _stringStore.LightweightSession();
+
+        var entry = await query.LoadAsync<EnvelopeSnapshot>("started", TestContext.Current.CancellationToken);
+
+        entry.ShouldNotBeNull();
+        entry.StreamKey.ShouldBe("StartedService");
+    }
+
+    [Fact]
+    public async Task an_appended_event_carries_its_stream_id_into_an_inline_projection()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = _guidStore.LightweightSession())
+        {
+            session.Events.Append(streamId, new EnvelopeRecorded("guid-first"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _guidStore.LightweightSession();
+
+        var entry = await query.LoadAsync<EnvelopeSnapshot>("guid-first", TestContext.Current.CancellationToken);
+
+        entry.ShouldNotBeNull();
+        entry.StreamId.ShouldBe(streamId);
+    }
+}
+
+public record EnvelopeRecorded(string Name);
+
+// partial, because JasperFx's source generator emits the conventional-method dispatcher into it.
+public partial class EnvelopeProjection : EventProjection
+{
+    public EnvelopeSnapshot Create(IEvent<EnvelopeRecorded> e) => new()
+    {
+        Id = e.Data.Name,
+        StreamId = e.StreamId,
+        StreamKey = e.StreamKey ?? string.Empty,
+        TenantId = e.TenantId ?? string.Empty,
+        Version = e.Version
+    };
+}
+
+public class EnvelopeSnapshot
+{
+    public string Id { get; set; } = string.Empty;
+    public Guid StreamId { get; set; }
+    public string StreamKey { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public long Version { get; set; }
+}

--- a/src/Fisher/Events/AppendPlanner.cs
+++ b/src/Fisher/Events/AppendPlanner.cs
@@ -158,11 +158,30 @@ internal sealed class AppendPlanner
     ///         written at all — stamping the envelope anyway would report metadata on append that no
     ///         longer exists after a round trip.
     ///     </para>
+    ///     <para>
+    ///         The stream's own identity is stamped here too, and that is <b>not</b> redundant
+    ///         (fisher#72). <c>StreamAction.AddEvent</c> stamps <c>StreamId</c>/<c>StreamKey</c>, but
+    ///         <c>StreamAction.Append(graph, string, …)</c> appends straight to the backing list and
+    ///         bypasses it, where the <c>Guid</c> overload beside it does not — so every event appended
+    ///         to a string-identified stream reached an inline projection with an empty
+    ///         <c>StreamKey</c>. That is the normal way a string-identified projection learns which
+    ///         entity it is projecting, and the failure was silent: the document was written with a
+    ///         blank key rather than anything throwing. Filed upstream as jasperfx#663; stamping here
+    ///         is idempotent, so it stays correct either way.
+    ///     </para>
     /// </remarks>
     private void ApplySessionMetadata(StreamAction stream)
     {
         foreach (var @event in stream.Events)
         {
+            @event.StreamId = stream.Id;
+            @event.StreamKey = stream.Key;
+
+            if (!string.IsNullOrEmpty(stream.TenantId))
+            {
+                @event.TenantId = stream.TenantId;
+            }
+
             if (_session.CorrelationIdEnabled)
             {
                 @event.CorrelationId ??= _session.CorrelationId;


### PR DESCRIPTION
Closes #72.

`StreamAction.AddEvent` stamps `StreamId`/`StreamKey`/`TenantId` onto every event it takes, and `StreamAction.Append(graph, Guid, …)` goes through it — but `StreamAction.Append(graph, string, …)` appends straight to the backing list and does not:

```csharp
// Guid — stamped
stream.AddEvents(events.Select(graph.BuildEvent).ToArray());

// string — not stamped
stream._events.AddRange(events.Select(graph.BuildEvent));
```

`PrepareEvents` does not close the gap either: `applyQuickMetadata` and `applyRichMetadata` set `TenantId`, `Timestamp`, `Version` and `Sequence`, never the stream identity. So every event appended to a string-identified stream reached an inline projection with an empty `StreamKey` — which is exactly how such a projection learns which entity it is projecting. Nothing threw; the projection ran and wrote a document with a blank field, and the first visible symptom was a query returning nothing.

## The fix

`AppendPlanner.ApplySessionMetadata` already exists as "the metadata JasperFx would have applied, which Fisher has to apply itself" — it is there because Fisher cannot use `PrepareEvents` without defeating its own concurrency guard. It runs both ahead of inline projections and inside the write transaction, so the stream identity goes there too. Stamping is idempotent, so it stays correct once the upstream asymmetry is fixed.

Filed upstream as JasperFx/jasperfx#663.

## Scope, checked in the same pass

The issue asked which of `StreamId`, `TenantId`, `Version`, `Sequence` and `Timestamp` also fail to survive.

- **`Version`** was already assigned by `AssignVersionsAheadOfProjectionsAsync` — the whole reason that early pass exists.
- **`TenantId`** was already correct: `StreamAction.TenantId`'s setter propagates to the events it holds, and Fisher sets it right after construction.
- **`StreamId`** on the `Guid` path was already correct, via `AddEvent`. It is now stamped uniformly and pinned anyway, because the asymmetry is upstream's and a release closing it must not silently change which half is covered.
- **The async daemon was never affected.** `FisherEventLoader` hydrates through `FisherEventsRowReader.ReadEventAcrossStreams`, which takes the identity off the row rather than from the append path.

## Tests

`event_envelope_metadata_in_projections` — three tests covering an append and a `StartStream` under string identity and an append under Guid identity. The first fails on `main` with `first.StreamKey should be "TestService" but was ""`.

Full suite green: 1201/1201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs