### PR TITLE
StoreOptions.RegisterValueType<T>() (closes #75)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1809,7 +1809,18 @@ ADO.NET boundary while the document keeps the wrapper. Nothing downstream knows 
 the table shape, the write SQL and the positional `?` contract are untouched.
 
 - **Fisher discovers wrappers rather than requiring registration**, which is Polecat's model rather
-  than Marten's, and is why the compliance seam's `RegisterValueType<T>` is a no-op here.
+  than Marten's — so nothing depends on `StoreOptions.RegisterValueType<T>()`, which exists anyway
+  (fisher#75) for the reason polecat#459 gives: **store configuration ought to be portable**, and a
+  shared block that reads `opts.RegisterValueType<AlertId>()` on two stores should not have to drop the
+  line for the third and explain the omission in a comment. **It is not an accepted no-op**, and that
+  is what makes it worth having rather than merely tolerable: discovery must treat "not a wrapper" as
+  the ordinary answer, since it is asked about every candidate identity member of every type, whereas
+  naming a type here is an *assertion* — so the same answer becomes a configuration error, reported
+  with the type named rather than surfacing later as "has no identity member" from a place that cannot
+  mention the wrapper. `StrongTypedId.Register` is the throwing half of `TryResolve`, and it tells a
+  bad *shape* apart from a good wrapper around an inner type Fisher cannot store. The compliance
+  seam's `RegisterValueType<T>` now delegates to it rather than staying empty, so the suite exercises
+  the method a consumer would call.
 - **`DocumentIdentity.FindIdMember`'s predicate overload is the whole entry point.** Its default
   accepts only the canonical four; the overload exists so a store can widen it, and
   `StrongTypedId.IsSupportedIdType` is Fisher's. Before this, every strong-typed aggregate failed with

--- a/docs/documents/identity.md
+++ b/docs/documents/identity.md
@@ -113,8 +113,23 @@ var order = await session.LoadAsync<Order, OrderId>(id);
 
 ::: tip
 **Fisher discovers wrappers rather than requiring registration**, which is Polecat's model rather than
-Marten's. There is no `RegisterValueType<T>` call to make.
+Marten's. Nothing above needs a registration call.
 :::
+
+`RegisterValueType<T>()` exists anyway, so a configuration block reads identically whichever store it
+is pointed at:
+
+```cs
+opts.ConfigureSerialization(EnumStorage.AsString, Casing.CamelCase);
+opts.Events.StreamIdentity = StreamIdentity.AsString;
+opts.RegisterValueType<CatchId>();
+```
+
+It is not quite a no-op, and the difference is the reason to use it. Discovery has to treat "not a
+wrapper" as the ordinary answer, because it is asked about every candidate identity member of every
+type. Naming a type here is an *assertion* that it is one, so the same answer becomes a configuration
+error — reported at configuration time, with the type named, rather than surfacing much later as
+`has no identity member`.
 
 Two things fall out of the design and are worth knowing:
 

--- a/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
+++ b/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
@@ -331,13 +331,18 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
         }
 
         /// <summary>
-        ///     A no-op: Fisher discovers strong-typed identifiers from their shape rather than needing
-        ///     them registered, which is Polecat's model. Marten is the store that needs the call.
+        ///     Delegates to <c>StoreOptions.RegisterValueType&lt;T&gt;()</c> (fisher#75).
         /// </summary>
+        /// <remarks>
+        ///     Fisher still discovers strong-typed identifiers from their shape, so nothing depends on
+        ///     the call — it was a no-op here until the store had one to delegate to. Delegating rather
+        ///     than staying empty is what makes the seam honest: the suite now exercises the same
+        ///     method a consumer would call, and a wrapper the store cannot actually resolve fails
+        ///     inside the suite rather than passing on a stub.
+        /// </remarks>
         /// <seealso cref="Fisher.Storage.StrongTypedId" />
         public void RegisterValueType<TValue>() where TValue : notnull
-        {
-        }
+            => _options.RegisterValueType<TValue>();
 
         /// <summary>
         ///     Register a mutating masking rule — the in-place form, for an event whose protected

--- a/src/Fisher.Tests/Configuration/registering_value_types.cs
+++ b/src/Fisher.Tests/Configuration/registering_value_types.cs
@@ -1,0 +1,90 @@
+using Fisher.Tests.Documents;
+using JasperFx.Core.Reflection;
+
+namespace Fisher.Tests.Configuration;
+
+/// <summary>
+///     <c>StoreOptions.RegisterValueType&lt;T&gt;()</c> (fisher#75) — the call Fisher does not need and
+///     carries anyway, so a strong-typed-id configuration block reads identically against all three
+///     stores.
+/// </summary>
+/// <remarks>
+///     The interesting property is <em>not</em> that registering makes a wrapper work — it already did,
+///     and <c>strong_typed_identities</c> covers that. It is that the call means something rather than
+///     being an accepted no-op: naming a type is an assertion it is a wrapper, so a type that is not one
+///     is a configuration error reported here instead of surfacing later as "has no identity member"
+///     from a place that cannot mention the wrapper.
+/// </remarks>
+public class registering_value_types
+{
+    [Fact]
+    public void a_wrapper_resolves_to_its_inner_type()
+    {
+        var options = new StoreOptions();
+
+        options.RegisterValueType<RodId>().SimpleType.ShouldBe(typeof(Guid));
+        options.RegisterValueType<HookId>().SimpleType.ShouldBe(typeof(string));
+        options.RegisterValueType<SwivelId>().SimpleType.ShouldBe(typeof(int));
+    }
+
+    /// <remarks>
+    ///     The builder shape rather than a constructor — the other form <c>ValueTypeInfo</c> accepts,
+    ///     included because a registration call that only understood constructors would look correct.
+    /// </remarks>
+    [Fact]
+    public void a_wrapper_built_by_a_static_factory_resolves_too()
+    {
+        new StoreOptions().RegisterValueType<SpoonId>().SimpleType.ShouldBe(typeof(long));
+    }
+
+    [Fact]
+    public void the_non_generic_overload_answers_the_same()
+    {
+        var options = new StoreOptions();
+
+        options.RegisterValueType(typeof(RodId)).SimpleType
+            .ShouldBe(options.RegisterValueType<RodId>().SimpleType);
+    }
+
+    [Fact]
+    public void a_type_that_is_not_a_wrapper_is_refused()
+    {
+        Should.Throw<InvalidValueTypeException>(() => new StoreOptions().RegisterValueType<NotAWrapper>())
+            .Message.ShouldContain(nameof(NotAWrapper));
+    }
+
+    /// <remarks>
+    ///     A perfectly well-shaped wrapper around something Fisher cannot store as an identity. The
+    ///     message has to say which four it can, because the shape is not what is wrong.
+    /// </remarks>
+    [Fact]
+    public void a_wrapper_around_an_unstorable_type_is_refused_by_its_inner_type()
+    {
+        var message = Should.Throw<InvalidValueTypeException>(
+            () => new StoreOptions().RegisterValueType<PriceId>()).Message;
+
+        message.ShouldContain("Decimal");
+        message.ShouldContain("Guid, string, int or long");
+    }
+
+    /// <remarks>
+    ///     Registration is a validation, not a mutation — the store discovers wrappers either way, so
+    ///     calling it twice, or not at all, has to reach the same place.
+    /// </remarks>
+    [Fact]
+    public void registering_twice_is_harmless()
+    {
+        var options = new StoreOptions();
+
+        options.RegisterValueType<RodId>();
+        options.RegisterValueType<RodId>().SimpleType.ShouldBe(typeof(Guid));
+    }
+}
+
+public class NotAWrapper
+{
+    public string First { get; set; } = string.Empty;
+    public string Second { get; set; } = string.Empty;
+}
+
+public readonly record struct PriceId(decimal Value);

--- a/src/Fisher/Storage/StrongTypedId.cs
+++ b/src/Fisher/Storage/StrongTypedId.cs
@@ -79,6 +79,48 @@ internal static class StrongTypedId
     }
 
     /// <summary>
+    ///     Resolve a wrapper eagerly, throwing when the type cannot be one — what
+    ///     <c>StoreOptions.RegisterValueType</c> is (fisher#75).
+    /// </summary>
+    /// <remarks>
+    ///     The difference from <see cref="TryResolve" /> is the whole value of the call. Discovery has
+    ///     to treat "not a wrapper" as the ordinary answer, because it is asked about every candidate
+    ///     identity member of every type; a caller who has <em>named</em> a type is asserting it is one,
+    ///     so the same answer is a configuration error and says so here rather than surfacing later as
+    ///     "has no identity member" from somewhere that cannot mention the wrapper.
+    /// </remarks>
+    /// <exception cref="InvalidValueTypeException"><paramref name="type" /> is not a usable wrapper.</exception>
+    internal static ValueTypeInfo Register(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        if (TryResolve(type, out var info))
+        {
+            return info;
+        }
+
+        // Two different failures, and telling them apart is worth the second resolve: a shape problem
+        // is answered by ValueTypeInfo's own message, where a perfectly good wrapper around an
+        // unsupported inner type needs to be told which four Fisher can store.
+        try
+        {
+            var resolved = ValueTypeInfo.ForType(type);
+
+            throw new InvalidValueTypeException(type,
+                $"It wraps a {resolved.SimpleType.FullNameInCode()}, and Fisher stores an identity as a "
+                + "Guid, string, int or long.");
+        }
+        catch (InvalidValueTypeException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            throw new InvalidValueTypeException(type, e.Message);
+        }
+    }
+
+    /// <summary>
     ///     The type actually stored for an identity — a wrapper's inner type, or the type itself.
     /// </summary>
     internal static Type StoredTypeFor(Type idType)

--- a/src/Fisher/StoreOptions.cs
+++ b/src/Fisher/StoreOptions.cs
@@ -316,6 +316,47 @@ public class StoreOptions
         Serializer = serializer;
     }
 
+    /// <summary>
+    ///     Register a strong-typed identifier — a wrapper around a single <see cref="Guid" />,
+    ///     <c>string</c>, <c>int</c> or <c>long</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Fisher discovers these on its own, so calling this is never required.</b> It exists
+    ///         because Marten's <c>StoreOptions.RegisterValueType&lt;T&gt;()</c> does and Polecat gained
+    ///         one in polecat#459, and store configuration ought to be portable: a shared block that
+    ///         reads <c>opts.RegisterValueType&lt;AlertId&gt;()</c> on two stores should not have to drop
+    ///         the line for the third and explain the omission in a comment (fisher#75).
+    ///     </para>
+    ///     <para>
+    ///         It is not quite a no-op, and the difference is what makes it worth having rather than
+    ///         merely accepting. Discovery has to treat "not a wrapper" as the ordinary answer, because
+    ///         it is asked about every candidate identity member of every type. Naming a type here is an
+    ///         <em>assertion</em> that it is one, so the same answer becomes a configuration error and is
+    ///         reported at configuration time — rather than surfacing much later as "has no identity
+    ///         member" from a place that cannot mention the wrapper.
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TValueType">The wrapper, e.g. <c>readonly record struct OrderId(Guid Value)</c>.</typeparam>
+    /// <returns>The resolved shape, matching Marten's and Polecat's return type.</returns>
+    /// <exception cref="JasperFx.Core.Reflection.InvalidValueTypeException">
+    ///     <typeparamref name="TValueType" /> is not a usable wrapper, or wraps something Fisher cannot
+    ///     store as an identity.
+    /// </exception>
+    public JasperFx.Core.Reflection.ValueTypeInfo RegisterValueType<TValueType>() where TValueType : notnull
+        => Storage.StrongTypedId.Register(typeof(TValueType));
+
+    /// <summary>
+    ///     Register a strong-typed identifier by <see cref="Type" />. See
+    ///     <see cref="RegisterValueType{TValueType}" /> for why this exists.
+    /// </summary>
+    /// <exception cref="JasperFx.Core.Reflection.InvalidValueTypeException">
+    ///     <paramref name="type" /> is not a usable wrapper, or wraps something Fisher cannot store as
+    ///     an identity.
+    /// </exception>
+    public JasperFx.Core.Reflection.ValueTypeInfo RegisterValueType(Type type)
+        => Storage.StrongTypedId.Register(type);
+
     internal void AssertValid()
     {
         // Under database-per-tenant there is no store-level connection string to set: every tenant


### PR DESCRIPTION
Closes #75.

Fisher discovers strong-typed identifiers from their shape, so nothing depends on this call. It exists for the reason polecat#459 gives — Polecat did not strictly need one either: **store configuration ought to be portable**, and a shared block that reads

```csharp
opts.ConfigureSerialization(EnumStorage.AsString, Casing.CamelCase);
opts.Events.StreamIdentity = StreamIdentity.AsString;
opts.RegisterValueType<AlertId>();
```

should not have to drop the third line for one store and explain the omission in a comment.

## It is not an accepted no-op

That is the part worth having, and it falls out of the asymmetry between discovering and being told. Discovery has to treat "not a wrapper" as the **ordinary** answer — `StrongTypedId.TryResolve` is asked about every candidate identity member of every type, and caches the negative precisely because most types are not wrappers. Naming a type here is an *assertion* that it is one, so the same answer is a configuration error.

`StrongTypedId.Register` is the throwing half of `TryResolve`, and it tells the two failures apart:

- a bad **shape** gets `ValueTypeInfo`'s own message;
- a well-shaped wrapper around an inner type Fisher cannot store — `readonly record struct PriceId(decimal Value)` — is told which four it can, because the shape is not what is wrong.

Without it, the same mistake surfaces much later as `has no identity member` from a place that cannot mention the wrapper at all.

## Also

`FisherComplianceFixture`'s `RegisterValueType<T>` now delegates instead of staying empty. Nothing depends on it either way, but delegating is what makes the seam honest — the suite exercises the method a consumer would call, and a wrapper the store cannot actually resolve fails inside the suite rather than passing on a stub. (CLAUDE.md's note that it is a no-op is updated accordingly.)

## Tests

`registering_value_types`, six tests. The point under test is deliberately **not** that registering makes a wrapper work — it already did, and `strong_typed_identities` covers that. It is that the call means something: both overloads, the static-builder shape as well as the constructor one, a non-wrapper refused by name, a wrapper around `decimal` refused by its inner type, and registering twice being harmless.

Docs: `documents/identity.md` keeps the "Fisher discovers wrappers" tip and adds the portability block underneath.

Full suite green: 1207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs