### PR TITLE
Docs for the 0.7.0 wave, and the version bump

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.6.0</Version>
+        <Version>0.7.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/docs/documents/identity.md
+++ b/docs/documents/identity.md
@@ -164,8 +164,9 @@ Fisher therefore *requires* an identity member and says so, rather than defaulti
 identity primitive and failing later with a message about a missing generated dispatcher.
 
 ::: warning
-The generator runs in the assembly that **defines the aggregate**, so that project needs a reference
-to `JasperFx.Events.SourceGenerator`, and a conventional-method projection class must be declared
+The generator runs in the assembly that **defines the aggregate**, so that assembly is the one that
+has to reference Fisher — the package carries `JasperFx.Events.SourceGenerator` inside it, so there is
+no analyzer reference to add yourself. A conventional-method projection class must be declared
 `partial`.
 :::
 

--- a/docs/documents/storing.md
+++ b/docs/documents/storing.md
@@ -93,12 +93,12 @@ To seed reference data at startup, see [Initial Baseline Data](/documents/initia
 You do not have to register a document type. The first `Store` of an unregistered type creates its
 table.
 
+A read provisions the table too, so `Query<T>()` or `LoadAsync<T>` against a type nothing has written
+yet answers empty rather than failing.
+
 ::: warning
 The exception is an [enlisted session](/documents/sessions#enlisting-in-your-own-connection-or-transaction),
-where a missing table throws by name rather than being created — running a migration on a second
-connection from inside your transaction would deadlock against your own write lock.
-
-The other place this bites is a query: SQLite resolves a table name when it *prepares* a statement,
-so `Query<T>()` against a type that has never been written fails with `no such table` rather than
-returning an empty list. Register the type, or apply the schema at startup.
+where a missing table throws by name rather than being created, on reads as on writes — running a
+migration on a second connection from inside your transaction would deadlock against your own write
+lock. Apply the schema before enlisting.
 :::

--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -62,7 +62,9 @@ public class Order
 ::: warning
 The dispatcher is emitted by `JasperFx.Events.SourceGenerator`, and **there is no runtime fallback**.
 
-- The project defining the aggregate or projection needs a reference to that package.
+- **The Fisher package carries the generator**, so referencing Fisher is enough — no analyzer
+  reference of your own. The generator runs in the assembly that *defines* the aggregate or
+  projection, so that assembly is the one that has to reference Fisher.
 - A conventional-method **projection class** must be declared `partial`.
 - The aggregate needs an identity member, because the generator keys the dispatcher on `(TDoc, TId)`.
 - `TId` is the aggregate's **own** id type — a strong-typed id is a wrapper struct, and the generated

--- a/docs/events/projections/live-aggregates.md
+++ b/docs/events/projections/live-aggregates.md
@@ -29,7 +29,9 @@ No registration is needed — a self-aggregating type is discovered.
 Conventional `Apply` / `Create` / `ShouldDelete` dispatch is **compile-time only**. JasperFx's source
 generator emits the dispatcher and there is no runtime fallback, so:
 
-- the defining project needs `JasperFx.Events.SourceGenerator`;
+- the generator runs in the assembly that **defines** the aggregate, so that assembly is the one that
+  has to reference Fisher — the package carries `JasperFx.Events.SourceGenerator` inside it, so there
+  is nothing to add yourself;
 - the aggregate needs an **identity member**, because the generator keys the dispatcher on
   `(TDoc, TId)` and resolves `TId` from it.
 

--- a/docs/events/projections/single-stream-projections.md
+++ b/docs/events/projections/single-stream-projections.md
@@ -99,10 +99,9 @@ opts.Schema.For<OrderSummary>().Index(x => x.Customer);
 ```
 
 ::: tip
-The table is created by the migration when the projection is registered, and on demand at first write
-otherwise. Register the type if you will `Query<T>()` it before anything has been written — SQLite
-resolves a table name when it *prepares* a statement, so a query against a never-written type fails
-with `no such table` rather than returning empty.
+The table is created by the migration when the projection is registered, and on demand otherwise — at
+the first write of the type, or at the first read, whichever comes first. So a `Query<T>()` before
+anything has been projected returns empty rather than failing.
 :::
 
 ## Rebuilds

--- a/docs/events/quickstart.md
+++ b/docs/events/quickstart.md
@@ -30,7 +30,9 @@ public class Order
 ::: warning
 The `Apply` dispatcher is **source-generated**, and there is no runtime fallback. Two consequences:
 
-- The project defining the aggregate needs a reference to `JasperFx.Events.SourceGenerator`.
+- The generator runs in the assembly that **defines the aggregate**, so that assembly is the one that
+  has to reference Fisher. The Fisher package carries `JasperFx.Events.SourceGenerator` inside it, so
+  there is no analyzer reference to add yourself.
 - A conventional-method **projection class** must be declared `partial`.
 
 An aggregate also needs an identity member, because the generator keys the dispatcher on

--- a/docs/events/snapshots.md
+++ b/docs/events/snapshots.md
@@ -32,8 +32,9 @@ public class Order
 
 ::: warning
 The `Apply` dispatcher is source-generated with no runtime fallback, keyed on `(TDoc, TId)`. The
-aggregate needs an identity member, and the defining project needs a reference to
-`JasperFx.Events.SourceGenerator`.
+aggregate needs an identity member, and the generator runs in the assembly that **defines** it — so
+that assembly is the one that has to reference Fisher. The package carries
+`JasperFx.Events.SourceGenerator` inside it; there is no analyzer reference to add yourself.
 :::
 
 ## Inline snapshots

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -51,15 +51,16 @@ A document type can be stored without ever being registered, and a snapshot type
 projection configuration — so the first write may be the first time the table is needed. Fisher
 creates it at commit.
 
-::: warning
-Two exceptions:
+A **read** does the same: `Query<T>()` or `LoadAsync<T>` against a type nothing has written yet
+provisions its table and answers empty, rather than failing. That matters more than it sounds, because
+it is what every cold start does — resolving a cache before anything has populated it, listing a
+collection on a fresh install.
 
-- An [enlisted session](/documents/sessions#enlisting-in-your-own-connection-or-transaction) does not
-  do this — running a migration on a second connection from inside your transaction would deadlock
-  against your own write lock. A missing table throws by name.
-- A **query** against a type whose table has never been created fails with `no such table`, because
-  SQLite resolves a table name when it *prepares* a statement. Register the type, or apply the schema
-  at startup.
+::: warning
+An [enlisted session](/documents/sessions#enlisting-in-your-own-connection-or-transaction) is the one
+exception, on reads as on writes: running a migration on a second connection from inside your
+transaction would deadlock against your own write lock, so a missing table throws by name instead.
+Apply the schema before enlisting.
 :::
 
 ## Multi-tenancy

--- a/docs/testing/integration.md
+++ b/docs/testing/integration.md
@@ -85,17 +85,26 @@ See [Tearing Down Document Storage](/schema/cleaning).
 
 ## Registering document types up front
 
-::: warning
-SQLite resolves a table name when it **prepares** a statement, so a `Query<T>()` against a type that
-has never been written fails with `no such table` rather than returning an empty list.
-
-Register the types your tests query, or apply the schema at startup. This is the single most common
-first surprise for a test suite.
+::: tip
+**A read against a type nothing has written provisions its table and answers empty**, exactly as the
+first write of that type does. So a test that queries a collection before seeding it gets an empty
+list, not `no such table`.
 :::
+
+Registering the types up front is still worth doing, for a different reason: it puts every table in
+the one migration your fixture already runs, instead of paying a migration on the first read or write
+of each type.
 
 ```cs
 opts.Schema.For<Order>();
 ```
+
+::: warning
+An [enlisted session](/documents/sessions#enlisting-in-your-own-connection-or-transaction) is the
+exception, on reads as on writes: it cannot provision, because running a migration on a second
+connection from inside your transaction would deadlock against your own write lock. A missing table
+throws by name there.
+:::
 
 ## Testing async projections
 


### PR DESCRIPTION
Follow-up to #79, #80, #82, #83, #84 and #85. Two of those changed behaviour the docs stated the old way, across nine pages — and a doc that tells a reader to do something no longer necessary is worse than one that says nothing.

## The nupkg carries the source generator (#73)

Five pages told readers to add `JasperFx.Events.SourceGenerator` to the project defining the aggregate. That is no longer true, and the half that *is* still true was buried in it: **the generator runs in the assembly that defines the aggregate or projection, so that assembly is the one that has to reference Fisher.** Each of the five now says that instead.

- `events/quickstart.md`
- `events/snapshots.md`
- `events/projections/index.md`
- `events/projections/live-aggregates.md`
- `documents/identity.md`

## A read provisions its table (#74)

Four pages warned that `Query<T>()` against a never-written type fails with `no such table`. That was the behaviour #74 removed.

- `schema/index.md`, `documents/storing.md`, `events/projections/single-stream-projections.md` — the surviving exception is the enlisted session, which now says it applies to **reads as well as writes**, with "apply the schema before enlisting" as the fix.
- `testing/integration.md` — this one had "register document types up front" as a warning headed *the single most common first surprise for a test suite*. The advice is still good and the reason is not, so it is now a tip on the honest ground: registering puts every table in the migration the fixture already runs, instead of paying one on first read or write of each type.

## Version

`0.6.0` → `0.7.0`. Three bug fixes, two of them silent-data-loss class, plus three API additions.

## Verified

- `npm run docs-build` clean — a dead internal link would fail it.
- Release build, all three suites, both target frameworks: **1228 + 36 + 13, zero failures on each**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs