### PR TITLE
JasperFx 2.51.0, and the document compliance fixture honours StreamIdentity (closes #98)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2048,10 +2048,15 @@ branches — `IQuerySession`'s and `IDocumentSessionOperations`' — and neither
 `new EventOperations Events { get; }` to resolve the lookup. That declaration looks redundant and is
 not.
 
-⚠️ **The compliance suite appends by string stream key throughout and `DocumentComplianceConfig`
-carries no stream-identity knob**, so `FisherDocumentComplianceFixture` sets
-`StreamIdentity.AsString` when the config declares event types. Fisher's default — and every sibling's
-— is Guid, which refuses every append in the suite by name.
+⚠️ **The compliance suite appends by string stream key throughout**, and Fisher's default — like every
+sibling's — is Guid, which refuses every append in the suite by name. The suite now *says* so:
+`DocumentComplianceConfig.StreamIdentity` (jasperfx#672 / fisher#98) is nullable, defaults to null
+meaning "leave the store on its own default", and `FisherDocumentComplianceFixture` replays it exactly
+as it replays `ValueTypes`. **What that replaced was an inference made in the fixture** — string
+identity whenever the config declared *event types* — which was right only because
+`DocumentSessionEventsCompliance` was the one suite populating `EventTypes`, and would have silently
+mis-configured the first Guid-keyed event suite to arrive. A precondition a config cannot carry is one
+each fixture has to guess, and a correct store then fails an undeclared requirement.
 
 #### `LoadAsync<T>(object)` — the eighth operation
 
@@ -3093,12 +3098,21 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**Fisher is enrolled, in full.** `JasperFx.Events.ComplianceTests` is referenced unconditionally —
-the old `$(EnableComplianceTests)` gate is gone. **All 34 suites, 286 tests, are live**, as of 2.50.0,
-which added both of the last two: `BinaryEventSerializationCompliance` (6, the event half's
-twenty-ninth) and `DocumentSessionEventsCompliance` (5, the document half's fifth). Both are **opt-in**
-— their registrar members carry throwing defaults, so enrolling is a deliberate line rather than
-something a bump does to you.
+**34 of the 36 suites are enrolled, 286 tests, as of 2.51.0.** `JasperFx.Events.ComplianceTests` is
+referenced unconditionally — the old `$(EnableComplianceTests)` gate is gone. 2.50.0 added the two most
+recently enrolled: `BinaryEventSerializationCompliance` (6, the event half's twenty-ninth) and
+`DocumentSessionEventsCompliance` (5, the document half's fifth). Both are **opt-in** — their registrar
+members carry throwing defaults, so enrolling is a deliberate line rather than something a bump does to
+you.
+
+**The two that are not enrolled are 2.51.0's, and both are opt-in the same way**:
+`PendingStreamActionsCompliance` (fisher#96, `IDocumentSessionOperations.PendingStreams`) and
+`AggregateWriteCacheCompliance` (fisher#97, the shared second-level `FetchForWriting` snapshot cache).
+Each needs production work, so each has its own issue rather than being enrolled against a throwing
+default. 2.51.0's third change is fisher#98 and is fixture-side: `DocumentComplianceConfig.StreamIdentity`
+(jasperfx#672) replaced an inference `FisherDocumentComplianceFixture` was making — string identity
+whenever the config declared event types, right only for as long as `DocumentSessionEventsCompliance`
+was the sole suite populating `EventTypes`.
 The event sourcing half is 28 suites and 230 tests and has been the whole library since 2.45.0
 emptied the upstream event sourcing backlog; **2.46.0 added no suite and no test** (fisher#64), and
 **2.48.0 added neither, and changed no existing suite file** — the counts were re-verified against a

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.8.0</Version>
+        <Version>0.8.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.50.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.50.0" />
+        <PackageVersion Include="JasperFx" Version="2.51.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.51.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.50.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.50.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.51.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.51.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -14,8 +14,12 @@ scoreboard and the things that are true right now but not obvious from either.
 
 **1314 tests green on net9.0 and net10.0**, with no known intermittent failures — 1265 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 13 in `Fisher.EntityFrameworkCore.Tests`. 286 of
-them are shared cross-store compliance tests — 236 event sourcing, which as of 2.50.0 is every event
-suite the shared library has, and 50 document. On JasperFx **2.50.0** / Weasel **9.24.0**.
+them are shared cross-store compliance tests — 236 event sourcing and 50 document. On JasperFx
+**2.51.0** / Weasel **9.24.0**.
+
+**Two of 2.51.0's suites are not enrolled**, and both are opt-in with throwing contract defaults, so
+nothing here reports them as missing: `PendingStreamActionsCompliance` (fisher#96) and
+`AggregateWriteCacheCompliance` (fisher#97). Those are the only two shared suites Fisher does not run.
 
 ## Closed since the comparison
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,10 +3,12 @@
 Where Fisher is, what comes next, and why in this order. See [CLAUDE.md](CLAUDE.md) for
 architecture and the SQLite-specific decisions.
 
-Status: **no open issues**, for the first time since the tracker was opened.
+Status: **two open issues**, [#96](https://github.com/JasperFx/fisher/issues/96) and
+[#97](https://github.com/JasperFx/fisher/issues/97), both of them the JasperFx 2.51.0 bump asking for
+production work — which is exactly the pattern this file has predicted for eight bumps running.
 
-That is a milestone and not a finish line, so it is worth being precise about what it does and does not
-mean. Every gap this repository knows about is closed; it is emphatically **not** the same as being
+The tracker was empty before them, and that is a milestone rather than a finish line, so it is worth
+being precise about what it does and does not mean. Every gap this repository knows about is closed; it is emphatically **not** the same as being
 feature-complete against Marten, and the deliberate gaps in [HANDOFF.md](HANDOFF.md) are still gaps —
 they are decisions rather than omissions, which is why they are not issues. The live work that remains
 lives elsewhere: `Wolverine.Fisher` is built in the wolverine repo against
@@ -14,6 +16,22 @@ lives elsewhere: `Wolverine.Fisher` is built in the wolverine repo against
 [weasel#426](https://github.com/JasperFx/weasel/issues/426) is upstream. **The next issue is most
 likely to come from a JasperFx release rather than from this repository** — that has been the pattern
 for seven bumps, and it is what the compliance enrollment is for.
+
+**0.8.1** is the JasperFx **2.51.0** bump. [#98](https://github.com/JasperFx/fisher/issues/98) is its
+one requirement and it is entirely fixture-side: `DocumentComplianceConfig` gained a `StreamIdentity`
+knob (jasperfx#672), so a document suite now *states* the stream identity it needs instead of leaving
+each fixture to guess. Fisher's fixture had exactly that guess to remove — it set string identity
+whenever the config declared event types, an inference that happened to be right only because
+`DocumentSessionEventsCompliance` was the only suite populating `EventTypes`, and would have silently
+mis-configured the first Guid-keyed event suite to arrive. Verified load-bearing by disabling it: three
+of that suite's five facts fail with the stream-identity error jasperfx#672 describes.
+
+The bump also ships two **opt-in** suites, neither enrolled here yet because each needs real production
+work and has an issue of its own: `PendingStreamActionsCompliance`
+([#96](https://github.com/JasperFx/fisher/issues/96), the document contract's `PendingStreams`) and
+`AggregateWriteCacheCompliance` ([#97](https://github.com/JasperFx/fisher/issues/97), the shared
+second-level `FetchForWriting` snapshot cache). Both contract members carry throwing defaults, which is
+why the bump itself builds clean — the compiler has nothing to say and only the suites would.
 
 The 2026-08-17 wave is **0.8.0**, and it is the pattern above playing out exactly: the issue came from
 a JasperFx release. [#93](https://github.com/JasperFx/fisher/issues/93) asked for Marten's binary event
@@ -28,7 +46,7 @@ attribute, `Events.BinarySerializer` renamed to `Events.DefaultBinarySerializer`
 not do. 2.50.0's other half is jasperfx#669, an `Events` accessor on the document session contracts;
 Fisher's sessions declared `Events` as their own concrete type, which does **not** satisfy a contract
 member (C# interface implementation is not return-type covariant), so both tiers needed an explicit
-implementation. Two new compliance suites pin both halves. On JasperFx **2.50.0** / Weasel **9.24.0**.
+implementation. Two new compliance suites pin both halves. On JasperFx **2.51.0** / Weasel **9.24.0**.
 **All 34 compliance suites, 286 tests, green** — 29 event suites and 236 tests, plus five document
 suites and 50 tests. 1265 tests green on net9.0 and net10.0.
 

--- a/src/Fisher.Tests/Compliance/FisherDocumentComplianceFixture.cs
+++ b/src/Fisher.Tests/Compliance/FisherDocumentComplianceFixture.cs
@@ -78,22 +78,25 @@ public class FisherDocumentComplianceFixture : DocumentStorageComplianceFixture
                 options.Schema.MappingFor(documentType);
             }
 
+            // jasperfx#672. The suite states the stream identity it needs and the fixture replays it,
+            // exactly as it replays the value types above. This used to be an *inference* made here —
+            // string identity whenever the config declared event types — which was right only because
+            // DocumentSessionEventsCompliance was the only suite populating EventTypes, and would have
+            // silently mis-configured the first Guid-keyed event suite to arrive. Null means "leave the
+            // store on its own default", so every document-only suite is untouched.
+            if (config.StreamIdentity.HasValue)
+            {
+                options.Events.StreamIdentity = config.StreamIdentity.Value;
+            }
+
             // jasperfx#669. Only DocumentSessionEventsCompliance populates this, and only because that
             // suite reaches the event store through a document session. Registering up front is the
             // same discipline the document types above need and for a related reason: the event tables
             // have to be in the migration this fixture applies, and on SQLite a table that is not there
             // when a statement is prepared is a `no such table`, not an empty result.
-            if (config.EventTypes.Count != 0)
+            foreach (var eventType in config.EventTypes)
             {
-                // The suite appends by string stream key throughout and the config carries no knob for
-                // it, so the stream identity is the fixture's to supply. Guid — Fisher's default and
-                // every sibling's — would refuse every append in the suite by name.
-                options.Events.StreamIdentity = StreamIdentity.AsString;
-
-                foreach (var eventType in config.EventTypes)
-                {
-                    options.Events.AddEventType(eventType);
-                }
+                options.Events.AddEventType(eventType);
             }
         });
 


### PR DESCRIPTION
Closes #98. Consumes JasperFx **2.51.0**, and bumps Fisher to **0.8.1**.

## What 2.51.0 brings

Three things, and the bump itself needs none of them — both new contract members carry **throwing** defaults, so the compiler has nothing to say and only a compliance suite would.

| Upstream | Fisher |
|---|---|
| jasperfx#672 — `DocumentComplianceConfig.StreamIdentity` | **this PR** (#98) |
| jasperfx#673 — `IDocumentSessionOperations.PendingStreams` | #96, next |
| jasperfx#674 — `IAggregateWriteCache` into `JasperFx.Events` | #97, after that |

## The fixture change (#98)

`DocumentSessionEventsCompliance` appends by stream **key** throughout and had no way to say so, so `FisherDocumentComplianceFixture` was inferring it: string identity whenever the config declared *event types*. That inference was right only for as long as `DocumentSessionEventsCompliance` was the one suite populating `EventTypes` — it stops being right the moment a Guid-keyed event suite arrives, and the failure would be a mis-configured store rather than anything a reader would trace back to here.

It now replays `config.StreamIdentity` exactly as it replays `config.ValueTypes`. The knob is nullable and defaults to null, meaning "leave the store on its own default", so this is additive: every document-only suite is unaffected.

**Verified load-bearing rather than assumed** — the playbook step that exists because a bump going green is exactly where a seam quietly doing nothing hides. Disabling the replay fails three of that suite's five facts with `InvalidOperationException: This event store is configured for Guid stream identity (StreamIdentity.AsGuid)`, which is the failure jasperfx#672 describes by name.

## Compliance

**34 of 36 suites enrolled, 286 tests, unchanged.** The two unenrolled are 2.51.0's own opt-in pair, tracked by #96 and #97 and called out as such in HANDOFF.md so they read as scheduled rather than missed.

## Tests

`dotnet test fisher.slnx`, both TFMs:

- `Fisher.Tests` **1265 passed, 0 failed** (net9.0 and net10.0)
- `Fisher.AspNetCore.Tests` 36 passed
- `Fisher.EntityFrameworkCore.Tests` 13 passed

Docs touched: ROADMAP.md, HANDOFF.md, CLAUDE.md — the version references, the compliance scoreboard, and the note in "The store-agnostic document contract" that described the removed inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs