### PR TITLE
Bundle the projection dispatcher generator in the nupkg (closes #73)

### DIFF
--- a/.github/workflows/fisher.yml
+++ b/.github/workflows/fisher.yml
@@ -88,3 +88,48 @@ jobs:
           reporter: dotnet-trx
           list-suites: "failed"
           list-tests: "failed"
+
+  # fisher#73. The one property of the published package that nothing else can see: a consumer
+  # referencing only the Fisher package needs the projection-dispatcher generator, and its absence
+  # is silent — the consumer's assembly compiles clean (the generator's absence removes generated
+  # partials nothing hand-written references) and then throws "No source-generated dispatcher
+  # found ..." on its first projected event. No test can catch that from inside this repository,
+  # because the test projects reference the generator directly. So it is asserted against the
+  # packed nupkg here.
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Pack
+        run: dotnet pack src/Fisher/Fisher.csproj -c Release -o ./artifacts
+
+      - name: The package carries the projection dispatcher generator
+        run: |
+          nupkg=$(ls ./artifacts/Fisher.*.nupkg)
+          echo "Inspecting $nupkg"
+          unzip -l "$nupkg" | grep -q 'analyzers/dotnet/cs/JasperFx.Events.SourceGenerator.dll' || {
+            echo "::error::$nupkg does not bundle JasperFx.Events.SourceGenerator. A consumer's"
+            echo "::error::projections would compile clean and throw on their first event."
+            unzip -l "$nupkg"
+            exit 1
+          }
+
+      - name: The generator is bundled, not leaked as a transitive dependency
+        run: |
+          nupkg=$(ls ./artifacts/Fisher.*.nupkg)
+          if unzip -p "$nupkg" Fisher.nuspec | grep -qi 'JasperFx.Events.SourceGenerator'; then
+            echo "::error::Fisher.nuspec declares JasperFx.Events.SourceGenerator as a dependency."
+            echo "::error::It must stay PrivateAssets=all — flowing downstream double-loads the"
+            echo "::error::generator in a project referencing two Critter Stack stores (CS0111)."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3018,6 +3018,31 @@ produced it. `inline_event_projections` covers it directly — note that a conve
 projection class must be declared `partial`, because the dispatcher is source-generated into it and
 there is no runtime fallback.
 
+### What the nupkg carries beyond Fisher.dll
+
+**`JasperFx.Events.SourceGenerator` is bundled into the package as an analyzer** (fisher#73), the way
+Marten (marten#4557) and Polecat (polecat#196) both bundle it into theirs. Projection dispatch is
+source-generated with no runtime reflection fallback, and the generator ships as a development
+dependency that does **not** flow transitively — so a consumer referencing only the Fisher package
+never ran it.
+
+**The absence is silent in the worst direction.** It is not a build failure: removing the generator
+removes generated partials that nothing hand-written references, so the consuming assembly *compiles
+clean* and then throws `No source-generated dispatcher found for EventProjection …` on its first
+projected event. In a service that is a clean deploy followed by a crash on the first message.
+
+Two things hold it in place, and neither is a test — the test projects reference the generator
+directly, so nothing inside this repository can observe the packaged shape:
+
+- `_BundleEventsSourceGeneratorAnalyzer` in `Fisher.csproj` contributes the analyzer DLL to
+  `analyzers/dotnet/cs`. It runs **per-TFM**, because `$(PkgJasperFx_Events_SourceGenerator)` is only
+  resolved there, and is **conditioned on one target framework**, because the analyzer is
+  TFM-agnostic and both passes claiming the same package path fails pack on a duplicate file.
+- The `package` job in `.github/workflows/fisher.yml` packs and asserts the DLL is present **and**
+  that the nuspec does not declare the generator as a dependency. `PrivateAssets=all` is load-bearing
+  for the second half: a generator that flows downstream is double-loaded by a project referencing
+  two Critter Stack stores, which emits each `.Evolver` partial twice and fails with CS0111.
+
 ## The companion packages
 
 Two, both modelled on Polecat's and Marten's, both multi-targeting net9.0/net10.0 as the core does.

--- a/src/Fisher/Fisher.csproj
+++ b/src/Fisher/Fisher.csproj
@@ -18,6 +18,15 @@
     <ItemGroup>
         <PackageReference Include="JasperFx" />
         <PackageReference Include="JasperFx.Events" />
+        <!-- fisher#73: referenced so the projection-dispatcher generator runs over Fisher itself,
+             and so the bundling target below has a resolved package path to copy from.
+             PrivateAssets=all keeps it a development-only dependency that does not flow to
+             consumers as an ordinary transitive PackageReference — the analyzer reaches them
+             through the package instead. -->
+        <PackageReference Include="JasperFx.Events.SourceGenerator" GeneratePathProperty="true">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Data.Sqlite" />
         <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
@@ -26,5 +35,36 @@
         <PackageReference Include="Weasel.Sqlite" />
         <PackageReference Include="Weasel.Storage" />
     </ItemGroup>
+
+    <!--
+      fisher#73 — bundle JasperFx.Events.SourceGenerator into Fisher's own package, as Marten
+      (marten#4557) and Polecat (polecat#196) both do.
+
+      Projection dispatch is source-generated with no runtime reflection fallback, so a
+      conventional-method projection must be `partial` or it fails at registration with "No
+      source-generated dispatcher found ...". The generator ships as a development dependency that
+      does NOT flow transitively, so a consumer referencing only the Fisher package never ran it —
+      and the absence removes generated partials nothing hand-written references, so the consumer's
+      assembly COMPILES CLEAN and then throws on its first projected event. Carrying the analyzer
+      DLL inside Fisher's package is the self-contained fix; without it every consumer declaring a
+      projection has to know to add an explicit analyzer reference of its own.
+    -->
+    <PropertyGroup>
+        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_BundleEventsSourceGeneratorAnalyzer</TargetsForTfmSpecificContentInPackage>
+    </PropertyGroup>
+
+    <!-- Runs per-TFM, which is where $(PkgJasperFx_Events_SourceGenerator) is resolved — it is not
+         set during the outer pack evaluation. The analyzer is TFM-agnostic and goes to one path, so
+         it must be contributed exactly once; the condition on a single target framework is what
+         stops the net9.0 and net10.0 passes both claiming analyzers/dotnet/cs and failing pack with
+         a duplicate package file. -->
+    <Target Name="_BundleEventsSourceGeneratorAnalyzer"
+            Condition="'$(TargetFramework)' == 'net9.0' And '$(PkgJasperFx_Events_SourceGenerator)' != ''">
+        <ItemGroup>
+            <TfmSpecificPackageFile Include="$(PkgJasperFx_Events_SourceGenerator)\analyzers\dotnet\cs\JasperFx.Events.SourceGenerator.dll">
+                <PackagePath>analyzers/dotnet/cs</PackagePath>
+            </TfmSpecificPackageFile>
+        </ItemGroup>
+    </Target>
 
 </Project>


### PR DESCRIPTION
Closes #73.

The `Fisher` nupkg had no `analyzers/` folder, where both siblings bundle `JasperFx.Events.SourceGenerator` into their own package (marten#4557, polecat#196). So a project referencing Marten or Polecat gets a generated dispatcher for every projection it declares, and a project referencing Fisher does not.

The absence is silent in the worst direction: removing the generator removes generated partials that nothing hand-written references, so the consuming assembly **compiles clean** and then throws `No source-generated dispatcher found for EventProjection …` on its first projected event.

## The change

`_BundleEventsSourceGeneratorAnalyzer` in `Fisher.csproj`, copied in shape from Polecat's. Two mechanics worth knowing:

- It runs **per-TFM**, because `$(PkgJasperFx_Events_SourceGenerator)` is only resolved there and not during the outer pack evaluation.
- It is **conditioned on one target framework**, because the analyzer is TFM-agnostic and goes to a single package path — both passes claiming `analyzers/dotnet/cs` fails pack on a duplicate package file.

`PrivateAssets=all` stays on the reference, so the generator does not flow to consumers as an ordinary transitive dependency; it reaches them through the package instead.

## How it is held

Nothing inside this repository can observe the packaged shape — every test project references the generator directly — so there is no test to write. A `package` job in `fisher.yml` packs and asserts both halves:

1. `analyzers/dotnet/cs/JasperFx.Events.SourceGenerator.dll` is in the nupkg.
2. `Fisher.nuspec` does **not** declare the generator as a dependency. That half matters as much as the first: a generator that flows downstream is double-loaded by a project referencing two Critter Stack stores, which emits each `.Evolver` partial twice and fails with CS0111.

Verified locally against a real pack:

```
$ unzip -l Fisher.0.6.0.nupkg | grep -i analyz
   115200  analyzers/dotnet/cs/JasperFx.Events.SourceGenerator.dll

$ unzip -p Fisher.0.6.0.nupkg Fisher.nuspec | grep -i sourcegenerator
   (nothing)
```

## Tests

The generator now also runs over Fisher itself, which is the other half of what Polecat's reference does. All three suites green on that: 1198 + 36 + 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs