### PR TITLE
JasperFx 2.48.0, and the fisher#72 workaround comes back out (0.7.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2945,12 +2945,13 @@ coalescing on purpose. Do not present it as a performance feature.
 ### Compliance suites
 
 **Fisher is enrolled, in full.** `JasperFx.Events.ComplianceTests` is referenced unconditionally —
-the old `$(EnableComplianceTests)` gate is gone. **All 32 suites, 272 tests, are live**, as of 2.47.0.
+the old `$(EnableComplianceTests)` gate is gone. **All 32 suites, 272 tests, are live**, as of 2.48.0.
 The event sourcing half is 28 suites and 230 tests and has been the whole library since 2.45.0
 emptied the upstream event sourcing backlog; **2.46.0 added no suite and no test** (fisher#64), and
-the counts were re-verified against it rather than carried over, since "still 28" is exactly the
-claim a bump can quietly falsify. **2.47.0 added a second half rather than another event suite** —
-four *document* suites, 42 tests, over the store-agnostic contract described below.
+**2.48.0 added neither, and changed no existing suite file** — the counts were re-verified against a
+real run on each rather than carried over, since "still 32" is exactly the claim a bump can quietly
+falsify. **2.47.0 added a second half rather than another event suite** — four *document* suites, 42
+tests, over the store-agnostic contract described below.
 The four that arrived in 2.40.0/2.41.0 — `StringStreamIdentityCompliance`,
 `SnapshotLifecycleCompliance`, `MultiStreamProjectionCompliance`, `FlatTableProjectionCompliance` —
 went in on the same bump.
@@ -3097,19 +3098,31 @@ the same method compare that value against itself and pass unconditionally. Keep
 assignment and metadata application apart is what keeps the guard real; the cost is that a new
 metadata field in JasperFx will not reach Fisher's events until this method learns about it.
 
-**The same method stamps the stream's own identity onto each event, and that is not redundant**
-(fisher#72). `StreamAction.AddEvent` stamps `StreamId`/`StreamKey`/`TenantId`, and the `Guid` append
-factory goes through it — but `StreamAction.Append(graph, string, …)` appends straight to the backing
-list and does not, and `PrepareEvents` does not close the gap either (it sets `TenantId`, `Timestamp`,
-`Version` and `Sequence`, never the stream identity). So **every event appended to a string-identified
-stream reached an inline projection with an empty `StreamKey`** — which is exactly how a
-string-identified projection learns which entity it is projecting. Nothing threw: the projection ran
-and wrote a document with a blank field, and the first visible symptom was a query returning nothing.
-Filed upstream as [jasperfx#663](https://github.com/JasperFx/jasperfx/issues/663); stamping here is
-idempotent, so it stays correct when that ships. **The async daemon was never affected** —
-`FisherEventLoader` hydrates through `FisherEventsRowReader.ReadEventAcrossStreams`, which takes the
-identity off the row. `event_envelope_metadata_in_projections` pins both identities, because the
-asymmetry is upstream's and a release closing it must not silently change which half is covered.
+#### Closed upstream gap — jasperfx#663
+
+Historical, and the second completed cycle of the "workaround, filed upstream, removed when the fix
+ships" rule after `FisherCommandBuilder`. This method used to stamp the stream's own identity onto
+each event as well (fisher#72). `StreamAction.AddEvent` stamps `StreamId`/`StreamKey`/`TenantId` and
+the `Guid` append factory went through it — but `StreamAction.Append(graph, string, …)` appended
+straight to the backing list and did not, and `PrepareEvents` did not close the gap either (it sets
+`TenantId`, `Timestamp`, `Version` and `Sequence`, never the stream identity). So **every event
+appended to a string-identified stream reached an inline projection with an empty `StreamKey`** —
+which is exactly how such a projection learns which entity it is projecting. Nothing threw: the
+projection ran and wrote a document with a blank field, and the first visible symptom was a query
+returning nothing.
+
+Fixed upstream by [jasperfx#663](https://github.com/JasperFx/jasperfx/issues/663) and shipped in
+**JasperFx 2.48.0**, which routes both string overloads through `AddEvents`. **The workaround is gone;
+do not reintroduce it.** Verified by deleting it and running the full suite against 2.48.0 — 1228
+green, including the test written to fail without it. That removal is also what makes 2.48.0 a real
+floor for Fisher rather than a preference.
+
+**The async daemon was never affected** — `FisherEventLoader` hydrates through
+`FisherEventsRowReader.ReadEventAcrossStreams`, which takes the identity off the row.
+`event_envelope_metadata_in_projections` now guards the upstream fix rather than a Fisher workaround,
+and still pins **both** identities: the asymmetry was upstream's, so a later release must not silently
+change which half is covered, and the Guid half passing is what tells a regression apart from a broken
+test.
 
 `ComplianceEventProjection` binds to `Fisher.Projections.EventProjection`. Its one required member,
 `storeEntity`, is now an ordinary `IDocumentSession.Store` onto the session the events are committing

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.7.0</Version>
+        <Version>0.7.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.47.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.47.0" />
+        <PackageVersion Include="JasperFx" Version="2.48.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.48.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.47.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.47.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.48.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.48.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -448,8 +448,8 @@ Three of the six turned up a real defect or a wrong premise, which is the useful
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.47.0 ships **32 suites, 272 tests**. Fisher passes **all 272,
-all 32 suites**. Every suite compiles; every one is also subclassed and running.
+`JasperFx.Events.ComplianceTests` 2.48.0 ships **32 suites, 272 tests** — it added no suite and
+changed no existing suite file. Fisher passes **all 272, all 32 suites**. Every suite compiles; every one is also subclassed and running.
 
 The library is now two halves. The **event sourcing** half is 28 suites and 230 tests, and its
 upstream backlog has been empty since 2.45.0 — that is the whole of it rather than a snapshot. The

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@ of joins, which cost one new type and made the rest of the join code shorter.
 
 Before that, the 2026-08-10 wave (#60–#66): two of those audits found real defects (#60's dead
 heartbeat branch, #63's composite teardown), #62's ported matrix found two more, and #61 and #66
-confirmed Fisher was already correct and now pin it. On JasperFx **2.47.0** / Weasel **9.24.0**.
+confirmed Fisher was already correct and now pin it. On JasperFx **2.48.0** / Weasel **9.24.0**.
 **All 32 compliance suites, 272 tests, green** — 28 event suites and 230 tests, plus 2.47.0's four
 document suites and 42 tests. 1241 tests green on net9.0 and net10.0.
 

--- a/src/Fisher.Tests/Projections/event_envelope_metadata_in_projections.cs
+++ b/src/Fisher.Tests/Projections/event_envelope_metadata_in_projections.cs
@@ -13,12 +13,17 @@ namespace Fisher.Tests.Projections;
 ///         The string case is the one that was broken. <c>StreamAction.AddEvent</c> stamps
 ///         <c>StreamId</c> / <c>StreamKey</c> / <c>TenantId</c> onto every event it takes, and the
 ///         <c>Guid</c> append overload goes through it — but
-///         <c>StreamAction.Append(graph, string, …)</c> appends straight to the backing list and does
+///         <c>StreamAction.Append(graph, string, …)</c> appended straight to the backing list and did
 ///         not, so an event appended to a string-identified stream reached a projection with an empty
-///         key. Nothing threw; the projection wrote a document with a blank field. Both identities are
-///         pinned here because the fix stamps them uniformly and the asymmetry is upstream's, not
-///         Fisher's — a future JasperFx release closing jasperfx#663 must not silently change which
-///         half is covered.
+///         key. Nothing threw; the projection wrote a document with a blank field.
+///     </para>
+///     <para>
+///         <b>These tests now guard the fix rather than a Fisher workaround.</b> Fisher stamped the
+///         identity in its own <c>AppendPlanner</c> until jasperfx#663 shipped in JasperFx 2.48.0,
+///         which routes both string overloads through <c>AddEvents</c>; the workaround is gone and
+///         this is what holds the behaviour. Both identities stay pinned because the asymmetry was
+///         upstream's, so a later release must not silently change which half is covered — and because
+///         the Guid half passing is what tells a regression here apart from a broken test.
 ///     </para>
 ///     <para>
 ///         The async daemon was never affected: <c>FisherEventLoader</c> hydrates through

--- a/src/Fisher/Events/AppendPlanner.cs
+++ b/src/Fisher/Events/AppendPlanner.cs
@@ -159,29 +159,25 @@ internal sealed class AppendPlanner
     ///         longer exists after a round trip.
     ///     </para>
     ///     <para>
-    ///         The stream's own identity is stamped here too, and that is <b>not</b> redundant
-    ///         (fisher#72). <c>StreamAction.AddEvent</c> stamps <c>StreamId</c>/<c>StreamKey</c>, but
-    ///         <c>StreamAction.Append(graph, string, …)</c> appends straight to the backing list and
-    ///         bypasses it, where the <c>Guid</c> overload beside it does not — so every event appended
-    ///         to a string-identified stream reached an inline projection with an empty
-    ///         <c>StreamKey</c>. That is the normal way a string-identified projection learns which
-    ///         entity it is projecting, and the failure was silent: the document was written with a
-    ///         blank key rather than anything throwing. Filed upstream as jasperfx#663; stamping here
-    ///         is idempotent, so it stays correct either way.
+    ///         <b>This used to stamp the stream's own identity as well, and no longer needs to.</b>
+    ///         fisher#72: <c>StreamAction.Append(graph, string, …)</c> appended straight to the backing
+    ///         list where the <c>Guid</c> overload beside it went through <c>AddEvent</c>, so every
+    ///         event appended to a string-identified stream reached an inline projection with an empty
+    ///         <c>StreamKey</c> — the normal way such a projection learns which entity it is projecting,
+    ///         and silent, because the document was written with a blank key rather than anything
+    ///         throwing. Fixed upstream by
+    ///         <see href="https://github.com/JasperFx/jasperfx/issues/663">jasperfx#663</see> and
+    ///         shipped in <b>JasperFx 2.48.0</b>, which routes both string overloads through
+    ///         <c>AddEvents</c>; the workaround here is gone, and the behaviour is pinned by
+    ///         <c>event_envelope_metadata_in_projections</c> rather than by this method. Do not
+    ///         reintroduce it — and note that removing it is what makes 2.48.0 a real floor rather than
+    ///         a preference.
     ///     </para>
     /// </remarks>
     private void ApplySessionMetadata(StreamAction stream)
     {
         foreach (var @event in stream.Events)
         {
-            @event.StreamId = stream.Id;
-            @event.StreamKey = stream.Key;
-
-            if (!string.IsNullOrEmpty(stream.TenantId))
-            {
-                @event.TenantId = stream.TenantId;
-            }
-
             if (_session.CorrelationIdEnabled)
             {
                 @event.CorrelationId ??= _session.CorrelationId;


### PR DESCRIPTION
All four JasperFx packages to **2.48.0**. Weasel stays at 9.24.0 — still current, and its JasperFx floor is well below this.

## No new compliance suites

Verified rather than assumed: diffing the `jasperfx.events.compliancetests` `contentFiles` between 2.47.0 and 2.48.0 reports **no added files and no changed files**. Enrollment re-checked by extracting every `public abstract class *Compliance` from the package and diffing against the enrolled list — 32 in the package, 32 enrolled, nothing missing. 272 compliance tests green, unchanged.

The scoreboards in CLAUDE.md, ROADMAP.md and HANDOFF.md are re-stamped to 2.48.0 with the counts re-verified against a real run, because "still 32" is exactly the claim a bump can quietly falsify.

## The substantive part: jasperfx#663 shipped

This release contains [jasperfx#663](https://github.com/JasperFx/jasperfx/issues/663), the upstream half of #72 — filed from this repo two commits ago. `StreamAction.Append(graph, string, …)` appended straight to the backing list where the `Guid` overload beside it went through `AddEvent`, so every event appended to a string-identified stream reached an inline projection with an empty `StreamKey`. 2.48.0 routes both string overloads through `AddEvents`.

**So Fisher's workaround comes out**, per the standing rule that a workaround is local, commented, filed upstream, and *removed when the fix ships* — the same cycle `FisherCommandBuilder` completed for weasel#424.

Verified rather than taken on trust, even though upstream's own commit message says the workaround "is idempotent and stays correct once this ships": deleting the stamping from `AppendPlanner` and running the full suite against 2.48.0 gives **1228 green**, including `event_envelope_metadata_in_projections` — the test written to fail without it. That test now guards the upstream fix rather than a Fisher workaround, and still pins **both** identities, because the asymmetry was upstream's and the Guid half passing is what tells a regression apart from a broken test.

Removing it is also what makes 2.48.0 a **real floor** rather than a preference. The packed nuspec declares it:

```
<dependency id="JasperFx" version="2.48.0" />
<dependency id="JasperFx.Events" version="2.48.0" />
```

## The source generator

Fisher bundles this analyzer as of #80, so 2.48.0's batch of source-generator fixes now ships inside the Fisher package (the bundled DLL goes 115200 → 116736 bytes). One of them — *"report unregistered published types instead of skipping in silence"* — could plausibly have emitted new diagnostics against Fisher's own projections.

It does not. Checked by diffing full-build warning counts by code between 2.47.0 and 2.48.0: **identical profile, code for code.** (An earlier 62-vs-67 reading was incremental-build noise, not a real difference.)

## Verified

- Release build, all three suites, both target frameworks: **1228 + 36 + 13, zero failures on each.**
- Packed nupkg: 2.48.0 floor declared, analyzer still bundled, generator still absent from the dependency list.

Version to **0.7.1** — a patch, since nothing in Fisher's own public surface moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs