### PR TITLE
A document read provisions its table (closes #74)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,46 @@ configuration — either way the first write may be the first time the table is 
 schema has already mapped are considered, which is how a document operation is told apart from an
 event one.
 
+### Reads provision the table too
+
+**Reaching that path from the write side only was fisher#74.** A `Query<T>()` or `LoadAsync<T>` against
+a type nothing had written yet failed with a raw `no such table`, where Marten and Polecat provision it
+and return an empty result. That is not an exotic shape — it is what every cold start does (resolve a
+cache before anything populates it, list a collection on a fresh install), and it is **asymmetric in
+the worst direction: it works on a warm database and fails on a fresh one**, so it passes in
+development and fails on first deploy.
+
+`FisherSession.EnsureDocumentTableForReadAsync` is the read-side entry, with three callers:
+
+- **`FisherQueryProvider.CommandFor`**, which is where every LINQ terminal converges — the same reason
+  the query span is opened there. A per-terminal call would be a dozen copies of one line and the one
+  that got forgotten would be the terminal nobody exercises against a fresh database. The types come
+  from `Statement.DocumentTypes`, which is the only thing on a statement that is not about rendering
+  SQL; the walk follows `Subquery`, because a count or an aggregate over a paged query holds the real
+  statement there, and each join adds its own side.
+- **`LoadByIdAsync` / `LoadManyByIdAsync`**, which go through storage rather than through LINQ.
+- **`MetadataForAsync`**, hand-built SQL and therefore its own caller — as it already is of the three
+  implicit filters.
+
+`CheckExistsAsync` and `LoadJsonAsync` need nothing, being routed through the LINQ path already.
+
+Three things that are decisions:
+
+- **A type with registered projection storage is skipped**, the same guard `FetchProjectionStorageAsync`
+  applies. Its rows are not in a Fisher document table, so provisioning would create one nothing ever
+  writes to.
+- **An enlisted session asserts rather than creating**, which is exactly what the write path does and
+  for the identical reason: the migration runs on its own connection and would block against the write
+  lock the caller's transaction is holding — a session deadlocking against itself. Naming the type
+  beats that, and beats the raw SQLite error it replaced.
+- **`AutoCreate.None` provisions, because the write path already does.** Weasel's explicit
+  `ApplyAllConfiguredChangesToDatabaseAsync` upgrades `None` to `CreateOrUpdate`, being the call that
+  means "apply it". Declining on reads alone would make the weaker operation the stricter one. Whether
+  the on-demand path should honour `AutoCreate.None` at all is a live question — `HiloSequence` checks
+  it and declines, so the store disagrees with itself — and is fisher#81;
+  `a_read_and_a_write_agree_about_auto_create_none` pins today's answer so either resolution is
+  deliberate.
+
 ### Flat-table projections
 
 `Projections/Flattened/` — a `FlatTableProjection` writes into a plain relational table keyed on the

--- a/src/Fisher.Tests/Documents/reading_before_the_first_write.cs
+++ b/src/Fisher.Tests/Documents/reading_before_the_first_write.cs
@@ -1,0 +1,233 @@
+using Fisher.Linq;
+using JasperFx;
+
+namespace Fisher.Tests.Documents;
+
+/// <summary>
+///     A read against a document type nothing has ever written provisions its table and answers empty,
+///     rather than failing with <c>no such table</c> (fisher#74).
+/// </summary>
+/// <remarks>
+///     <para>
+///         This is what every cold start does — resolve a cache before anything has populated it, look
+///         up defaults nobody has overridden, list a collection on a fresh install. The old shape was
+///         asymmetric in the worst direction: it worked on a warm database and failed on a fresh one,
+///         so it passed in development and failed on first deploy.
+///     </para>
+///     <para>
+///         The store here deliberately registers <em>nothing</em>. A type declared with
+///         <c>Schema.For&lt;T&gt;()</c> gets its table from the migration and would pass either way,
+///         which is exactly why the workaround in the issue was a hand-maintained list of ~30 types.
+///     </para>
+/// </remarks>
+public class reading_before_the_first_write : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("cold-read");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    [Fact]
+    public async Task a_query_over_an_unwritten_type_is_empty()
+    {
+        await using var session = _store.QuerySession();
+
+        var all = await session.Query<ShardProgression>().ToListAsync(TestContext.Current.CancellationToken);
+
+        all.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_filtered_query_over_an_unwritten_type_is_empty()
+    {
+        await using var session = _store.QuerySession();
+
+        var matching = await session.Query<ShardProgression>()
+            .Where(x => x.ShardName == "anything")
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        matching.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_load_over_an_unwritten_type_is_null()
+    {
+        await using var session = _store.QuerySession();
+
+        (await session.LoadAsync<ShardProgression>("nothing", TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_load_many_over_an_unwritten_type_is_empty()
+    {
+        await using var session = _store.QuerySession();
+
+        (await session.LoadManyAsync<ShardProgression>(TestContext.Current.CancellationToken, "a", "b"))
+            .ShouldBeEmpty();
+    }
+
+    /// <remarks>
+    ///     The scalar terminals wrap the real statement as a subquery, so they exercise the walk down
+    ///     the <c>Subquery</c> chain rather than the statement handed to the terminal.
+    /// </remarks>
+    [Fact]
+    public async Task the_scalar_terminals_over_an_unwritten_type_answer_from_no_rows()
+    {
+        await using var session = _store.QuerySession();
+
+        (await session.Query<ShardProgression>().AnyAsync(TestContext.Current.CancellationToken))
+            .ShouldBeFalse();
+
+        (await session.Query<ShardProgression>().CountAsync(TestContext.Current.CancellationToken))
+            .ShouldBe(0);
+
+        (await session.Query<ShardProgression>().Take(5)
+            .CountAsync(TestContext.Current.CancellationToken)).ShouldBe(0);
+
+        (await session.Query<ShardProgression>()
+            .SumAsync(x => x.Sequence, TestContext.Current.CancellationToken)).ShouldBe(0);
+
+        (await session.Query<ShardProgression>()
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task check_exists_over_an_unwritten_type_is_false()
+    {
+        await using var session = _store.QuerySession();
+
+        (await session.CheckExistsAsync<ShardProgression>("nothing", TestContext.Current.CancellationToken))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_json_read_over_an_unwritten_type_is_null()
+    {
+        await using var session = _store.QuerySession();
+
+        (await session.LoadJsonAsync<ShardProgression>("nothing", TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task metadata_for_an_unwritten_type_is_null()
+    {
+        await using var session = _store.QuerySession();
+
+        (await session.MetadataForAsync<ShardProgression>("nothing", TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    /// <remarks>
+    ///     Both sides of a join, and neither has ever been written. The inner side's table is
+    ///     provisioned from <c>Statement.DocumentTypes</c>, which each join adds to.
+    /// </remarks>
+    [Fact]
+    public async Task a_join_between_two_unwritten_types_is_empty()
+    {
+        await using var session = _store.QuerySession();
+
+        var joined = await session.Query<ShardProgression>()
+            .Join(session.Query<TraceProvider>(), x => x.ShardName, y => y.Id, (x, y) => new { x, y })
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        joined.ShouldBeEmpty();
+    }
+
+    /// <remarks>
+    ///     <para>
+    ///         <b>A read under <c>AutoCreate.None</c> provisions, because a write under
+    ///         <c>AutoCreate.None</c> already does.</b> Both go through
+    ///         <c>EnsureDocumentTableAsync</c>, and Weasel's explicit
+    ///         <c>ApplyAllConfiguredChangesToDatabaseAsync</c> deliberately upgrades <c>None</c> to
+    ///         <c>CreateOrUpdate</c> — being the call that means "apply it". So this pins that reads and
+    ///         writes agree rather than claiming a policy neither of them honours.
+    ///     </para>
+    ///     <para>
+    ///         Whether the on-demand path <em>should</em> honour <c>AutoCreate.None</c> is a real
+    ///         question — <c>HiloSequence</c> checks it explicitly and declines — but it is one about
+    ///         both paths at once, and answering it here would leave a read stricter than a write.
+    ///         Filed as fisher#81.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_read_and_a_write_agree_about_auto_create_none()
+    {
+        await using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.None;
+        });
+
+        await using var reading = store.QuerySession();
+
+        (await reading.Query<NeverCreated>().ToListAsync(TestContext.Current.CancellationToken))
+            .ShouldBeEmpty();
+
+        await using var writing = store.LightweightSession();
+
+        writing.Store(new NeverCreated { Id = "one" });
+        await writing.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await reading.Query<NeverCreated>().CountAsync(TestContext.Current.CancellationToken))
+            .ShouldBe(1);
+    }
+
+    /// <remarks>
+    ///     Reading twice must not re-run the migration — <c>EnsureDocumentTableAsync</c> caches per
+    ///     type, so the steady-state cost of the whole feature is a <c>HashSet</c> hit.
+    /// </remarks>
+    [Fact]
+    public async Task the_table_is_provisioned_once_and_then_written_to_normally()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            (await session.Query<ShardProgression>().ToListAsync(TestContext.Current.CancellationToken))
+                .ShouldBeEmpty();
+
+            session.Store(new ShardProgression { Id = "one", ShardName = "Alpha:All", Sequence = 12 });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _store.QuerySession();
+
+        var all = await query.Query<ShardProgression>().ToListAsync(TestContext.Current.CancellationToken);
+
+        all.Count.ShouldBe(1);
+        all[0].Sequence.ShouldBe(12);
+    }
+}
+
+public class ShardProgression
+{
+    public string Id { get; set; } = string.Empty;
+    public string ShardName { get; set; } = string.Empty;
+    public long Sequence { get; set; }
+}
+
+public class TraceProvider
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}
+
+public class NeverCreated
+{
+    public string Id { get; set; } = string.Empty;
+}

--- a/src/Fisher/Internal/FisherSession.Documents.cs
+++ b/src/Fisher/Internal/FisherSession.Documents.cs
@@ -434,9 +434,14 @@ internal partial class FisherSession
         where T : notnull where TId : notnull
         => LoadByIdAsync<T, TId>(id, token);
 
-    private Task<T?> LoadByIdAsync<T, TId>(TId id, CancellationToken token)
+    private async Task<T?> LoadByIdAsync<T, TId>(TId id, CancellationToken token)
         where T : notnull where TId : notnull
-        => ((Weasel.Storage.IDocumentStorage<T, TId>)StorageFor<T>()).LoadAsync(id, this, token);
+    {
+        await EnsureDocumentTableForReadAsync(typeof(T), token).ConfigureAwait(false);
+
+        return await ((Weasel.Storage.IDocumentStorage<T, TId>)StorageFor<T>())
+            .LoadAsync(id, this, token).ConfigureAwait(false);
+    }
 
     /// <summary>
     ///     Load several documents by identity. Missing ids are simply absent from the result, which is
@@ -478,9 +483,14 @@ internal partial class FisherSession
         where T : notnull where TId : notnull
         => LoadManyByIdAsync<T, TId>(ids, token);
 
-    private Task<IReadOnlyList<T>> LoadManyByIdAsync<T, TId>(TId[] ids, CancellationToken token)
+    private async Task<IReadOnlyList<T>> LoadManyByIdAsync<T, TId>(TId[] ids, CancellationToken token)
         where T : notnull where TId : notnull
-        => ((Weasel.Storage.IDocumentStorage<T, TId>)StorageFor<T>()).LoadManyAsync(ids, this, token);
+    {
+        await EnsureDocumentTableForReadAsync(typeof(T), token).ConfigureAwait(false);
+
+        return await ((Weasel.Storage.IDocumentStorage<T, TId>)StorageFor<T>())
+            .LoadManyAsync(ids, this, token).ConfigureAwait(false);
+    }
 
     // ---- existence, plans and diagnostics (fisher#37) ----
 

--- a/src/Fisher/Internal/FisherSession.Metadata.cs
+++ b/src/Fisher/Internal/FisherSession.Metadata.cs
@@ -53,6 +53,10 @@ internal partial class FisherSession
     private async Task<StoredDocumentMetadata?> MetadataForIdAsync<T>(object id, CancellationToken token)
         where T : notnull
     {
+        // Hand-built SQL, so it is a caller of the on-demand provisioning in its own right (fisher#74)
+        // exactly as it is a caller of the implicit filters.
+        await EnsureDocumentTableForReadAsync(typeof(T), token).ConfigureAwait(false);
+
         var mapping = Options.Schema.MappingFor(typeof(T));
         var metadata = mapping.Metadata;
         var storage = StorageFor<T>();

--- a/src/Fisher/Internal/FisherSession.cs
+++ b/src/Fisher/Internal/FisherSession.cs
@@ -740,6 +740,59 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
     }
 
     /// <summary>
+    ///     Create a document type's table before reading it, exactly as the commit loop does before
+    ///     writing it (fisher#74).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <c>EnsureDocumentTableAsync</c> used to be reached from the write path only, so a
+    ///         <c>Query&lt;T&gt;()</c> or <c>LoadAsync&lt;T&gt;</c> against a type nothing had written
+    ///         yet failed with a raw <c>no such table</c> where Marten and Polecat provision it and
+    ///         return an empty result. That is not an unusual shape — it is what every cold start does,
+    ///         and it is asymmetric in the worst direction: it works on a warm database and fails on a
+    ///         fresh one, so it passes in development and fails on first deploy.
+    ///     </para>
+    ///     <para>
+    ///         <b>A type stored by a registered projection provider is skipped</b>, because its rows are
+    ///         not in a Fisher document table at all — the same guard <c>FetchProjectionStorageAsync</c>
+    ///         applies, and for the same reason: provisioning one here would create a table nothing ever
+    ///         writes to.
+    ///     </para>
+    ///     <para>
+    ///         <b>An enlisted session asserts instead of creating</b>, which is what the write path
+    ///         already does and for the identical reason — the migration runs on its own connection and
+    ///         would block against the write lock the caller's transaction is holding. Naming the type
+    ///         beats deadlocking, and beats the raw SQLite error this replaced.
+    ///     </para>
+    ///     <para>
+    ///         <b>A read provisions under <c>AutoCreate.None</c> because a write already does.</b> Both
+    ///         reach <c>EnsureDocumentTableAsync</c>, and Weasel's explicit
+    ///         <c>ApplyAllConfiguredChangesToDatabaseAsync</c> upgrades <c>None</c> to
+    ///         <c>CreateOrUpdate</c> — it is the call that means "apply it". Making a read decline where
+    ///         a write does not would be a stricter rule on the weaker operation, and would leave the
+    ///         cold-start shape this exists to fix broken for exactly the deployments most likely to
+    ///         meet it. Whether the on-demand path should honour <c>AutoCreate.None</c> at all is a
+    ///         question about both halves at once — <c>HiloSequence</c> checks it and declines, so the
+    ///         store is not consistent with itself — and is fisher#81.
+    ///     </para>
+    /// </remarks>
+    internal async Task EnsureDocumentTableForReadAsync(Type documentType, CancellationToken token)
+    {
+        if (Options.Projections.StorageProviders.HasProviderFor(documentType))
+        {
+            return;
+        }
+
+        if (EnlistedTransaction is not null)
+        {
+            await AssertDocumentTableExistsAsync(documentType, token).ConfigureAwait(false);
+            return;
+        }
+
+        await FisherDatabase.EnsureDocumentTableAsync(documentType, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
     ///     For an enlisted session, check that a document type's table is already there rather than
     ///     creating it.
     /// </summary>

--- a/src/Fisher/Linq/FisherQueryProvider.Joins.cs
+++ b/src/Fisher/Linq/FisherQueryProvider.Joins.cs
@@ -149,6 +149,7 @@ public partial class FisherQueryProvider
             statement.Joins[^1].On.AddRange(InnerConditions(join, side));
 
             sides.Add(side);
+            statement.DocumentTypes.Add(side.DocumentType);
             columns.AddRange(Qualified(side.Clause.SelectFields(), side.Alias));
 
             (result, intermediate, shape) = Collapse(join, sides, shape);

--- a/src/Fisher/Linq/FisherQueryProvider.cs
+++ b/src/Fisher/Linq/FisherQueryProvider.cs
@@ -1027,6 +1027,7 @@ public partial class FisherQueryProvider : IQueryProvider
             NonStaleTimeout = parser.NonStaleTimeout
         };
 
+        statement.DocumentTypes.Add(sourceType);
         statement.OrderBys.AddRange(parser.OrderBys);
 
         statement.Wheres.AddRange(parser.Wheres);
@@ -1331,6 +1332,19 @@ public partial class FisherQueryProvider : IQueryProvider
     private async Task<Microsoft.Data.Sqlite.SqliteCommand> CommandFor(Statement statement,
         CancellationToken token)
     {
+        // fisher#74: a query against a type nothing has written yet provisions its table, exactly as
+        // the first write of that type does. Here rather than at each terminal because this is the one
+        // place every terminal converges — the same reason the query span is opened here. The walk
+        // covers a wrapped statement (a count or an aggregate over a paged query holds the real one as
+        // its Subquery) and every side of a join.
+        for (var current = statement; current is not null; current = current.Subquery)
+        {
+            foreach (var documentType in current.DocumentTypes)
+            {
+                await _session.EnsureDocumentTableForReadAsync(documentType, token).ConfigureAwait(false);
+            }
+        }
+
         // QueryForNonStaleData: wait for the daemon before reading, not as part of the SQL. Read
         // through the subquery chain so a count, a page, an aggregate or a reversal carries it without
         // its wrap site having to remember to.

--- a/src/Fisher/Linq/SqlGeneration/Statement.cs
+++ b/src/Fisher/Linq/SqlGeneration/Statement.cs
@@ -57,6 +57,18 @@ internal class Statement
     /// <summary>The joined tables, in order. Empty for every query that is not a join.</summary>
     public List<Joins.JoinClause> Joins { get; } = [];
 
+    /// <summary>
+    ///     Every document type this statement reads from — the source type, plus one per joined side.
+    /// </summary>
+    /// <remarks>
+    ///     Carried so <c>FisherQueryProvider.CommandFor</c> can provision the tables before executing
+    ///     (fisher#74). It is the only thing on a statement that is not about rendering SQL, and it is
+    ///     here rather than at each terminal because <c>CommandFor</c> is where every terminal converges
+    ///     — a per-terminal call would be a dozen copies of one line, one of which would be forgotten,
+    ///     and the terminal that forgot it would be the one nobody exercises against a fresh database.
+    /// </remarks>
+    public List<Type> DocumentTypes { get; } = [];
+
     public string SelectColumns { get; set; } = "data";
     public List<ISqlFragment> Wheres { get; } = [];
     public List<(string Locator, bool Descending)> OrderBys { get; } = [];


### PR DESCRIPTION
Closes #74.

`EnsureDocumentTableAsync` was reached from the write path only, so a `Query<T>()` or `LoadAsync<T>` against a type nothing had written yet threw `no such table` where both siblings provision it and return an empty result.

The issue's framing is the right one: this is not "read before write is unusual", it is what every cold start does — and it works on a warm database and fails on a fresh one, so it passes in development and fails on first deploy.

## Where it hooks in

`FisherSession.EnsureDocumentTableForReadAsync`, with three callers:

- **`FisherQueryProvider.CommandFor`** — every LINQ terminal converges there, which is the same reason the query span is opened there. A per-terminal call would be a dozen copies of one line, and the one that got forgotten would be the terminal nobody exercises against a fresh database. The types come from a new `Statement.DocumentTypes`; the walk follows `Subquery` (a count or an aggregate over a paged query holds the real statement there) and each join adds its own side.
- **`LoadByIdAsync` / `LoadManyByIdAsync`** — through storage rather than LINQ.
- **`MetadataForAsync`** — hand-built SQL, so its own caller, as it already is of the three implicit filters.

`CheckExistsAsync` and `LoadJsonAsync` needed nothing: both already route through the LINQ path.

## Three decisions

- **A type with registered projection storage is skipped**, the same guard `FetchProjectionStorageAsync` applies — its rows are not in a Fisher document table, so provisioning would create one nothing ever writes to.
- **An enlisted session asserts rather than creating.** That is exactly what the write path does and for the identical reason: the migration runs on its own connection and would block against the write lock the caller's transaction is holding, which is a session deadlocking against itself. The named message beats that, and beats the raw SQLite error it replaced.
- **`AutoCreate.None` provisions, because the write path already does.** This surprised me and is worth stating plainly: Weasel's explicit `ApplyAllConfiguredChangesToDatabaseAsync` upgrades `None` to `CreateOrUpdate`, being the call that means "apply it" — so `EnsureDocumentTableAsync` has never honoured `AutoCreate.None`, on either path. Making reads decline where writes do not would put the stricter rule on the weaker operation. Whether the on-demand path *should* honour it is a real question — `HiloSequence` checks it and declines, so the store disagrees with itself — and is filed as #81. `a_read_and_a_write_agree_about_auto_create_none` pins today's answer so either resolution is deliberate.

## Tests

`reading_before_the_first_write`, 11 tests against a store that registers **nothing** — a `Schema.For<T>()` declaration gets its table from the migration and would pass either way, which is exactly why the issue's workaround was a hand-maintained list of ~30 types. Query, filtered query, load, load-many, the scalar terminals (which exercise the `Subquery` walk), `CheckExistsAsync`, `LoadJsonAsync`, `MetadataForAsync`, and a join where **neither** side has ever been written.

All three suites green: 1209 + 36 + 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs