### PR TITLE
JasperFx 2.49.0 and LoadAsync<T>(object) (closes #89), and 0.7.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2012,8 +2012,45 @@ reintroduce fisher#20's bug one level up, where it is harder to see.
 `JasperFx.Events.Documents` (fisher#68 / jasperfx#647), shipped in JasperFx 2.47.0 — the document
 slice a store-agnostic consumer needs alongside the event store, and the first half of what
 `Wolverine.Fisher` and a Fisher-backed CritterWatch are built on. Three session tiers, a session
-factory and a query-execution hook; seven operations, measured off CritterWatch's actual call sites
-rather than designed as a document-store facade.
+factory and a query-execution hook; seven operations at 2.47.0 and **eight from 2.49.0**, measured off
+CritterWatch's actual call sites rather than designed as a document-store facade.
+
+#### `LoadAsync<T>(object)` — the eighth operation
+
+jasperfx#665 added `Task<T?> LoadAsync<T>(object id, …)` to `IDocumentReadOperations`, and fisher#89
+is Fisher's half. **It is not a compile break**: the member ships with a default implementation that
+unboxes a `Guid` or a `string`, forwards to the existing overload, and throws `NotSupportedException`
+for anything else — so the bump is clean on its own and what tells you the member is only half-present
+is the compliance suite, not the compiler.
+
+- **`LoadAsync<T, TId>` does not satisfy it**, different arity, so the contract falls to the default.
+  Fisher carries both. The two-parameter spelling keeps its own reason for existing — both type
+  parameters explicit is what keeps it unambiguous against the four single-parameter overloads.
+- **Declared on `IQuerySession` as public API rather than implemented explicitly**, matching Marten and
+  Polecat, so a consumer moving between the stores meets one spelling. The four canonical overloads are
+  more specific and still win overload resolution, so no existing call site moved.
+- **The trap is the canonical case, not the strong-typed one.** The overload is reached by a caller
+  holding *any* identity in an `object`-typed local, so an implementation that assumed a wrapper passes
+  the two strong-typed facts and silently regresses the boxed-`Guid` one.
+  `the_object_overload_resolves_canonical_identities_too` exists for exactly that, and the default gets
+  it right for free — which is what makes an override the only way to break it.
+- **`CoerceIdentity` is where the three shapes are decided**: exact match, wrapper-from-inner (through
+  `StrongTypedId`, so it agrees with how the identity was discovered in the first place), and integral
+  widening. The last is narrow on purpose — an untyped literal is an `int`, so refusing it against a
+  `long`-keyed document would refuse a difference the caller cannot see, while a general
+  `Convert.ChangeType` would turn `"12"` into an id and hide a real mistake.
+- **The wrapper half is what let fisher#88's gate widen from `IdType` to `StoredIdType`**, closing the
+  `FetchLatest` phantom for strong-typed aggregates too. Verified by narrowing it back: the strong-typed
+  phantom test fails.
+- **`FisherDocumentComplianceFixture` replays `config.ValueTypes` before the mappings.** Fisher
+  discovers wrappers by itself, so it is an assertion rather than a prerequisite — but a fixture that
+  would break under a store needing it is not worth writing.
+
+One thing this surfaced and did **not** change: the typed overloads still throw a raw
+`InvalidCastException` for a mismatched identity — `LoadAsync<Order>("12")` against a `long`-keyed type
+binds to `LoadAsync<T>(string)` and casts storage. Pre-existing, out of fisher#89's scope, and noted in
+`an_identity_of_the_wrong_type_is_refused_by_name` so the next reader does not mistake it for this
+member's behaviour.
 
 **Fisher's own types *are* the contracts — there is no adapter, and that is the result rather than a
 convenience.** The binding is four interface declarations and one partial class:
@@ -2064,7 +2101,7 @@ convenience.** The binding is four interface declarations and one partial class:
 - **No DI registration was needed or added**, matching both siblings. `IDocumentStore` is already
   registered and *is* the factory.
 
-Four compliance suites, 42 tests, enrolled in `fisher_event_store_compliance.cs` and green on the
+Four compliance suites, 45 tests, enrolled in `fisher_event_store_compliance.cs` and green on the
 first run. `FisherDocumentComplianceFixture` is three members wide and **deliberately not generic over
 Fisher's session pair**, unlike the event fixture: everything the document suites do runs through the
 shared contracts, so `Sessions` is typed as the bare `IDocumentSessionFactory` and a suite reaching
@@ -2995,13 +3032,22 @@ coalescing on purpose. Do not present it as a performance feature.
 ### Compliance suites
 
 **Fisher is enrolled, in full.** `JasperFx.Events.ComplianceTests` is referenced unconditionally —
-the old `$(EnableComplianceTests)` gate is gone. **All 32 suites, 272 tests, are live**, as of 2.48.0.
+the old `$(EnableComplianceTests)` gate is gone. **All 32 suites, 275 tests, are live**, as of 2.49.0.
 The event sourcing half is 28 suites and 230 tests and has been the whole library since 2.45.0
 emptied the upstream event sourcing backlog; **2.46.0 added no suite and no test** (fisher#64), and
 **2.48.0 added neither, and changed no existing suite file** — the counts were re-verified against a
 real run on each rather than carried over, since "still 32" is exactly the claim a bump can quietly
-falsify. **2.47.0 added a second half rather than another event suite** — four *document* suites, 42
-tests, over the store-agnostic contract described below.
+falsify. **2.47.0 added a second half rather than another event suite** — four *document* suites,
+over the store-agnostic contract described below.
+
+**2.49.0 is the first bump to widen an existing suite rather than add one** (fisher#89 / jasperfx#665).
+No new suite file; `DocumentLoadAndStoreCompliance` gained three tests, taking the document half from
+42 to 45, and `DocumentComplianceConfig` gained `ValueTypes` / `RegisterValueType<T>()` because the
+strong-typed facts need the identity type registered and the document contract carries no identity
+configuration. **That shape is worth noticing**: a bump whose suite *list* is unchanged can still
+demand production work, so diffing the file list is not enough — diff the contents. The three tests
+are two strong-typed facts and one guarding the canonical case, which is the one an override gets
+wrong; see "The store-agnostic document contract".
 The four that arrived in 2.40.0/2.41.0 — `StringStreamIdentityCompliance`,
 `SnapshotLifecycleCompliance`, `MultiStreamProjectionCompliance`, `FlatTableProjectionCompliance` —
 went in on the same bump.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.7.1</Version>
+        <Version>0.7.2</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.48.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.48.0" />
+        <PackageVersion Include="JasperFx" Version="2.49.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.49.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.48.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.48.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.49.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.49.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,9 +12,10 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1165 tests green on net9.0 and net10.0**, with no known intermittent failures — 1132 in
-`Fisher.Tests`, 20 in `Fisher.AspNetCore.Tests` and 13 in `Fisher.EntityFrameworkCore.Tests`. 230 of
-them are shared cross-store compliance tests — which as of 2.45.0 is every event sourcing suite the shared library has.
+**1297 tests green on net9.0 and net10.0**, with no known intermittent failures — 1248 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 13 in `Fisher.EntityFrameworkCore.Tests`. 275 of
+them are shared cross-store compliance tests — 230 event sourcing, which as of 2.45.0 is every event
+suite the shared library has, and 45 document.
 
 ## Closed since the comparison
 
@@ -448,12 +449,17 @@ Three of the six turned up a real defect or a wrong premise, which is the useful
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.48.0 ships **32 suites, 272 tests** — it added no suite and
-changed no existing suite file. Fisher passes **all 272, all 32 suites**. Every suite compiles; every one is also subclassed and running.
+`JasperFx.Events.ComplianceTests` 2.49.0 ships **32 suites, 275 tests**. Fisher passes **all 275, all
+32 suites**. Every suite compiles; every one is also subclassed and running.
+
+**2.49.0 added no suite file and still required production work**, which is the first bump of that
+shape: `DocumentLoadAndStoreCompliance` gained three tests for `LoadAsync<T>(object)` (jasperfx#665 /
+fisher#89) and `DocumentComplianceConfig` gained `ValueTypes`. Diffing the suite *list* would have
+reported a clean bump — diff the contents.
 
 The library is now two halves. The **event sourcing** half is 28 suites and 230 tests, and its
 upstream backlog has been empty since 2.45.0 — that is the whole of it rather than a snapshot. The
-**document** half arrived in 2.47.0 (jasperfx#647): four suites, 42 tests, over the store-agnostic
+**document** half arrived in 2.47.0 (jasperfx#647): four suites, 45 tests as of 2.49.0, over the store-agnostic
 document contract Fisher implements for fisher#68. That half exists because the document side had no
 shared definition at all — Fisher's document parity with Polecat was established by the one-time
 hand-comparison that filed #22–#50, and enrolling replaces it with something standing.
@@ -490,7 +496,7 @@ and `Query<T>` were already `notnull`. See "The store-agnostic document contract
 **Green on all thirty-two is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 32 suites, 272 tests
+### Green — 32 suites, 275 tests
 
 Event sourcing — 28 suites, 230 tests:
 
@@ -525,13 +531,13 @@ Event sourcing — 28 suites, 230 tests:
 | `AsyncDaemonCompliance` | 2 |
 | `AutoDiscoveredAggregateCompliance` | 2 |
 
-Documents — 4 suites, 42 tests, through `FisherDocumentComplianceFixture`:
+Documents — 4 suites, 45 tests, through `FisherDocumentComplianceFixture`:
 
 | Suite | Tests |
 |---|---|
 | `DocumentQueryCompliance` | 17 |
 | `DocumentDeleteCompliance` | 10 |
-| `DocumentLoadAndStoreCompliance` | 8 |
+| `DocumentLoadAndStoreCompliance` | 11 |
 | `DocumentSessionCompliance` | 7 |
 
 ### Nothing in the fixture throws any more

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 32 suites and 272 tests** of `JasperFx.Events.ComplianceTests`, the shared
+> Fisher passes **all 32 suites and 275 tests** of `JasperFx.Events.ComplianceTests`, the shared
 > cross-store suite Marten and Polecat also enroll in.
 >
 > The one thing that is *not* there is deliberate and permanent: **no message bus.** The projection

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,17 @@ lives elsewhere: `Wolverine.Fisher` is built in the wolverine repo against
 likely to come from a JasperFx release rather than from this repository** — that has been the pattern
 for seven bumps, and it is what the compliance enrollment is for.
 
+The 2026-08-16 wave is **0.7.2**, and it emptied the tracker again.
+[#88](https://github.com/JasperFx/fisher/issues/88) was a real cross-store divergence found by the
+CritterWatch port — `FetchLatest<T>` synthesised a default-constructed aggregate for a stream its type
+does not handle, where Marten and Polecat return null — and is the polecat#463 class.
+[#81](https://github.com/JasperFx/fisher/issues/81) settled a disagreement the store had with itself:
+the on-demand table path now honours `AutoCreate.None`, as `HiloSequence` already did. **That one is a
+behaviour change** rather than a fix, and is the only thing in 0.7.2 that can break a store which works
+today. [#89](https://github.com/JasperFx/fisher/issues/89) is the JasperFx **2.49.0** bump and
+`LoadAsync<T>(object)`, the document contract's eighth operation — which is also what let #88's fix
+widen to cover strong-typed aggregates.
+
 [#68](https://github.com/JasperFx/fisher/issues/68) closed with its **first half done** — Fisher
 implements the JasperFx document persistence abstractions and is enrolled in the four document
 compliance suites that came with them — and its second half handed to the wolverine repo, which is
@@ -30,9 +41,10 @@ of joins, which cost one new type and made the rest of the join code shorter.
 
 Before that, the 2026-08-10 wave (#60–#66): two of those audits found real defects (#60's dead
 heartbeat branch, #63's composite teardown), #62's ported matrix found two more, and #61 and #66
-confirmed Fisher was already correct and now pin it. On JasperFx **2.48.0** / Weasel **9.24.0**.
-**All 32 compliance suites, 272 tests, green** — 28 event suites and 230 tests, plus 2.47.0's four
-document suites and 42 tests. 1241 tests green on net9.0 and net10.0.
+confirmed Fisher was already correct and now pin it. On JasperFx **2.49.0** / Weasel **9.24.0**.
+**All 32 compliance suites, 275 tests, green** — 28 event suites and 230 tests, plus the four
+document suites, now 45 tests after 2.49.0 added three to `DocumentLoadAndStoreCompliance`. 1248 tests
+green on net9.0 and net10.0.
 
 Most of the issues this file tracks came out of a file-by-file comparison against Polecat on
 2026-08-08, which filed [#22](https://github.com/JasperFx/fisher/issues/22) through

--- a/docs/documents/identity.md
+++ b/docs/documents/identity.md
@@ -109,7 +109,18 @@ constructor or a static builder.
 // Loading by a wrapper needs both type parameters, which is what keeps it
 // unambiguous against the four single-parameter overloads.
 var order = await session.LoadAsync<Order, OrderId>(id);
+
+// Or the identity-agnostic overload, which is the one the store-agnostic
+// document contract declares. It resolves a wrapper, a raw value the wrapper
+// is over, and the four canonical types alike.
+var same = await session.LoadAsync<Order>((object)id);
 ```
+
+::: tip
+The four canonical overloads are more specific than `LoadAsync<T>(object)`, so a `Guid` argument still
+binds to `LoadAsync<T>(Guid)`. Prefer a typed overload where the type is known — they resolve storage
+without a reflection step, and the compiler checks the identity against the document.
+:::
 
 ::: tip
 **Fisher discovers wrappers rather than requiring registration**, which is Polecat's model rather than

--- a/src/Fisher.Tests/Compliance/FisherDocumentComplianceFixture.cs
+++ b/src/Fisher.Tests/Compliance/FisherDocumentComplianceFixture.cs
@@ -62,6 +62,16 @@ public class FisherDocumentComplianceFixture : DocumentStorageComplianceFixture
             options.AutoCreateSchemaObjects = AutoCreate.All;
             options.DatabaseSchemaName = schemaName;
 
+            // Before the mappings: a document keyed by a wrapper has to have that wrapper resolvable
+            // as an identity type by the time its mapping is built, or the mapping has no identity
+            // member to find. Fisher discovers wrappers by itself, so this is an assertion rather than
+            // a prerequisite — but a configuration that would break under a store that needs it is not
+            // worth writing.
+            foreach (var valueType in config.ValueTypes)
+            {
+                options.RegisterValueType(valueType);
+            }
+
             foreach (var documentType in config.DocumentTypes)
             {
                 options.Schema.MappingFor(documentType);

--- a/src/Fisher.Tests/Documents/loading_by_an_untyped_identity.cs
+++ b/src/Fisher.Tests/Documents/loading_by_an_untyped_identity.cs
@@ -1,0 +1,259 @@
+using JasperFx;
+using JasperFx.Events.Documents;
+
+namespace Fisher.Tests.Documents;
+
+public readonly record struct VoucherCode(Guid Value);
+
+public readonly record struct BranchCode(string Value);
+
+public readonly record struct DaybookNumber(long Value);
+
+public class Voucher
+{
+    public VoucherCode Id { get; set; }
+    public string Description { get; set; } = string.Empty;
+}
+
+public class Branch
+{
+    public BranchCode Id { get; set; }
+    public string Town { get; set; } = string.Empty;
+}
+
+public class Daybook
+{
+    public DaybookNumber Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class Receipt
+{
+    public Guid Id { get; set; }
+    public string Vendor { get; set; } = string.Empty;
+}
+
+public class Docket
+{
+    public long Id { get; set; }
+    public string Vendor { get; set; } = string.Empty;
+}
+
+/// <summary>
+///     <c>LoadAsync&lt;T&gt;(object)</c> — the document contract's identity-agnostic read (fisher#89 /
+///     jasperfx#665).
+/// </summary>
+/// <remarks>
+///     <para>
+///         Declared on <c>IQuerySession</c> as public Fisher API rather than implemented explicitly, so
+///         Fisher spells it the way Marten and Polecat do and a consumer moving between the stores meets
+///         one API.
+///     </para>
+///     <para>
+///         The half that is easy to get wrong is <em>not</em> the strong-typed one. The overload is
+///         reached by any caller holding an identity in an <c>object</c>-typed local, so an
+///         implementation that assumed a wrapper would pass the strong-typed facts and silently regress
+///         the canonical ones — which is what the shared suite's
+///         <c>the_object_overload_resolves_canonical_identities_too</c> is for, and what
+///         <see cref="a_boxed_canonical_identity_resolves_the_same_way_the_typed_overload_does" />
+///         pins here.
+///     </para>
+/// </remarks>
+public class loading_by_an_untyped_identity : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("untyped-id");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    [Fact]
+    public async Task a_boxed_canonical_identity_resolves_the_same_way_the_typed_overload_does()
+    {
+        var receiptId = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new Receipt { Id = receiptId, Vendor = "Chandlery" });
+            session.Store(new Docket { Id = 4100, Vendor = "Ropeworks" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _store.QuerySession();
+
+        object boxedGuid = receiptId;
+        (await query.LoadAsync<Receipt>(boxedGuid, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Vendor.ShouldBe("Chandlery");
+
+        object boxedLong = 4100L;
+        (await query.LoadAsync<Docket>(boxedLong, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Vendor.ShouldBe("Ropeworks");
+    }
+
+    [Fact]
+    public async Task a_strong_typed_identity_resolves_over_all_three_backings()
+    {
+        var voucher = new VoucherCode(Guid.NewGuid());
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new Voucher { Id = voucher, Description = "Launch week" });
+            session.Store(new Branch { Id = new BranchCode("penzance"), Town = "Penzance" });
+            session.Store(new Daybook { Id = new DaybookNumber(7), Name = "General" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _store.QuerySession();
+
+        (await query.LoadAsync<Voucher>((object)voucher, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Description.ShouldBe("Launch week");
+
+        (await query.LoadAsync<Branch>((object)new BranchCode("penzance"),
+            TestContext.Current.CancellationToken)).ShouldNotBeNull().Town.ShouldBe("Penzance");
+
+        (await query.LoadAsync<Daybook>((object)new DaybookNumber(7),
+            TestContext.Current.CancellationToken)).ShouldNotBeNull().Name.ShouldBe("General");
+    }
+
+    /// <remarks>
+    ///     The wrapping half: a caller holding the raw value a wrapper is over. This is what lets
+    ///     <c>FetchLatest</c> address a strong-typed aggregate's document from a raw stream id
+    ///     (fisher#88), so it is a real path rather than a courtesy.
+    /// </remarks>
+    [Fact]
+    public async Task a_raw_value_is_wrapped_for_a_strong_typed_document()
+    {
+        var raw = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new Voucher { Id = new VoucherCode(raw), Description = "Wrapped" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _store.QuerySession();
+
+        (await query.LoadAsync<Voucher>((object)raw, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Description.ShouldBe("Wrapped");
+    }
+
+    [Fact]
+    public async Task a_missing_identity_is_null_rather_than_a_throw()
+    {
+        await using var query = _store.QuerySession();
+
+        (await query.LoadAsync<Voucher>((object)new VoucherCode(Guid.NewGuid()),
+            TestContext.Current.CancellationToken)).ShouldBeNull();
+
+        (await query.LoadAsync<Receipt>((object)Guid.NewGuid(),
+            TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    /// <remarks>
+    ///     Integral widening only. An untyped literal is an <c>int</c>, so refusing it against a
+    ///     <c>long</c>-keyed document would be a refusal for a difference the caller cannot see.
+    /// </remarks>
+    [Fact]
+    public async Task an_int_addresses_a_long_keyed_document()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new Docket { Id = 12, Vendor = "Widened" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _store.QuerySession();
+
+        object narrowed = 12;
+        (await query.LoadAsync<Docket>(narrowed, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Vendor.ShouldBe("Widened");
+    }
+
+    /// <remarks>
+    ///     <para>
+    ///         Deliberately narrower than <c>Convert.ChangeType</c>, which would turn the string "12"
+    ///         into an id and hide a genuine mistake. The message names both types.
+    ///     </para>
+    ///     <para>
+    ///         <b>The cast to <c>object</c> is load-bearing in the test rather than decorative.</b>
+    ///         A bare <c>LoadAsync&lt;Docket&gt;("12")</c> binds to the <em>string</em> overload, which
+    ///         is more specific than this one — and that path hard-casts the storage and throws
+    ///         <c>InvalidCastException</c> instead. Pre-existing behaviour of the typed overloads,
+    ///         unchanged here, and worth knowing about when reading this test.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task an_identity_of_the_wrong_type_is_refused_by_name()
+    {
+        await using var query = _store.QuerySession();
+
+        object wrongType = "12";
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            async () => await query.LoadAsync<Docket>(wrongType, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(nameof(Docket));
+        ex.Message.ShouldContain("System.String");
+        ex.Message.ShouldContain("System.Int64");
+    }
+
+    /// <remarks>
+    ///     The four canonical overloads are more specific, so adding this one changed no existing call
+    ///     site. A <c>Guid</c> argument still binds to <c>LoadAsync&lt;T&gt;(Guid)</c> — pinned by
+    ///     resolving the overload rather than by asserting on a result, which would be identical either
+    ///     way.
+    /// </remarks>
+    [Fact]
+    public void the_typed_overloads_still_win_overload_resolution()
+    {
+        var method = typeof(IQuerySession)
+            .GetMethods()
+            .Where(x => x.Name == nameof(IQuerySession.LoadAsync) && x.GetGenericArguments().Length == 1)
+            .Select(x => x.GetParameters()[0].ParameterType)
+            .ToList();
+
+        method.ShouldContain(typeof(Guid));
+        method.ShouldContain(typeof(string));
+        method.ShouldContain(typeof(int));
+        method.ShouldContain(typeof(long));
+        method.ShouldContain(typeof(object));
+    }
+
+    /// <remarks>
+    ///     The member is the contract's, so a store-agnostic caller holding only
+    ///     <see cref="IDocumentReadOperations" /> reaches Fisher's override rather than the default
+    ///     implementation that throws for anything but a Guid or a string.
+    /// </remarks>
+    [Fact]
+    public async Task the_contract_reaches_fishers_override()
+    {
+        var voucher = new VoucherCode(Guid.NewGuid());
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new Voucher { Id = voucher, Description = "Through the contract" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _store.QuerySession();
+
+        IDocumentReadOperations contract = query;
+
+        (await contract.LoadAsync<Voucher>(voucher, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Description.ShouldBe("Through the contract");
+    }
+}

--- a/src/Fisher.Tests/Events/fetch_latest_for_unhandled_streams.cs
+++ b/src/Fisher.Tests/Events/fetch_latest_for_unhandled_streams.cs
@@ -57,6 +57,27 @@ public partial class AlertRecord
     }
 }
 
+public readonly record struct TicketId(string Value);
+
+/// <summary>
+///     An aggregate keyed on a strong-typed identity wrapping the stream key.
+/// </summary>
+public partial class TicketRecord
+{
+    public TicketId Id { get; set; }
+    public string Reason { get; set; } = "";
+    public bool IsActive { get; set; } = true;
+
+    public void Evolve(IEvent e)
+    {
+        if (e.Data is AlertRaised raised)
+        {
+            Reason = raised.Reason;
+            IsActive = true;
+        }
+    }
+}
+
 /// <summary>
 ///     A Live aggregate over the same events, to pin that the document read is <c>Inline</c> only.
 /// </summary>
@@ -257,6 +278,47 @@ public class fetch_latest_for_unhandled_streams : IDisposable
 
         live.ShouldNotBeNull();
         live.Reason.ShouldBe("still burning");
+    }
+
+    /// <summary>
+    ///     <b>The strong-typed shape, which fisher#88 alone could not cover.</b> Its gate compared
+    ///     <c>IdType</c>, so an aggregate keyed on a wrapper kept folding and kept synthesising the
+    ///     phantom. fisher#89's <c>LoadAsync&lt;T&gt;(object)</c> is what made comparing
+    ///     <c>StoredIdType</c> safe: the raw stream id is now wrapped on the way to the document
+    ///     rather than hard-cast against storage keyed on the wrapper.
+    /// </summary>
+    [Fact]
+    public async Task fetch_latest_is_null_for_a_strong_typed_aggregate_that_does_not_handle_the_stream()
+    {
+        await using var store = StoreWith(o => o.Projections.Snapshot<TicketRecord>(SnapshotLifecycle.Inline));
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+        await StartServiceStream(store, "StrongTyped");
+
+        await using var session = store.LightweightSession();
+
+        (await session.Events.FetchLatest<TicketRecord>("StrongTyped",
+            TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_strong_typed_aggregate_still_reads_its_own_stream()
+    {
+        await using var store = StoreWith(o => o.Projections.Snapshot<TicketRecord>(SnapshotLifecycle.Inline));
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<TicketRecord>("OwnedTicket", new AlertRaised("wedged"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.LightweightSession();
+
+        var ticket = await query.Events.FetchLatest<TicketRecord>("OwnedTicket",
+            TestContext.Current.CancellationToken);
+
+        ticket.ShouldNotBeNull();
+        ticket.Reason.ShouldBe("wedged");
     }
 
     /// <summary>

--- a/src/Fisher/Events/EventOperations.Writing.cs
+++ b/src/Fisher/Events/EventOperations.Writing.cs
@@ -355,7 +355,7 @@ public partial class EventOperations
     {
         if (CanReadInlineDocument<T>(typeof(Guid)))
         {
-            return await _session.LoadAsync<T>(id, cancellation).ConfigureAwait(false);
+            return await _session.LoadAsync<T>((object)id, cancellation).ConfigureAwait(false);
         }
 
         return await AggregateStreamAsync<T>(id, token: cancellation).ConfigureAwait(false);
@@ -366,7 +366,7 @@ public partial class EventOperations
     {
         if (CanReadInlineDocument<T>(typeof(string)))
         {
-            return await _session.LoadAsync<T>(id, cancellation).ConfigureAwait(false);
+            return await _session.LoadAsync<T>((object)id, cancellation).ConfigureAwait(false);
         }
 
         return await AggregateStreamAsync<T>(id, token: cancellation).ConfigureAwait(false);
@@ -424,25 +424,23 @@ public partial class EventOperations
     ///         at all; those fall back to live aggregation exactly as before.
     ///     </para>
     ///     <para>
-    ///         <b><c>IdType</c> rather than <c>StoredIdType</c>, which is where Polecat's equivalent
-    ///         does not port.</b> Polecat compares the <em>inner</em> type so a strong-typed id matches
-    ///         on the value it wraps, because its load path re-wraps on the way through. Fisher's does
-    ///         not: <c>LoadAsync&lt;T&gt;(Guid)</c> resolves storage by hard-casting to
-    ///         <c>IDocumentStorage&lt;T, Guid&gt;</c>, and a strong-typed aggregate's storage is keyed
-    ///         on the wrapper — so unwrapping here passes the gate and then throws
-    ///         <c>InvalidCastException</c> from inside the load. Comparing <c>IdType</c> leaves a
-    ///         strong-typed aggregate folding the stream, exactly as it did before this change, so the
-    ///         phantom survives only for that shape. <c>StrongTypedIdentityCompliance</c> is what
-    ///         caught it, and widening this is what fisher#89's <c>LoadAsync&lt;T&gt;(object)</c> —
-    ///         an entry point that resolves a canonical and a wrapped identity alike — exists to make
-    ///         possible.
+    ///         <b><c>StoredIdType</c>, so a strong-typed aggregate is covered too</b> — it compares the
+    ///         wrapper's <em>inner</em> type against the stream key, and the load then re-wraps.
+    ///         <b>That only became safe with fisher#89.</b> Before it, the raw value went to
+    ///         <c>LoadAsync&lt;T&gt;(Guid)</c>, which resolves storage by hard-casting to
+    ///         <c>IDocumentStorage&lt;T, Guid&gt;</c> while a strong-typed aggregate's storage is keyed
+    ///         on the wrapper — so unwrapping passed the gate and then threw
+    ///         <c>InvalidCastException</c> from inside the load, which is what
+    ///         <c>StrongTypedIdentityCompliance</c> caught. The identity is now handed to
+    ///         <c>LoadAsync&lt;T&gt;(object)</c>, which resolves a canonical and a wrapped identity
+    ///         alike, so the phantom is closed for every aggregate shape rather than all but one.
     ///     </para>
     /// </remarks>
     private bool CanReadInlineDocument<T>(Type keyType) where T : class
         => Graph.Options.Projections.TryFindAggregate(typeof(T), out var projection)
            && projection.Lifecycle == ProjectionLifecycle.Inline
            && Graph.Options.Schema.HasMappingFor(typeof(T))
-           && Graph.Options.Schema.MappingFor(typeof(T)).IdType == keyType;
+           && Graph.Options.Schema.MappingFor(typeof(T)).StoredIdType == keyType;
 
     /// <inheritdoc cref="FetchForWriting{T,TId}(TId,CancellationToken)" />
     /// <inheritdoc cref="FetchForWriting{T,TId}(TId,CancellationToken)" />

--- a/src/Fisher/IDocumentSession.cs
+++ b/src/Fisher/IDocumentSession.cs
@@ -90,6 +90,35 @@ public interface IQuerySession : IAsyncDisposable, IDisposable, IDocumentReadOpe
         where T : notnull where TId : notnull;
 
     /// <summary>
+    ///     Load a document by an identity whose type is not known at the call site, or null when there
+    ///     is none.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>This is <see cref="IDocumentReadOperations" />'s member</b> (fisher#89 /
+    ///         jasperfx#665), and it is declared here rather than implemented explicitly so that Fisher
+    ///         spells it the way Marten and Polecat do — a consumer moving between the stores meets one
+    ///         API. The member ships with a default implementation on the contract that handles a
+    ///         <c>Guid</c> and a <c>string</c> and throws for anything else, so overriding it is what
+    ///         makes a strong-typed identity work for a store-agnostic caller.
+    ///     </para>
+    ///     <para>
+    ///         <b>It resolves a boxed canonical identity as well as a wrapper</b>, because it is reached
+    ///         by any caller holding an identity in an <c>object</c>-typed local rather than only by one
+    ///         holding a wrapper. An implementation that assumed a wrapper would pass the strong-typed
+    ///         facts and silently regress the canonical ones — which is what
+    ///         <c>the_object_overload_resolves_canonical_identities_too</c> exists to catch.
+    ///     </para>
+    ///     <para>
+    ///         Prefer a typed overload where the type is known: they resolve storage without a
+    ///         reflection step, and the compiler checks the identity against the document. This one is
+    ///         the escape hatch, and the four canonical overloads still win overload resolution against
+    ///         it — a <c>Guid</c> argument binds to <c>LoadAsync&lt;T&gt;(Guid)</c>, not to this.
+    ///     </para>
+    /// </remarks>
+    Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull;
+
+    /// <summary>
     ///     Run your own SQL through this session and get typed results back.
     /// </summary>
     /// <remarks>

--- a/src/Fisher/Internal/FisherSession.Documents.cs
+++ b/src/Fisher/Internal/FisherSession.Documents.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Reflection;
 using Fisher.Storage;
 using Fisher.Storage.ClosedShape;
 using JasperFx;
@@ -433,6 +434,83 @@ internal partial class FisherSession
     public Task<T?> LoadAsync<T, TId>(TId id, CancellationToken token = default)
         where T : notnull where TId : notnull
         => LoadByIdAsync<T, TId>(id, token);
+
+    /// <inheritdoc cref="IQuerySession.LoadAsync{T}(object,CancellationToken)" />
+    public Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(id);
+
+        var idType = Options.Schema.MappingFor(typeof(T)).IdType;
+
+        return LoadByUntypedIdAsync<T>(idType, CoerceIdentity<T>(idType, id), token);
+    }
+
+    /// <summary>
+    ///     Bring a loosely-typed identity to the exact type this document's storage is keyed on.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Three shapes, and the first is by far the common one — a caller holding the document's
+    ///         real identity in an <c>object</c>-typed local, which is what the contract's own member is
+    ///         for. The wrapper case is what makes a strong-typed identity reachable from a raw stream
+    ///         id, and it is the one an implementation that assumed a wrapper would get backwards.
+    ///     </para>
+    ///     <para>
+    ///         <b>The numeric case is a real convenience rather than a courtesy.</b> An untyped integer
+    ///         literal is an <c>int</c>, so <c>LoadAsync&lt;Order&gt;((object)1)</c> against a
+    ///         <c>long</c>-keyed document would otherwise be refused for a difference the caller cannot
+    ///         see. It is deliberately narrow — integral widening only, through the identity types
+    ///         Fisher actually supports — rather than a general <c>Convert.ChangeType</c>, which would
+    ///         happily turn the string "12" into an id and hide a genuine mistake.
+    ///     </para>
+    /// </remarks>
+    private object CoerceIdentity<T>(Type idType, object id) where T : notnull
+    {
+        if (idType.IsInstanceOfType(id))
+        {
+            return id;
+        }
+
+        // A raw value for a wrapper-keyed document. StrongTypedId is what knows how to build one, and
+        // going through it is what keeps this agreeing with how the identity was discovered.
+        if (Storage.StrongTypedId.TryResolve(idType, out var valueType)
+            && valueType.SimpleType.IsInstanceOfType(id))
+        {
+            return valueType.Ctor is not null
+                ? valueType.Ctor.Invoke([id])
+                : valueType.Builder!.Invoke(null, [id])!;
+        }
+
+        if (id is int or long && (idType == typeof(int) || idType == typeof(long)))
+        {
+            return Convert.ChangeType(id, idType);
+        }
+
+        throw new InvalidOperationException(
+            $"Cannot load a {typeof(T).FullName} by an identity of type {id.GetType().FullName}: the "
+            + $"document is keyed on {idType.FullName}.");
+    }
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(Type, Type), MethodInfo>
+        LoadByUntypedId = new();
+
+    /// <summary>
+    ///     Dispatch to <see cref="LoadByIdAsync{T,TId}" /> for an identity type only known at runtime.
+    /// </summary>
+    /// <remarks>
+    ///     The closed method is cached per <c>(document, identity)</c> pair, because the reflection is
+    ///     the only thing this overload costs over a typed one and it is the same pair every time.
+    /// </remarks>
+    private Task<T?> LoadByUntypedIdAsync<T>(Type idType, object id, CancellationToken token)
+        where T : notnull
+    {
+        var method = LoadByUntypedId.GetOrAdd((typeof(T), idType), static key =>
+            typeof(FisherSession)
+                .GetMethod(nameof(LoadByIdAsync), BindingFlags.Instance | BindingFlags.NonPublic)!
+                .MakeGenericMethod(key.Item1, key.Item2));
+
+        return (Task<T?>)method.Invoke(this, [id, token])!;
+    }
 
     private async Task<T?> LoadByIdAsync<T, TId>(TId id, CancellationToken token)
         where T : notnull where TId : notnull


### PR DESCRIPTION
[jasperfx#665](https://github.com/JasperFx/jasperfx/issues/665) adds `Task<T?> LoadAsync<T>(object id, …)` to `IDocumentReadOperations`, which `Fisher.IQuerySession` implements.

**Not a compile break.** The member ships with a default implementation that unboxes a `Guid` or a `string` and throws `NotSupportedException` for anything else — so what tells you it is only half-present is the compliance suite, not the compiler.

## The API decision

Public on `IQuerySession` alongside `LoadAsync<T, TId>` rather than an explicit interface implementation, matching Marten and Polecat so a consumer moving between the stores meets one spelling. The four canonical overloads are more specific and still win overload resolution, so no existing call site moved. `LoadAsync<T, TId>` keeps its own reason for existing — both type parameters explicit is what keeps it unambiguous against the four single-parameter overloads.

## The trap is the canonical case, not the strong-typed one

`LoadAsync<T>(object)` is reached by a caller holding **any** identity in an `object`-typed local, not only one holding a wrapper. So an implementation that assumed a wrapper passes both strong-typed facts and silently regresses the boxed-`Guid` one — which is what the suite's `the_object_overload_resolves_canonical_identities_too` exists for, and what the default gets right for free.

`CoerceIdentity` decides three shapes:

- **Exact match** — the common one.
- **Wrapper-from-inner**, through `StrongTypedId`, so it agrees with how the identity was discovered in the first place.
- **Integral widening**, narrow on purpose. An untyped literal is an `int`, so refusing it against a `long`-keyed document would refuse a difference the caller cannot see — while a general `Convert.ChangeType` would turn `"12"` into an id and hide a real mistake.

## It completes #88

The wrapper half is what let #88's gate widen from `IdType` to `StoredIdType`, closing the `FetchLatest` phantom for strong-typed aggregates too — the follow-up #88's own code comment promised. Verified by narrowing it back: `fetch_latest_is_null_for_a_strong_typed_aggregate_that_does_not_handle_the_stream` fails.

## The bump

**2.49.0 is the first bump to widen an existing suite rather than add one.** No new suite file; `DocumentLoadAndStoreCompliance` gained three tests and `DocumentComplianceConfig` gained `ValueTypes` / `RegisterValueType<T>()`, which `FisherDocumentComplianceFixture` now replays before the mappings. Diffing the suite *list* would have reported a clean bump — diff the contents.

Compliance is **32 suites / 275 tests** (230 event, 45 document), counted off a real run and cross-checked against the package: **0 suites unenrolled**. The HANDOFF tables sum to 275 rather than carrying numbers forward.

## Verification

Verified load-bearing by disabling wrapper coercion — **6** strong-typed compliance tests fail, including the inline-snapshot and fetch-for-writing ones, so the widened #88 gate is genuinely exercised rather than merely present.

Full suite **1248/0 on both TFMs**, plus 36 AspNetCore and 13 EF Core.

## Noted, deliberately not changed

The typed overloads still throw a raw `InvalidCastException` for a mismatched identity — `LoadAsync<Order>("12")` against a `long`-keyed type binds to `LoadAsync<T>(string)` and hard-casts storage. Pre-existing, out of scope here, and recorded in `an_identity_of_the_wrong_type_is_refused_by_name` so it isn't mistaken for this member's behaviour.

## Release

Bumps `Directory.Build.props` to **0.7.2**, which with #90 and #91 is the release.

Closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs