### PR TITLE
The on-demand document table path honours AutoCreate.None (closes #81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,13 +352,24 @@ Three things that are decisions:
   for the identical reason: the migration runs on its own connection and would block against the write
   lock the caller's transaction is holding — a session deadlocking against itself. Naming the type
   beats that, and beats the raw SQLite error it replaced.
-- **`AutoCreate.None` provisions, because the write path already does.** Weasel's explicit
-  `ApplyAllConfiguredChangesToDatabaseAsync` upgrades `None` to `CreateOrUpdate`, being the call that
-  means "apply it". Declining on reads alone would make the weaker operation the stricter one. Whether
-  the on-demand path should honour `AutoCreate.None` at all is a live question — `HiloSequence` checks
-  it and declines, so the store disagrees with itself — and is fisher#81;
-  `a_read_and_a_write_agree_about_auto_create_none` pins today's answer so either resolution is
-  deliberate.
+- **`AutoCreate.None` is honoured: the on-demand path checks and declines** (fisher#81). Weasel's
+  `ApplyAllConfiguredChangesToDatabaseAsync` upgrades `None` to `CreateOrUpdate`, because that call
+  *is* the explicit "apply it" — correct for the call as Weasel means it, and wrong for a path whose
+  whole point is that it fires implicitly, on the first write and (since fisher#74) the first read of a
+  document type. So a store configured "the schema is not yours to change" was still issuing DDL from
+  inside a session, while `HiloSequence` checked the same setting and declined. Both halves were
+  answered together, because answering the read alone would make the weaker operation the stricter one
+  — `a_read_and_a_write_agree_about_auto_create_none` still pins that they agree, having been rewritten
+  to pin the refusal rather than the provisioning.
+  - **An existing table is not an error**, so the common case for a store deploying this way — schema
+    applied out of band — is untouched. `auto_create_none_is_happy_once_the_schema_has_been_applied`
+    exists because "honours `AutoCreate.None`" could otherwise be an unconditional throw and still pass.
+  - **A refused type is removed from the ensured-tables cache**, the same discipline that keeps the
+    first-use migration uncached until it succeeds. Without it the second call succeeds silently and the
+    failure resurfaces as `no such table` from wherever the caller went next — and worse, a read would
+    cache the type and let the *write* through. Verified by removing it: two tests fail.
+  - The message names the document type, the setting, and the call to make — strictly better than the
+    raw `SQLite Error 1: no such table` about a name the caller never wrote.
 
 ### Flat-table projections
 

--- a/docs/configuration/storeoptions.md
+++ b/docs/configuration/storeoptions.md
@@ -59,6 +59,18 @@ cleaning the other's rows, silently.
 `AutoCreate.None` is honoured everywhere for free, because all DDL goes through Weasel's migrations
 rather than being issued ad hoc at call sites.
 
+::: warning
+Fisher normally creates a document type's table **on demand**, the first time something reads or
+writes one — a snapshot type is registered by projection configuration, which can run after the
+schema was last applied.
+
+Under `AutoCreate.None` that path checks instead of creating, and throws naming the document type if
+its table is missing. So a store configured this way must apply its schema out of band — with
+`ApplyAllConfiguredChangesToDatabaseAsync`, the generated DDL, or
+`ApplyAllDatabaseChangesOnStartup()` — and must **re-apply it after registering a new projection**,
+since that registration is what maps the snapshot's document type.
+:::
+
 ## Event store options
 
 ```cs

--- a/src/Fisher.Tests/Documents/reading_before_the_first_write.cs
+++ b/src/Fisher.Tests/Documents/reading_before_the_first_write.cs
@@ -152,18 +152,19 @@ public class reading_before_the_first_write : IAsyncLifetime
 
     /// <remarks>
     ///     <para>
-    ///         <b>A read under <c>AutoCreate.None</c> provisions, because a write under
-    ///         <c>AutoCreate.None</c> already does.</b> Both go through
-    ///         <c>EnsureDocumentTableAsync</c>, and Weasel's explicit
-    ///         <c>ApplyAllConfiguredChangesToDatabaseAsync</c> deliberately upgrades <c>None</c> to
-    ///         <c>CreateOrUpdate</c> — being the call that means "apply it". So this pins that reads and
-    ///         writes agree rather than claiming a policy neither of them honours.
+    ///         <b>The on-demand path honours <c>AutoCreate.None</c> and declines</b> (fisher#81), which
+    ///         is a deliberate reversal of what this test used to pin. Weasel's
+    ///         <c>ApplyAllConfiguredChangesToDatabaseAsync</c> upgrades <c>None</c> to
+    ///         <c>CreateOrUpdate</c> — correct for the call as Weasel means it, since that call <em>is</em>
+    ///         the explicit "apply it" — but wrong for a path that fires implicitly on the first write
+    ///         (and since fisher#74 the first read) of a type. So a store configured "the schema is not
+    ///         yours to change" was still issuing DDL from inside a session, while <c>HiloSequence</c>
+    ///         checked the same setting and declined.
     ///     </para>
     ///     <para>
-    ///         Whether the on-demand path <em>should</em> honour <c>AutoCreate.None</c> is a real
-    ///         question — <c>HiloSequence</c> checks it explicitly and declines — but it is one about
-    ///         both paths at once, and answering it here would leave a read stricter than a write.
-    ///         Filed as fisher#81.
+    ///         What has not changed is that the two agree: a read and a write are refused the same way,
+    ///         which is the property this test has always been for. Answering only one of them would
+    ///         leave the weaker operation the stricter one.
     ///     </para>
     /// </remarks>
     [Fact]
@@ -177,16 +178,89 @@ public class reading_before_the_first_write : IAsyncLifetime
 
         await using var reading = store.QuerySession();
 
-        (await reading.Query<NeverCreated>().ToListAsync(TestContext.Current.CancellationToken))
-            .ShouldBeEmpty();
+        var read = await Should.ThrowAsync<InvalidOperationException>(
+            async () => await reading.Query<NeverCreated>()
+                .ToListAsync(TestContext.Current.CancellationToken));
 
         await using var writing = store.LightweightSession();
 
         writing.Store(new NeverCreated { Id = "one" });
-        await writing.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        (await reading.Query<NeverCreated>().CountAsync(TestContext.Current.CancellationToken))
+        var written = await Should.ThrowAsync<InvalidOperationException>(
+            async () => await writing.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        // Same refusal, and it names the type rather than leaving SQLite to say "no such table" about
+        // a name the caller never wrote.
+        foreach (var message in new[] { read.Message, written.Message })
+        {
+            message.ShouldContain(nameof(NeverCreated));
+            message.ShouldContain("AutoCreate.None");
+            message.ShouldContain("ApplyAllConfiguredChangesToDatabaseAsync");
+        }
+    }
+
+    /// <remarks>
+    ///     The overwhelmingly common case for a store deploying this way: the schema was applied out of
+    ///     band, so the table is already there and nothing is refused. Without this, "honours
+    ///     <c>AutoCreate.None</c>" could be implemented as an unconditional throw and still pass the
+    ///     test above.
+    /// </remarks>
+    [Fact]
+    public async Task auto_create_none_is_happy_once_the_schema_has_been_applied()
+    {
+        await using (var applying = DocumentStore.For(options =>
+                     {
+                         options.ConnectionString = _database.ConnectionString;
+                         options.AutoCreateSchemaObjects = AutoCreate.All;
+                         options.Schema.For<AppliedUpFront>();
+                     }))
+        {
+            await applying.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.None;
+            options.Schema.For<AppliedUpFront>();
+        });
+
+        await using var session = store.LightweightSession();
+
+        (await session.Query<AppliedUpFront>().ToListAsync(TestContext.Current.CancellationToken))
+            .ShouldBeEmpty();
+
+        session.Store(new AppliedUpFront { Id = "one" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.Query<AppliedUpFront>().CountAsync(TestContext.Current.CancellationToken))
             .ShouldBe(1);
+    }
+
+    /// <remarks>
+    ///     A refused type must not be remembered as handled, or the second call through the on-demand
+    ///     path succeeds silently and the failure resurfaces as <c>no such table</c> from wherever the
+    ///     caller went next. Same discipline as the first-use migration, which is not cached until it
+    ///     succeeds.
+    /// </remarks>
+    [Fact]
+    public async Task a_refusal_is_not_cached_as_though_the_table_existed()
+    {
+        await using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.None;
+        });
+
+        await using var session = store.QuerySession();
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            async () => await session.Query<NeverCreated>()
+                .ToListAsync(TestContext.Current.CancellationToken));
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            async () => await session.Query<NeverCreated>()
+                .ToListAsync(TestContext.Current.CancellationToken));
     }
 
     /// <remarks>
@@ -228,6 +302,11 @@ public class TraceProvider
 }
 
 public class NeverCreated
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class AppliedUpFront
 {
     public string Id { get; set; } = string.Empty;
 }

--- a/src/Fisher/Storage/FisherDatabase.cs
+++ b/src/Fisher/Storage/FisherDatabase.cs
@@ -215,10 +215,34 @@ public partial class FisherDatabase : SqliteDatabase, Weasel.Storage.IStorageDat
     ///     Create this document type's table if it is not known to exist yet.
     /// </summary>
     /// <remarks>
-    ///     Snapshot types are registered by projection configuration, which can run after the schema
-    ///     was last applied, so the inline projection path cannot assume its table is already there.
-    ///     The set of types already handled is cached because the check would otherwise run on every
-    ///     commit.
+    ///     <para>
+    ///         Snapshot types are registered by projection configuration, which can run after the schema
+    ///         was last applied, so the inline projection path cannot assume its table is already there.
+    ///         The set of types already handled is cached because the check would otherwise run on every
+    ///         commit.
+    ///     </para>
+    ///     <para>
+    ///         <b>Under <c>AutoCreate.None</c> this checks and declines instead of creating</b>
+    ///         (fisher#81). Weasel's <c>ApplyAllConfiguredChangesToDatabaseAsync</c> deliberately
+    ///         upgrades <c>None</c> to <c>CreateOrUpdate</c>, because that call <em>is</em> the explicit
+    ///         "apply it" — correct for the call as Weasel means it, and wrong for a path whose whole
+    ///         point is that it fires implicitly, on the first write (and since fisher#74 the first
+    ///         read) of a document type. So a store configured "the schema is not yours to change" was
+    ///         still issuing DDL from inside a session, while <c>HiloSequence</c> checked the same
+    ///         setting and declined — the store disagreeing with itself.
+    ///     </para>
+    ///     <para>
+    ///         <b>An existing table is not an error.</b> A store deploying this way applies its schema
+    ///         out of band, so the overwhelmingly common case is that the table is already there; only a
+    ///         genuinely missing one is refused, and the message names the type rather than leaving
+    ///         SQLite to say <c>no such table</c> about a name the caller never wrote.
+    ///     </para>
+    ///     <para>
+    ///         <b>The type is uncached when the check fails</b>, for the reason the first-use migration
+    ///         above is not cached until it succeeds: remembering a type as handled after refusing it
+    ///         would make the second call through this path silently succeed, and the failure would then
+    ///         surface as <c>no such table</c> from wherever the caller went next.
+    ///     </para>
     /// </remarks>
     internal async Task EnsureDocumentTableAsync(Type documentType, CancellationToken token)
     {
@@ -230,12 +254,56 @@ public partial class FisherDatabase : SqliteDatabase, Weasel.Storage.IStorageDat
             }
         }
 
-        // Registering the mapping is what puts the table into BuildFeatureSchemas; applying the whole
-        // configuration then creates it. Heavier than emitting one CREATE TABLE, but it goes through
-        // the same migration path as every other Fisher table instead of beside it.
-        _options.Schema.MappingFor(documentType);
+        try
+        {
+            // Registering the mapping is what puts the table into BuildFeatureSchemas; applying the
+            // whole configuration then creates it. Heavier than emitting one CREATE TABLE, but it goes
+            // through the same migration path as every other Fisher table instead of beside it.
+            var mapping = _options.Schema.MappingFor(documentType);
 
-        await ApplyAllConfiguredChangesToDatabaseAsync(ct: token).ConfigureAwait(false);
+            if (AutoCreate == JasperFx.AutoCreate.None)
+            {
+                await AssertDocumentTableExistsAsync(documentType, mapping.TableName.Name, token)
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            await ApplyAllConfiguredChangesToDatabaseAsync(ct: token).ConfigureAwait(false);
+        }
+        catch
+        {
+            lock (_ensuredDocumentTables)
+            {
+                _ensuredDocumentTables.Remove(documentType);
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///     Under <c>AutoCreate.None</c>, check that a document type's table is already there and say
+    ///     which type is missing if it is not.
+    /// </summary>
+    private async Task AssertDocumentTableExistsAsync(Type documentType, string tableName,
+        CancellationToken token)
+    {
+        await using var conn = await OpenConnectionAsync(token).ConfigureAwait(false);
+
+        await using var command = conn.CreateCommand();
+        command.CommandText = "select 1 from sqlite_master where type = 'table' and name = $name";
+        command.Parameters.AddWithValue("$name", tableName);
+
+        if (await command.ExecuteScalarAsync(token).ConfigureAwait(false) is null)
+        {
+            throw new InvalidOperationException(
+                $"There is no table '{tableName}' for document type {documentType.FullName}. This store is "
+                + "configured AutoCreate.None, so Fisher will not create one on demand — register the type "
+                + "with StoreOptions.Schema.For<T>() and apply the configuration with "
+                + "ApplyAllConfiguredChangesToDatabaseAsync (or the generated DDL) before using it. A type "
+                + "registered only by projection configuration needs the schema re-applied after that "
+                + "registration.");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Two on-demand schema paths disagreed about `AutoCreate.None`. `HiloSequence` checked it and declined; `FisherDatabase.EnsureDocumentTableAsync` did not.

Weasel's `ApplyAllConfiguredChangesToDatabaseAsync` deliberately upgrades `None` to `CreateOrUpdate`, because that call *is* the explicit "apply it" — correct for the call as Weasel means it, and wrong for a path whose whole point is that it fires implicitly, on the first write (and since #74 the first read) of a document type. So a store configured "the schema is not yours to change" was still issuing DDL from inside a session.

**Both halves are answered together.** Answering the read alone would leave the weaker operation the stricter one, which is exactly why #74 declined to settle this.

## Three decisions rather than mechanics

**An existing table is not an error.** A store deploying this way applies its schema out of band, so the overwhelmingly common case is that the table is already there; only a genuinely missing one is refused. `auto_create_none_is_happy_once_the_schema_has_been_applied` exists because without it "honours `AutoCreate.None`" could be implemented as an unconditional throw and still pass.

**A refused type is removed from the ensured-tables cache** — the same discipline that keeps the first-use migration uncached until it succeeds. Without it the second call through the path succeeds silently and the failure resurfaces as `no such table` from wherever the caller went next. Worse: a read would cache the type and let the *write* through. Verified by removing it — two tests fail, including the read/write agreement one.

**The message names the type, the setting, and the call to make:**

> There is no table 'fi_doc_nevercreated' for document type `Fisher.Tests.Documents.NeverCreated`. This store is configured AutoCreate.None, so Fisher will not create one on demand — register the type with `StoreOptions.Schema.For<T>()` and apply the configuration with `ApplyAllConfiguredChangesToDatabaseAsync` (or the generated DDL) before using it. A type registered only by projection configuration needs the schema re-applied after that registration.

Strictly better than the raw `SQLite Error 1: no such table` about a name the caller never wrote.

## Behaviour change

This is the one part of 0.7.2 that changes behaviour for a store that works today. A store on `AutoCreate.None` that has been relying on implicit provisioning will now be refused, and must apply its schema out of band — including **re-applying after registering a new projection**, since that registration is what maps the snapshot's document type. Documented in `docs/configuration/storeoptions.md`.

`a_read_and_a_write_agree_about_auto_create_none` is rewritten rather than deleted: it still pins that the two agree, now about the refusal. That one test was the **only** failure across 1228 — nothing else depended on on-demand provisioning under `AutoCreate.None`.

Full suite **1230/0 on both TFMs**, plus 36 AspNetCore and 13 EF Core.

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs