### PR TITLE
Projections.Add<T>(lifecycle) (closes #76)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,6 +280,23 @@ ones most likely to be assumed present:
   the end state, not a gap: fisher#8 was closed wontfix, and delivery is a bus integration's job here
   as it is on both siblings.
 
+### Registering a projection by type
+
+`Projections.Add<T>(lifecycle)` (fisher#76) **hides an inherited overload rather than adding a missing
+one**, and that is the whole content of the fix. `ProjectionGraph.Add<TProjectionType>` compiled on
+Fisher already and went straight to `All.Add`, bypassing `Register` — so it invoked neither
+`onAddProjection`, which registers the projection's event types (without which a read-only process
+cannot resolve them by name), nor `FisherProjectionOptions.Add`'s `PublishedTypes()` sweep, **without
+which the projection's document type is never mapped and its table is never created**. Both silent at
+registration; the symptom is `no such table` on the first event, or a rebuild that finds nothing.
+
+The `new` overload routes through the instance form, so the two spellings mean the same thing. Its
+constraint is deliberately *weaker* than the base's (`ProjectionBase, new()` rather than also
+`IProjectionSource`), because the instance form wraps a bare `IProjection` and refusing one here would
+decline a projection the store runs perfectly well; every call that satisfied the base still compiles.
+`registering_a_projection_by_type` asserts equivalence with the instance form rather than existence,
+which is the property that was actually missing.
+
 ### Inline projections
 
 `Snapshot<T>` closes `SingleStreamProjection<TDoc, TId>` over the aggregate's own identity type — the

--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -26,9 +26,23 @@ or Polecat runs here unaltered.
 
 ```cs
 opts.Projections.Snapshot<Order>(SnapshotLifecycle.Inline);
-opts.Projections.Add(new OrdersByCustomer(), ProjectionLifecycle.Async);
+opts.Projections.Add<OrdersByCustomer>(ProjectionLifecycle.Async);
 opts.Projections.CompositeProjectionFor("reporting", c => { … });
 opts.Projections.Subscribe(new NotifyOnShipment());
+```
+
+`Add<T>(lifecycle)` constructs the projection for you and is the spelling Marten and Polecat use, so a
+registration block reads identically against all three stores. Pass an instance instead when the
+projection needs constructor arguments:
+
+```cs
+opts.Projections.Add(new OrdersByCustomer(connectionString), ProjectionLifecycle.Async);
+```
+
+Both forms take an optional `AsyncOptions` lambda for rebuild and batching behaviour:
+
+```cs
+opts.Projections.Add<OrdersByCustomer>(ProjectionLifecycle.Async, o => o.BatchSize = 1000);
 ```
 
 ## Conventional methods are source-generated

--- a/src/Fisher.Tests/Projections/registering_a_projection_by_type.cs
+++ b/src/Fisher.Tests/Projections/registering_a_projection_by_type.cs
@@ -1,0 +1,121 @@
+using Fisher.Projections;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+
+namespace Fisher.Tests.Projections;
+
+/// <summary>
+///     <c>Projections.Add&lt;T&gt;(lifecycle)</c> — registering a projection by type (fisher#76).
+/// </summary>
+/// <remarks>
+///     The overload existed, inherited from <c>ProjectionGraph</c>, and went straight to
+///     <c>All.Add</c> — so it skipped both halves of what registering a projection means on Fisher: the
+///     event types were never added to the graph, and the published document type was never mapped, so
+///     its table was never created. Both silent at registration. These tests are therefore about
+///     equivalence rather than existence: what the generic form registers has to be what the instance
+///     form registers.
+/// </remarks>
+public class registering_a_projection_by_type : IDisposable
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("generic-add");
+
+    public void Dispose() => _database.Dispose();
+
+    private DocumentStore StoreWith(Action<StoreOptions> configure)
+        => DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            configure(options);
+        });
+
+    [Fact]
+    public void the_generic_form_registers_what_the_instance_form_registers()
+    {
+        using var byType = StoreWith(o => o.Projections.Add<ByTypeProjection>(ProjectionLifecycle.Inline));
+        using var byInstance = StoreWith(o =>
+            o.Projections.Add(new ByTypeProjection(), ProjectionLifecycle.Inline));
+
+        byType.Options.Schema.HasMappingFor(typeof(ByTypeSnapshot))
+            .ShouldBe(byInstance.Options.Schema.HasMappingFor(typeof(ByTypeSnapshot)));
+
+        EventNamesOf(byType).ShouldBe(EventNamesOf(byInstance));
+
+        // ...and both are the non-empty answer, or the equality above would hold vacuously.
+        byType.Options.Schema.HasMappingFor(typeof(ByTypeSnapshot)).ShouldBeTrue();
+        EventNamesOf(byType).ShouldContain("by_type_happened");
+    }
+
+    [Fact]
+    public async Task a_projection_registered_by_type_runs_and_its_table_exists()
+    {
+        await using var store = StoreWith(o =>
+            o.Projections.Add<ByTypeProjection>(ProjectionLifecycle.Inline));
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid(), new ByTypeHappened("first"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.LightweightSession();
+
+        (await query.LoadAsync<ByTypeSnapshot>("first", TestContext.Current.CancellationToken))
+            .ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void the_lifecycle_argument_is_carried()
+    {
+        using var store = StoreWith(o => o.Projections.Add<ByTypeProjection>(ProjectionLifecycle.Async));
+
+        store.Options.Projections.All.Single().Lifecycle.ShouldBe(ProjectionLifecycle.Async);
+    }
+
+    [Fact]
+    public void the_async_configuration_argument_is_applied()
+    {
+        using var store = StoreWith(o => o.Projections.Add<ByTypeProjection>(
+            ProjectionLifecycle.Async, options => options.BatchSize = 37));
+
+        store.Options.Projections.All.Single().Options.BatchSize.ShouldBe(37);
+    }
+
+    /// <remarks>
+    ///     The constraint is weaker than the inherited one, which demanded <c>IProjectionSource</c>. The
+    ///     instance overload wraps a bare <see cref="IProjection" />, so requiring more of the generic
+    ///     form would refuse a projection the store runs perfectly well.
+    /// </remarks>
+    [Fact]
+    public void a_bare_projection_can_be_registered_by_type_too()
+    {
+        using var store = StoreWith(o => o.Projections.Add<BareByTypeProjection>(ProjectionLifecycle.Inline));
+
+        store.Options.Projections.All.ShouldHaveSingleItem();
+    }
+
+    private static string[] EventNamesOf(DocumentStore store)
+        => store.Options.EventGraph.AllKnownEventTypes().Select(x => x.EventTypeName).Order().ToArray();
+}
+
+public record ByTypeHappened(string Name);
+
+// partial, because JasperFx's source generator emits the conventional-method dispatcher into it.
+public partial class ByTypeProjection : EventProjection
+{
+    public ByTypeSnapshot Create(ByTypeHappened e) => new() { Id = e.Name };
+}
+
+public class ByTypeSnapshot
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class BareByTypeProjection : ProjectionBase, IProjection
+{
+    public Task ApplyAsync(IDocumentSession operations, IReadOnlyList<IEvent> events,
+        CancellationToken cancellation) => Task.CompletedTask;
+}

--- a/src/Fisher/Projections/FisherProjectionOptions.cs
+++ b/src/Fisher/Projections/FisherProjectionOptions.cs
@@ -186,6 +186,52 @@ public class FisherProjectionOptions : ProjectionGraph<IProjection, IDocumentSes
     }
 
     /// <summary>
+    ///     Register a projection by type, constructing it — the spelling both siblings use.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <c>Projections.Add&lt;OrderProjection&gt;(ProjectionLifecycle.Inline)</c> is what
+    ///         registration code in the wild is written against, and it is the one line that stopped an
+    ///         otherwise identical block from being shared across the three stores (fisher#76). It shows
+    ///         up once per projection, and <see cref="Snapshot{T}" /> already takes its type argument, so
+    ///         the two halves of one registration block were inconsistent with each other as well.
+    ///     </para>
+    ///     <para>
+    ///         <b>This hides an inherited overload rather than adding a missing one, and that is the
+    ///         point.</b> <c>ProjectionGraph.Add&lt;TProjectionType&gt;</c> compiles today and goes
+    ///         straight to <c>All.Add</c> — bypassing <c>Register</c>, so it invokes neither
+    ///         <see cref="onAddProjection" /> (which registers the projection's event types, without
+    ///         which a process that only reads cannot resolve them by name) nor the
+    ///         <c>PublishedTypes()</c> sweep above (without which the projection's document type is
+    ///         never mapped and its <b>table is never created</b>). Both failures are silent at
+    ///         registration. Routing through the instance overload is what makes the generic form mean
+    ///         the same thing as the form beside it.
+    ///     </para>
+    ///     <para>
+    ///         The constraint is deliberately weaker than the base's, which demands
+    ///         <c>IProjectionSource</c>: the instance overload accepts a bare
+    ///         <see cref="IProjection" /> and wraps it, so requiring more here would refuse a projection
+    ///         the store can perfectly well run. Every call that satisfied the base still compiles.
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TProjection">
+    ///     The projection class, which must have a parameterless constructor. Use the instance overload
+    ///     for a projection that needs constructor arguments.
+    /// </typeparam>
+    public new void Add<TProjection>(ProjectionLifecycle lifecycle,
+        Action<AsyncOptions>? asyncConfiguration = null)
+        where TProjection : ProjectionBase, new()
+    {
+        var projection = new TProjection();
+
+        // Before Add, matching the base's ordering: the options a rebuild reads have to be in place
+        // before AssembleAndAssertValidity runs over them.
+        asyncConfiguration?.Invoke(projection.Options);
+
+        Add(projection, lifecycle);
+    }
+
+    /// <summary>
     ///     Register a subscription — arbitrary code the async daemon drives over each range of events,
     ///     rather than a projection folding them into storage (fisher#21).
     /// </summary>


### PR DESCRIPTION
Closes #76.

The issue reads as "the overload is missing". It is not — `ProjectionGraph.Add<TProjectionType>(ProjectionLifecycle, Action<AsyncOptions>?)` is inherited and compiles on Fisher today. **It is worse than missing**, which is why this is a bug fix wearing an enhancement label.

The base implementation goes straight to `All.Add`, bypassing `Register`. So it invokes neither:

- `onAddProjection`, which registers the projection's event types — without which a process that only reads cannot resolve them by name; nor
- `FisherProjectionOptions.Add`'s `PublishedTypes()` sweep — **without which the projection's document type is never mapped, so its table is never created**.

Probed before writing anything, against a store registered with the inherited overload:

```
PROBE mapped=False
PROBE eventTypes=
```

Both failures are silent at registration. The symptom is `no such table` on the first projected event, or a rebuild that finds nothing to tear down.

## The change

A `new` overload on `FisherProjectionOptions` that routes through the instance form, so the two spellings mean the same thing.

Its constraint is deliberately **weaker** than the base's — `ProjectionBase, new()` rather than also `IProjectionSource` — because the instance form accepts a bare `IProjection` and wraps it, and requiring more here would refuse a projection the store runs perfectly well. Every call that satisfied the base still compiles.

`asyncConfiguration` is invoked before `Add`, matching the base's ordering: the options a rebuild reads have to be in place before `AssembleAndAssertValidity` runs over them.

## Tests

`registering_a_projection_by_type`, five tests, written as **equivalence with the instance form** rather than existence — existence was never the missing property:

- the generic form registers the same mapping and the same event types as the instance form, and both are the non-empty answer (or the equality would hold vacuously);
- a projection registered by type actually runs, and its table exists;
- the lifecycle and the `AsyncOptions` lambda are both carried;
- a bare `IProjection` can be registered by type too, which the base's constraint refused.

Docs: the registering block in `events/projections/index.md` now leads with `Add<T>`, with the instance form shown as the constructor-argument case.

Full suite green: 1206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs