### PR TITLE
Read an Inline-projected aggregate from its document in FetchLatest (closes #88)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2517,9 +2517,59 @@ cross-store compliance suites route everything through, so declaring it is what 
 `EventStoreComplianceFixture.EventsFor(session)` possible at all.
 
 Everything reachable without document storage is real: `FetchForWriting` rebuilds the aggregate by
-live aggregation (there is no snapshot to read instead), `WriteToAggregate` is fetch + callback +
-`SaveChangesAsync`, and `ProjectLatest` folds the session's pending events on top of the committed
-state.
+live aggregation, `WriteToAggregate` is fetch + callback + `SaveChangesAsync`, and `ProjectLatest`
+folds the session's pending events on top of the committed state.
+
+**`FetchLatest` is the exception, and it reads a document rather than folding** — see below.
+
+#### `FetchLatest` reads an Inline aggregate's document
+
+`EventOperations.CanReadInlineDocument` (fisher#88, the polecat#463 class). `FetchLatest<T>` used to
+live-aggregate the stream for *every* `T`, whatever its lifecycle, and the doc comment said so —
+adding that Fisher had no snapshot storage to read instead, which stopped being true when
+`Projections.Snapshot<T>` landed. So the claim aged into a bug: JasperFx's `InlineFetchPlanner` routes
+an Inline aggregate to its projected document, and Fisher kept folding.
+
+**The visible difference is a stream that exists but holds nothing `T` owns.** Marten and Polecat find
+no document and return null; Fisher folded the foreign events and handed back whatever the aggregator
+constructed. That matters because `FetchLatest<T>(id) is null` is the idiomatic "does this aggregate
+exist?" probe — so the probe was satisfied by any stream id holding events at all, and the answer
+depended on whether some other aggregate happened to share the id space.
+
+- **A default-constructed aggregate is not neutral**, which is what makes this worse than an empty
+  answer. A conventional `Create`/`Apply` aggregate came out null anyway, because nothing built an
+  instance; the shape that surfaces it is a catch-all `Evolve(IEvent)`, which accepts every event type
+  by construction. The reported case had `bool IsActive` defaulting to `true`, so the phantom read as
+  an **active alert** for a service that had none.
+- **Reading the document is what the write side already believed.** The inline projection screens out
+  streams it does not own, which is exactly why no row was ever written for them; the read path now
+  agrees. `no_document_is_written_for_a_stream_the_aggregate_does_not_handle` pins both halves
+  together — it passed before the fix, and keeping it is the point.
+- **Inline only**, mirroring `InlineFetchPlanner`. A Live aggregate has no document to read, and Marten
+  routes an Async one to the document only when the mapping is revisioned.
+- **Gated on the type having a Fisher mapping**, which is what keeps an EF Core-backed projection on
+  the old path: a type registered with `Projections.StorageProviders` is deliberately never mapped, so
+  its rows are in no `fi_doc_*` table and `LoadAsync` would answer about a table nothing writes to.
+  `HasMappingFor` is the same question the storage registry is itself constructed with, and unlike
+  `MappingFor` it does not create a mapping as a side effect of asking.
+- **And gated on the key type**, because a stream identity and a document identity are not always the
+  same type — a natural key resolves to a stream *key* (string) for an aggregate whose document id is a
+  Guid, and that key cannot address the document at all. Those fall back to live aggregation exactly as
+  before.
+- **`IdType` rather than `StoredIdType`, which is the one place Polecat's version does not port.**
+  Polecat compares the *inner* type so a strong-typed id matches on the value it wraps, because its
+  load path re-wraps on the way through; Fisher's does not. `LoadAsync<T>(Guid)` resolves storage by
+  hard-casting to `IDocumentStorage<T, Guid>`, and a strong-typed aggregate's storage is keyed on the
+  wrapper — so unwrapping passes the gate and then throws `InvalidCastException` from inside the load.
+  **`StrongTypedIdentityCompliance` is what caught it**, which is the argument for the suites in one
+  line: the gate looked right, matched the sibling it was ported from, and was wrong. Comparing
+  `IdType` leaves a strong-typed aggregate folding the stream exactly as before, so the phantom
+  survives for that shape alone; fisher#89's `LoadAsync<T>(object)` is the entry point that resolves a
+  canonical and a wrapped identity alike, and widening this is what it makes possible.
+- **`FetchForWriting` deliberately still folds**, as it does on Polecat. The two ask different
+  questions: `FetchLatest` reports current state, where `FetchForWriting` is the read half of a
+  read-modify-write whose guard is the stream's version — so the fold is what the version it hands back
+  has to agree with.
 
 **Nothing on `IEventStoreOperations` throws any more.** What did lived in
 `EventOperations.Unsupported.cs`, one file on purpose so that file shrinking was the progress

--- a/src/Fisher.Tests/Events/fetch_latest_for_unhandled_streams.cs
+++ b/src/Fisher.Tests/Events/fetch_latest_for_unhandled_streams.cs
@@ -1,0 +1,278 @@
+using Fisher.Linq;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+
+namespace Fisher.Tests.Events;
+
+public record ServiceRegistered(string Name, string Uri);
+
+public record AlertRaised(string Reason);
+
+public record AlertCleared(string Reason);
+
+/// <summary>
+///     Cares about service registration, and nothing else.
+/// </summary>
+public partial class ServiceSummary
+{
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Uri { get; set; } = "";
+
+    public static ServiceSummary Create(ServiceRegistered e) => new() { Name = e.Name, Uri = e.Uri };
+}
+
+/// <summary>
+///     A self-aggregating type whose only handler is a catch-all <c>Evolve(IEvent)</c> — the shape
+///     that surfaces fisher#88. A catch-all accepts every event type at the method level, so nothing
+///     in the aggregation path filters by event applicability: the aggregator default-constructs an
+///     instance and the switch inside simply matches nothing.
+///     <para>
+///         <see cref="IsActive" /> defaults to <c>true</c> on purpose, as in the reported aggregate.
+///         A default-constructed phantom does not read as "empty" — it reads as an <em>active
+///         alert</em>.
+///     </para>
+/// </summary>
+public partial class AlertRecord
+{
+    public string Id { get; set; } = "";
+    public string Reason { get; set; } = "";
+    public bool IsActive { get; set; } = true;
+
+    public void Evolve(IEvent e)
+    {
+        switch (e.Data)
+        {
+            case AlertRaised raised:
+                Reason = raised.Reason;
+                IsActive = true;
+                break;
+
+            case AlertCleared cleared:
+                Reason = cleared.Reason;
+                IsActive = false;
+                break;
+        }
+    }
+}
+
+/// <summary>
+///     A Live aggregate over the same events, to pin that the document read is <c>Inline</c> only.
+/// </summary>
+public partial class LiveAlertRecord
+{
+    public string Id { get; set; } = "";
+    public string Reason { get; set; } = "";
+    public bool IsActive { get; set; } = true;
+
+    public void Evolve(IEvent e)
+    {
+        if (e.Data is AlertRaised raised)
+        {
+            Reason = raised.Reason;
+            IsActive = true;
+        }
+    }
+}
+
+/// <summary>
+///     fisher#88 — <c>FetchLatest&lt;T&gt;(id)</c> on a stream that exists but holds no event
+///     <c>T</c> handles returned a non-null, default-constructed aggregate where Marten and Polecat
+///     return null.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>FetchLatest&lt;T&gt;(id) is null</c> is the idiomatic "does this aggregate exist?"
+///         probe that code branching between <c>StartStream</c> and <c>Append</c> depends on. Under
+///         the old behaviour that probe was satisfied by any stream id holding events at all, so the
+///         answer depended on whether some other aggregate happened to share the id space — and
+///         because a default is not neutral, the phantom read as an <em>active</em> alert.
+///     </para>
+///     <para>
+///         The fix is Marten's mechanism rather than a filter bolted onto aggregation: an Inline
+///         aggregate is read from its projected document, which is what the write side already
+///         believed — the inline projection screens out streams it does not own, which is why no row
+///         was ever written for them. This is polecat#463 / polecat#467, same shape.
+///     </para>
+/// </remarks>
+public class fetch_latest_for_unhandled_streams : IDisposable
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("fetch-latest-88");
+
+    public void Dispose() => _database.Dispose();
+
+    private DocumentStore StoreWith(Action<StoreOptions>? extra = null)
+        => DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.StreamIdentity = StreamIdentity.AsString;
+            options.Projections.Snapshot<ServiceSummary>(SnapshotLifecycle.Inline);
+            options.Projections.Snapshot<AlertRecord>(SnapshotLifecycle.Inline);
+            extra?.Invoke(options);
+        });
+
+    private static async Task StartServiceStream(DocumentStore store, string key)
+    {
+        await using var session = store.LightweightSession();
+        session.Events.StartStream<ServiceSummary>(key,
+            new ServiceRegistered(key, "rabbitmq://queue/test_service"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ===== The reported case =====
+
+    [Fact]
+    public async Task fetch_latest_is_null_for_a_stream_the_aggregate_does_not_handle()
+    {
+        await using var store = StoreWith();
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+        await StartServiceStream(store, "TestService");
+
+        await using var session = store.LightweightSession();
+
+        var alert = await session.Events.FetchLatest<AlertRecord>("TestService",
+            TestContext.Current.CancellationToken);
+
+        // Before the fix this was a default-valued AlertRecord — and since IsActive defaults to
+        // true, the phantom read as an active alert rather than as absence.
+        alert.ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     The issue verified this already passed. Keeping it is what pins the two halves together:
+    ///     the read path now agrees with what the persistence path always did.
+    /// </summary>
+    [Fact]
+    public async Task no_document_is_written_for_a_stream_the_aggregate_does_not_handle()
+    {
+        await using var store = StoreWith();
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+        await StartServiceStream(store, "NoDocService");
+
+        await using var query = store.QuerySession();
+
+        (await query.Query<AlertRecord>().CountAsync(TestContext.Current.CancellationToken))
+            .ShouldBe(0);
+    }
+
+    // ===== The aggregate that does own the stream is unaffected =====
+
+    [Fact]
+    public async Task fetch_latest_still_returns_the_aggregate_that_handles_the_stream()
+    {
+        await using var store = StoreWith();
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+        await StartServiceStream(store, "OwnedService");
+
+        await using var session = store.LightweightSession();
+
+        var summary = await session.Events.FetchLatest<ServiceSummary>("OwnedService",
+            TestContext.Current.CancellationToken);
+
+        summary.ShouldNotBeNull();
+        summary.Name.ShouldBe("OwnedService");
+        summary.Uri.ShouldBe("rabbitmq://queue/test_service");
+    }
+
+    [Fact]
+    public async Task fetch_latest_returns_the_alert_when_the_stream_does_hold_its_events()
+    {
+        await using var store = StoreWith();
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<AlertRecord>("RealAlert", new AlertRaised("disk full"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.LightweightSession();
+
+        var alert = await query.Events.FetchLatest<AlertRecord>("RealAlert",
+            TestContext.Current.CancellationToken);
+
+        alert.ShouldNotBeNull();
+        alert.Reason.ShouldBe("disk full");
+        alert.IsActive.ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     The document read has to reflect later events, not just the creating one — otherwise
+    ///     "reads its document" would be indistinguishable from "reads a stale first write".
+    /// </summary>
+    [Fact]
+    public async Task fetch_latest_reflects_every_event_the_aggregate_handles()
+    {
+        await using var store = StoreWith();
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<AlertRecord>("Clearing", new AlertRaised("disk full"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.Append("Clearing", new AlertCleared("disk reclaimed"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.LightweightSession();
+
+        var alert = await query.Events.FetchLatest<AlertRecord>("Clearing",
+            TestContext.Current.CancellationToken);
+
+        alert.ShouldNotBeNull();
+        alert.Reason.ShouldBe("disk reclaimed");
+        alert.IsActive.ShouldBeFalse();
+    }
+
+    // ===== The gates =====
+
+    /// <summary>
+    ///     Inline only, mirroring JasperFx's <c>InlineFetchPlanner</c>. A Live aggregate has no
+    ///     document to read, so it still folds the stream — which for a catch-all aggregate means it
+    ///     still synthesises. That is not the bug being fixed: a Live aggregate is a fold by
+    ///     definition, and this pins the gate rather than the phantom.
+    /// </summary>
+    [Fact]
+    public async Task a_live_aggregate_still_folds_the_stream()
+    {
+        await using var store = StoreWith();
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<AlertRecord>("LiveFold", new AlertRaised("still burning"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.LightweightSession();
+
+        var live = await query.Events.FetchLatest<LiveAlertRecord>("LiveFold",
+            TestContext.Current.CancellationToken);
+
+        live.ShouldNotBeNull();
+        live.Reason.ShouldBe("still burning");
+    }
+
+    /// <summary>
+    ///     A stream that was never started is null either way, so this would pass without the fix.
+    ///     It is here because the document path must not turn "no stream" into a throw about a
+    ///     missing row.
+    /// </summary>
+    [Fact]
+    public async Task fetch_latest_is_null_for_a_stream_that_does_not_exist()
+    {
+        await using var store = StoreWith();
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using var session = store.LightweightSession();
+
+        (await session.Events.FetchLatest<AlertRecord>("NeverStarted",
+            TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+}

--- a/src/Fisher/Events/EventOperations.Writing.cs
+++ b/src/Fisher/Events/EventOperations.Writing.cs
@@ -1,6 +1,7 @@
 using Fisher.Exceptions;
 using Fisher.Storage;
 using JasperFx.Events;
+using JasperFx.Events.Projections;
 using Microsoft.Data.Sqlite;
 
 namespace Fisher.Events;
@@ -88,9 +89,18 @@ public partial class EventOperations
     ///     the stream has right now.
     /// </summary>
     /// <remarks>
-    ///     The aggregate is rebuilt by live aggregation on every call — Fisher has no snapshot storage
-    ///     to read instead. A stream that does not exist yet comes back with a null
-    ///     <see cref="IEventStream{T}.Aggregate" /> and an append surface that will start it.
+    ///     <para>
+    ///         The aggregate is rebuilt by live aggregation on every call. A stream that does not exist
+    ///         yet comes back with a null <see cref="IEventStream{T}.Aggregate" /> and an append surface
+    ///         that will start it.
+    ///     </para>
+    ///     <para>
+    ///         <b>Deliberately still a fold, where <c>FetchLatest</c> reads an Inline aggregate's
+    ///         document</b> (fisher#88). Polecat scoped its equivalent fix the same way. The two are
+    ///         asking different questions: <c>FetchLatest</c> reports current state, while this is the
+    ///         read half of a read-modify-write whose guard is the stream's version — so folding the
+    ///         stream is what the version it returns has to agree with.
+    ///     </para>
     /// </remarks>
     public Task<IEventStream<T>> FetchForWriting<T>(Guid id, CancellationToken cancellation = default)
         where T : class
@@ -336,17 +346,103 @@ public partial class EventOperations
     ///     The current state of an aggregate.
     /// </summary>
     /// <remarks>
-    ///     Equivalent to <c>AggregateStreamAsync</c> today. In Marten and Polecat this reads a
-    ///     persisted snapshot when one is registered and only falls back to folding the stream; Fisher
-    ///     has no snapshot storage yet, so it always folds. Events pending in this session are not
-    ///     included — see <see cref="ProjectLatest{T}(Guid,CancellationToken)" />.
+    ///     An <c>Inline</c>-projected aggregate is read from its projected document; anything else
+    ///     folds the stream through <c>AggregateStreamAsync</c>. See
+    ///     <see cref="CanReadInlineDocument{T}" />. Events pending in this session are not included —
+    ///     see <see cref="ProjectLatest{T}(Guid,CancellationToken)" />.
     /// </remarks>
     public async ValueTask<T?> FetchLatest<T>(Guid id, CancellationToken cancellation = default) where T : class
-        => await AggregateStreamAsync<T>(id, token: cancellation).ConfigureAwait(false);
+    {
+        if (CanReadInlineDocument<T>(typeof(Guid)))
+        {
+            return await _session.LoadAsync<T>(id, cancellation).ConfigureAwait(false);
+        }
+
+        return await AggregateStreamAsync<T>(id, token: cancellation).ConfigureAwait(false);
+    }
 
     /// <inheritdoc cref="FetchLatest{T}(Guid,CancellationToken)" />
     public async ValueTask<T?> FetchLatest<T>(string id, CancellationToken cancellation = default) where T : class
-        => await AggregateStreamAsync<T>(id, token: cancellation).ConfigureAwait(false);
+    {
+        if (CanReadInlineDocument<T>(typeof(string)))
+        {
+            return await _session.LoadAsync<T>(id, cancellation).ConfigureAwait(false);
+        }
+
+        return await AggregateStreamAsync<T>(id, token: cancellation).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     fisher#88: is <typeparamref name="T" /> the subject of an <c>Inline</c> projection whose
+    ///     projected document can be addressed by a <paramref name="keyType" />-typed identity?
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Fisher used to live-aggregate the stream for <em>every</em> <c>FetchLatest&lt;T&gt;</c>,
+    ///         whatever <c>T</c>'s lifecycle — the doc comment here said so, and said Fisher had no
+    ///         snapshot storage to read instead, which stopped being true when
+    ///         <c>Projections.Snapshot&lt;T&gt;</c> landed. Marten's fetch planner routes an Inline
+    ///         aggregate to <c>FetchInlinedPlan</c>, which simply loads the projected document. The
+    ///         visible difference is on a stream that exists but holds nothing <c>T</c> owns: Marten
+    ///         and Polecat find no document and return <c>null</c>, where Fisher folded the foreign
+    ///         events and handed back whatever the aggregator constructed. This is polecat#463, fixed
+    ///         there in 5.15.0 by polecat#467, and Fisher is the same shape.
+    ///     </para>
+    ///     <para>
+    ///         <b>A default-constructed aggregate is not neutral.</b> For a conventional
+    ///         <c>Create</c>/<c>Apply</c> aggregate the old path came out null anyway, because nothing
+    ///         built an instance. The shape that surfaces it is a catch-all <c>Evolve(IEvent)</c>,
+    ///         which accepts every event type by construction: the aggregator built an instance, the
+    ///         switch inside matched nothing, and the defaults came back as though they were state. In
+    ///         the reported case a <c>bool IsActive</c> defaulting to <c>true</c> made the phantom read
+    ///         as an <em>active alert</em> for a service that had none. Since
+    ///         <c>FetchLatest&lt;T&gt;(id) is null</c> is the idiomatic "does this aggregate exist?"
+    ///         probe, that probe was satisfied by any stream id holding events at all.
+    ///     </para>
+    ///     <para>
+    ///         Reading the document is also what the write side already believed: the inline projection
+    ///         screens out streams it does not own, which is exactly why no row was ever written for
+    ///         them. The two halves now agree.
+    ///     </para>
+    ///     <para>
+    ///         <b>Inline only</b>, mirroring JasperFx's <c>InlineFetchPlanner</c>. A Live aggregate has
+    ///         no document to read, and Marten routes an Async one to the document only when the
+    ///         mapping is revisioned.
+    ///     </para>
+    ///     <para>
+    ///         <b>The mapping gate is what keeps an externally-stored projection on the old path.</b>
+    ///         A type registered with <c>Projections.StorageProviders</c> — an EF Core-backed
+    ///         projection — is deliberately never mapped, so its rows are in no <c>fi_doc_*</c> table
+    ///         and <c>LoadAsync</c> would answer about a table nothing writes to.
+    ///         <c>HasMappingFor</c> is the same question the storage registry itself is constructed
+    ///         with, and it does not create a mapping the way <c>MappingFor</c> would.
+    ///     </para>
+    ///     <para>
+    ///         <b>And the key type has to match, because a stream identity and a document identity are
+    ///         not always the same type.</b> A natural key resolves to a stream <em>key</em> (string)
+    ///         for an aggregate whose document id is a Guid, and that key cannot address the document
+    ///         at all; those fall back to live aggregation exactly as before.
+    ///     </para>
+    ///     <para>
+    ///         <b><c>IdType</c> rather than <c>StoredIdType</c>, which is where Polecat's equivalent
+    ///         does not port.</b> Polecat compares the <em>inner</em> type so a strong-typed id matches
+    ///         on the value it wraps, because its load path re-wraps on the way through. Fisher's does
+    ///         not: <c>LoadAsync&lt;T&gt;(Guid)</c> resolves storage by hard-casting to
+    ///         <c>IDocumentStorage&lt;T, Guid&gt;</c>, and a strong-typed aggregate's storage is keyed
+    ///         on the wrapper — so unwrapping here passes the gate and then throws
+    ///         <c>InvalidCastException</c> from inside the load. Comparing <c>IdType</c> leaves a
+    ///         strong-typed aggregate folding the stream, exactly as it did before this change, so the
+    ///         phantom survives only for that shape. <c>StrongTypedIdentityCompliance</c> is what
+    ///         caught it, and widening this is what fisher#89's <c>LoadAsync&lt;T&gt;(object)</c> —
+    ///         an entry point that resolves a canonical and a wrapped identity alike — exists to make
+    ///         possible.
+    ///     </para>
+    /// </remarks>
+    private bool CanReadInlineDocument<T>(Type keyType) where T : class
+        => Graph.Options.Projections.TryFindAggregate(typeof(T), out var projection)
+           && projection.Lifecycle == ProjectionLifecycle.Inline
+           && Graph.Options.Schema.HasMappingFor(typeof(T))
+           && Graph.Options.Schema.MappingFor(typeof(T)).IdType == keyType;
 
     /// <inheritdoc cref="FetchForWriting{T,TId}(TId,CancellationToken)" />
     /// <inheritdoc cref="FetchForWriting{T,TId}(TId,CancellationToken)" />


### PR DESCRIPTION
`FetchLatest<T>(id)` on a stream that exists but holds no event `T` handles returned a non-null, default-constructed aggregate where Marten and Polecat return `null`. This is [polecat#463](https://github.com/JasperFx/polecat/issues/463), fixed there in 5.15.0 by polecat#467; Fisher was the same shape.

## The root cause is a missing fetch plan, not a missing filter

Fisher live-aggregated the stream for *every* `FetchLatest`, whatever `T`'s lifecycle. The doc comment said so — adding that Fisher had no snapshot storage to read instead, which stopped being true when `Projections.Snapshot<T>` landed. The comment aged into a bug.

JasperFx's `InlineFetchPlanner` routes an Inline aggregate to its projected document. Fisher now does too.

## Why it matters more than it looks

`FetchLatest<T>(id) is null` is the idiomatic "does this aggregate exist?" probe, so under the old behaviour the probe was satisfied by any stream id holding events at all — the answer depended on whether some other aggregate happened to share the id space.

And a default is not neutral. The reported case had `bool IsActive` defaulting to `true`, so the phantom read as an **active alert** for a service that had none. A conventional `Create`/`Apply` aggregate came out null anyway, because nothing built an instance; the shape that surfaces this is a catch-all `Evolve(IEvent)`, which accepts every event type by construction.

Reading the document is also what the write side already believed: the inline projection screens out streams it does not own, which is exactly why no row was ever written for them. `no_document_is_written_for_a_stream_the_aggregate_does_not_handle` passed before the fix, and keeping it is what pins the two halves together.

## The gates

- **Inline only**, mirroring `InlineFetchPlanner`. A Live aggregate has no document to read.
- **The type must have a Fisher mapping**, which keeps an EF Core-backed projection on the old path — those are deliberately never mapped, so `LoadAsync` would answer about a table nothing writes to. `HasMappingFor` is the same question the storage registry is constructed with, and unlike `MappingFor` it doesn't create a mapping as a side effect of asking.
- **The key type must match.** A natural key resolves to a stream *key* (string) for an aggregate whose document id is a Guid, and that key can't address the document at all.

## One place Polecat's fix does not port

The key-type gate compares `IdType`, **not** Polecat's `StoredIdType`.

Polecat compares the *inner* type so a strong-typed id matches on the value it wraps, because its load path re-wraps on the way through. Fisher's does not — `LoadAsync<T>(Guid)` resolves storage by hard-casting to `IDocumentStorage<T, Guid>`, and a strong-typed aggregate's storage is keyed on the wrapper. Unwrapping passes the gate and then throws `InvalidCastException` from inside the load.

`StrongTypedIdentityCompliance` is what caught it, which is the argument for the shared suites in one line: the gate looked right, matched the sibling it was ported from, and was wrong.

Comparing `IdType` leaves a strong-typed aggregate folding the stream exactly as before, so the phantom survives for that shape alone. #89's `LoadAsync<T>(object)` — an entry point that resolves a canonical and a wrapped identity alike — is what will widen it.

## Deliberately unchanged

`FetchForWriting` still folds, as on Polecat. The two ask different questions: `FetchLatest` reports current state, where `FetchForWriting` is the read half of a read-modify-write whose guard is the stream's version, so the fold is what the version it hands back has to agree with. Its stale doc comment is corrected to say this rather than the old "no snapshot storage" claim.

## Verification

Verified load-bearing by disabling the guard — the reported test fails with `should be null but was Fisher.Tests.Events.AlertRecord`.

Full suite **1235/0 on both TFMs**, plus 36 AspNetCore and 13 EF Core.

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs