### PR TITLE
IDocumentSessionOperations.PendingStreams (closes #96)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2058,6 +2058,39 @@ identity whenever the config declared *event types* — which was right only bec
 mis-configured the first Guid-keyed event suite to arrive. A precondition a config cannot carry is one
 each fixture has to guess, and a correct store then fails an undeclared requirement.
 
+#### `PendingStreams` — the same trap one member over
+
+jasperfx#673 (JasperFx 2.51.0) added `IReadOnlyList<StreamAction> PendingStreams` to
+`IDocumentSessionOperations`: the stream actions a session has queued and not yet committed, for code
+that did **not** do the appending — a listener, or a pre-commit hook deciding something from what is
+about to be written. Code at the call site already has the `StreamAction`, because `StartStream` and
+`Append` return it. fisher#96 is Fisher's half, and it is an explicit implementation on `FisherSession`
+beside the two `Events` ones.
+
+- **Fisher is the store most exposed to the non-covariance trap here**, because it already has a member
+  *named* `PendingStreams` — on `EventOperations`, returning `IReadOnlyCollection<StreamAction>` over
+  `_streams.Values`. That is not the contract's `IReadOnlyList<StreamAction>`, so had that shape ever
+  been put on the session it would have bound to the throwing default with no compile error anywhere.
+  The default **throws rather than answering empty**, deliberately: empty is indistinguishable from a
+  session with nothing pending, so a silent default would discard a consumer's derived work with a
+  clean build and green tests.
+- **The forward copies, and both reasons are worth keeping.** The types differ, so a copy is forced;
+  and the native collection is a *live* view of the tracking dictionary, so a caller holding it across
+  another append watches it change. The contract permits either and tells a caller wanting stability to
+  copy — doing it here is what makes every caller's answer stable rather than the ones who read that
+  remark.
+- **Tenant scopes are included**, where `EventOperations.PendingStreams` is per-scope by construction.
+  `SaveChangesAsync` commits the scopes' streams in the same transaction and `ChangeSet` already
+  reports the two together; a hook told "this is what is about to be written" and handed only the
+  default tenant's would be wrong about the commit it is bracketing. Each action carries its own
+  `TenantId`, and a scope holds no scopes of its own, so reading it from one reports that tenant alone.
+- **Not added to Fisher's own `IDocumentSession`.** `session.Events.PendingStreams` is the native
+  spelling and predates the contract; a second public member of a different type saying the same thing
+  is how the two would drift.
+
+`pending_stream_actions_compliance` (9 tests) is the definition; `pending_stream_actions` covers the
+two decisions above, which a suite written against three stores has no vocabulary for.
+
 #### `LoadAsync<T>(object)` — the eighth operation
 
 jasperfx#665 added `Task<T?> LoadAsync<T>(object id, …)` to `IDocumentReadOperations`, and fisher#89
@@ -3098,18 +3131,16 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**34 of the 36 suites are enrolled, 286 tests, as of 2.51.0.** `JasperFx.Events.ComplianceTests` is
-referenced unconditionally — the old `$(EnableComplianceTests)` gate is gone. 2.50.0 added the two most
-recently enrolled: `BinaryEventSerializationCompliance` (6, the event half's twenty-ninth) and
-`DocumentSessionEventsCompliance` (5, the document half's fifth). Both are **opt-in** — their registrar
-members carry throwing defaults, so enrolling is a deliberate line rather than something a bump does to
-you.
+**35 of the 36 suites are enrolled, 295 tests, as of 2.51.0.** `JasperFx.Events.ComplianceTests` is
+referenced unconditionally — the old `$(EnableComplianceTests)` gate is gone. The most recently
+enrolled are `BinaryEventSerializationCompliance` (6, the event half's twenty-ninth) and
+`DocumentSessionEventsCompliance` (5) from 2.50.0, and `PendingStreamActionsCompliance` (9, fisher#96)
+from 2.51.0. All three are **opt-in** — their contract members carry throwing defaults, so enrolling is
+a deliberate line rather than something a bump does to you.
 
-**The two that are not enrolled are 2.51.0's, and both are opt-in the same way**:
-`PendingStreamActionsCompliance` (fisher#96, `IDocumentSessionOperations.PendingStreams`) and
-`AggregateWriteCacheCompliance` (fisher#97, the shared second-level `FetchForWriting` snapshot cache).
-Each needs production work, so each has its own issue rather than being enrolled against a throwing
-default. 2.51.0's third change is fisher#98 and is fixture-side: `DocumentComplianceConfig.StreamIdentity`
+**The one that is not enrolled is `AggregateWriteCacheCompliance`** (fisher#97, the shared second-level
+`FetchForWriting` snapshot cache), opt-in the same way and with production work of its own to do.
+2.51.0's third change is fisher#98 and is fixture-side: `DocumentComplianceConfig.StreamIdentity`
 (jasperfx#672) replaced an inference `FisherDocumentComplianceFixture` was making — string identity
 whenever the config declared event types, right only for as long as `DocumentSessionEventsCompliance`
 was the sole suite populating `EventTypes`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.8.1</Version>
+        <Version>0.8.2</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,14 +12,14 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1314 tests green on net9.0 and net10.0**, with no known intermittent failures — 1265 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 13 in `Fisher.EntityFrameworkCore.Tests`. 286 of
-them are shared cross-store compliance tests — 236 event sourcing and 50 document. On JasperFx
+**1327 tests green on net9.0 and net10.0**, with no known intermittent failures — 1278 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 13 in `Fisher.EntityFrameworkCore.Tests`. 295 of
+them are shared cross-store compliance tests — 236 event sourcing and 59 document. On JasperFx
 **2.51.0** / Weasel **9.24.0**.
 
-**Two of 2.51.0's suites are not enrolled**, and both are opt-in with throwing contract defaults, so
-nothing here reports them as missing: `PendingStreamActionsCompliance` (fisher#96) and
-`AggregateWriteCacheCompliance` (fisher#97). Those are the only two shared suites Fisher does not run.
+**One of 2.51.0's suites is not enrolled**: `AggregateWriteCacheCompliance` (fisher#97). It is opt-in
+with a throwing contract default, so nothing here reports it as missing — it is the only shared suite
+Fisher does not run.
 
 ## Closed since the comparison
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,9 +3,9 @@
 Where Fisher is, what comes next, and why in this order. See [CLAUDE.md](CLAUDE.md) for
 architecture and the SQLite-specific decisions.
 
-Status: **two open issues**, [#96](https://github.com/JasperFx/fisher/issues/96) and
-[#97](https://github.com/JasperFx/fisher/issues/97), both of them the JasperFx 2.51.0 bump asking for
-production work — which is exactly the pattern this file has predicted for eight bumps running.
+Status: **one open issue**, [#97](https://github.com/JasperFx/fisher/issues/97) — the JasperFx 2.51.0
+bump asking for production work, which is exactly the pattern this file has predicted for eight bumps
+running.
 
 The tracker was empty before them, and that is a milestone rather than a finish line, so it is worth
 being precise about what it does and does not mean. Every gap this repository knows about is closed; it is emphatically **not** the same as being
@@ -26,12 +26,25 @@ whenever the config declared event types, an inference that happened to be right
 mis-configured the first Guid-keyed event suite to arrive. Verified load-bearing by disabling it: three
 of that suite's five facts fail with the stream-identity error jasperfx#672 describes.
 
-The bump also ships two **opt-in** suites, neither enrolled here yet because each needs real production
-work and has an issue of its own: `PendingStreamActionsCompliance`
-([#96](https://github.com/JasperFx/fisher/issues/96), the document contract's `PendingStreams`) and
+The bump also ships two **opt-in** suites, and both contract members behind them carry throwing
+defaults — which is why the bump itself builds clean, and why a store adopting neither would look
+finished to the compiler.
+
+**0.8.2** is the first of the two. [#96](https://github.com/JasperFx/fisher/issues/96) /
+jasperfx#673 puts `PendingStreams` on `IDocumentSessionOperations`, so a consumer holding a session as
+the shared contract can read the `StreamAction`s it has queued and not yet committed — a listener or a
+pre-commit hook deciding something from the events the session is about to write, without naming a
+store. Fisher had the collection and neither the spelling nor the type: `Events.PendingStreams` is
+`IReadOnlyCollection<StreamAction>` over a dictionary's values against the contract's
+`IReadOnlyList<StreamAction>`, and there is no `PendingChanges` facade as there is on both siblings. So
+it is an explicit forward that copies — and the copy is wanted, since the native collection is a *live*
+view. **Tenant scopes are included**, because the scopes' streams commit in the same transaction and
+`IChangeSet` already reports the two together; the question is about the unit of work rather than about
+one tenant. `PendingStreamActionsCompliance` (9 tests) enrolled, and verified load-bearing by removing
+the forward: every one of the nine fails on the contract's throwing default.
+
 `AggregateWriteCacheCompliance` ([#97](https://github.com/JasperFx/fisher/issues/97), the shared
-second-level `FetchForWriting` snapshot cache). Both contract members carry throwing defaults, which is
-why the bump itself builds clean — the compiler has nothing to say and only the suites would.
+second-level `FetchForWriting` snapshot cache) is the other, and is next.
 
 The 2026-08-17 wave is **0.8.0**, and it is the pattern above playing out exactly: the issue came from
 a JasperFx release. [#93](https://github.com/JasperFx/fisher/issues/93) asked for Marten's binary event
@@ -47,8 +60,8 @@ not do. 2.50.0's other half is jasperfx#669, an `Events` accessor on the documen
 Fisher's sessions declared `Events` as their own concrete type, which does **not** satisfy a contract
 member (C# interface implementation is not return-type covariant), so both tiers needed an explicit
 implementation. Two new compliance suites pin both halves. On JasperFx **2.51.0** / Weasel **9.24.0**.
-**All 34 compliance suites, 286 tests, green** — 29 event suites and 236 tests, plus five document
-suites and 50 tests. 1265 tests green on net9.0 and net10.0.
+**35 of the 36 compliance suites, 295 tests, green** — 29 event suites and 236 tests, plus six document
+suites and 59 tests. 1278 tests green on net9.0 and net10.0.
 
 The 2026-08-16 wave is **0.7.2**, and it emptied the tracker again.
 [#88](https://github.com/JasperFx/fisher/issues/88) was a real cross-store divergence found by the
@@ -138,8 +151,9 @@ against Polecat that filed #22–#50 with something standing.
 | Document suite | Tests |
 |---|---|
 | `DocumentQueryCompliance` | 17 |
+| `DocumentLoadAndStoreCompliance` | 11 |
 | `DocumentDeleteCompliance` | 10 |
-| `DocumentLoadAndStoreCompliance` | 8 |
+| `PendingStreamActionsCompliance` | 9 |
 | `DocumentSessionCompliance` | 7 |
 | `DocumentSessionEventsCompliance` | 5 |
 

--- a/docs/documents/listeners.md
+++ b/docs/documents/listeners.md
@@ -82,6 +82,42 @@ that had already committed.
   `AfterCommitAsync` on the daemon's threads for every batch of every shard. JasperFx's
   `IDaemonChangeListener` is the hook for that side, and Fisher supports it.
 
+## Reading what is about to be appended
+
+`IChangeSet` describes a commit that has happened. Before one has, the streams a session has enlisted
+are readable from the session itself — which is what a `BeforeSaveChangesAsync` hook deciding
+something from the events it is bracketing needs:
+
+```cs
+foreach (var action in session.Events.PendingStreams)
+{
+    // action.Id / action.Key, action.ActionType, action.Events, action.TenantId
+}
+```
+
+The same collection is on the shared `JasperFx.Events.Documents.IDocumentSessionOperations`, so a
+listener written against the store-agnostic contract rather than against Fisher reads it without
+naming Fisher:
+
+```cs
+IReadOnlyList<StreamAction> pending = ((IDocumentSessionOperations)session).PendingStreams;
+```
+
+The two answers are the same actions, with two differences worth knowing:
+
+- **The contract's is a snapshot; `Events.PendingStreams` is a live view** of the session's tracking
+  dictionary. A hook that appends while holding the latter sees it change underneath it.
+- **The contract's includes every [tenant scope](/documents/multi-tenancy#writing-across-tenants)
+  of the session**, because those commit in this same transaction — the question it answers is about
+  the unit of work rather than about one tenant. Each action carries its own `TenantId`. Read from a
+  scope, it reports that tenant alone.
+
+::: tip
+A stream is pending only until the commit clears it, and a session is reusable afterwards — so a
+collection that still held committed actions would double-count them on the next read. Fisher's is
+empty after `SaveChangesAsync`.
+:::
+
 ## IChangeSet
 
 ```cs

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -152,3 +152,19 @@ public class document_query_compliance
 
 public class document_session_events_compliance
     : DocumentSessionEventsCompliance<FisherDocumentComplianceFixture>;
+
+/*
+ * jasperfx#673 — the StreamActions a session has queued and not yet committed, read by code that did
+ * not do the appending. Same trap one member over, and Fisher is the store most exposed to it: it
+ * already has a member *named* PendingStreams, on EventOperations, returning
+ * IReadOnlyCollection<StreamAction> rather than the contract's IReadOnlyList<StreamAction>. Had that
+ * shape ever landed on the session type it would bind to the throwing default with a clean build.
+ *
+ * The suite's first fact is the load-bearing one: an empty collection on a session with nothing
+ * enlisted, which a store still on the default cannot produce. That is why the default throws rather
+ * than answering empty — empty is indistinguishable from a session with nothing pending, so a silent
+ * default would let a consumer's derived work be discarded with green tests.
+ */
+
+public class pending_stream_actions_compliance
+    : PendingStreamActionsCompliance<FisherDocumentComplianceFixture>;

--- a/src/Fisher.Tests/Documents/pending_stream_actions.cs
+++ b/src/Fisher.Tests/Documents/pending_stream_actions.cs
@@ -1,0 +1,149 @@
+using Fisher.Tests.Events;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Documents;
+using JasperFx.MultiTenancy;
+
+namespace Fisher.Tests.Documents;
+
+/// <summary>
+///     fisher#96 / jasperfx#673 — <see cref="IDocumentSessionOperations.PendingStreams" />, the stream
+///     actions a session has queued and not yet committed.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>PendingStreamActionsCompliance</c> is the definition and covers the shape of the answer:
+///         empty when nothing is enlisted, one action per stream, events in order, cleared by a commit,
+///         and <c>Start</c> told apart from <c>Append</c>. What it cannot see is the two decisions
+///         Fisher's forward makes, which is what this file is for — a suite written against three
+///         stores has no vocabulary for either.
+///     </para>
+///     <para>
+///         Both are about the difference between <em>this session's</em> events and <em>this unit of
+///         work's</em>. Fisher answers the second question, because that is the one the accessor exists
+///         to ask: a pre-commit hook told what is about to be written and then handed only part of it
+///         is wrong about the commit it is bracketing.
+///     </para>
+/// </remarks>
+public class pending_stream_actions : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("pending-streams");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <remarks>
+    ///     <para>
+    ///         The scopes' streams commit in the parent's transaction — that is the whole of fisher#33 —
+    ///         so a caller asking the parent what it is about to write has to be told about them.
+    ///         <c>ChangeSet</c> already reports the two together for the same reason, and this is the
+    ///         same question asked one interface over.
+    ///     </para>
+    ///     <para>
+    ///         Deliberately the same stream id in both tenants, which under conjoined tenancy is two
+    ///         streams: a forward that merged them, or that reported the parent's alone, is visibly
+    ///         wrong here rather than plausibly right.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_tenant_scopes_streams_are_pending_on_the_session_that_will_commit_them()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = _store.LightweightSession("north");
+        session.Events.StartStream(streamId, new QuestStarted("North"));
+        session.ForTenant("south").Events.StartStream(streamId, new QuestStarted("South"));
+
+        var pending = ((IDocumentSessionOperations)session).PendingStreams;
+
+        pending.Count.ShouldBe(2);
+        pending.Select(x => x.TenantId).OrderBy(x => x).ShouldBe(["north", "south"]);
+
+        // Every one of them is written by this call, which is the claim the collection is making.
+        await session.SaveChangesAsync(Token);
+
+        ((IDocumentSessionOperations)session).PendingStreams.ShouldBeEmpty();
+    }
+
+    /// <remarks>
+    ///     A scope holds no scopes of its own — they are flattened onto the session that commits — so
+    ///     reading the collection from one reports that tenant alone. The pair with the fact above:
+    ///     between them they say the streams are reported once, at the level that commits them.
+    /// </remarks>
+    [Fact]
+    public void a_tenant_scope_reports_only_its_own()
+    {
+        using var session = _store.LightweightSession("north");
+        session.Events.StartStream(Guid.NewGuid(), new QuestStarted("North"));
+
+        var scope = session.ForTenant("south");
+        scope.Events.StartStream(Guid.NewGuid(), new QuestStarted("South"));
+
+        var pending = ((IDocumentSessionOperations)scope).PendingStreams;
+
+        pending.ShouldHaveSingleItem().TenantId.ShouldBe("south");
+    }
+
+    /// <remarks>
+    ///     <b><c>EventOperations.PendingStreams</c> is a live view of the tracking dictionary; this is
+    ///     not.</b> The contract permits either and tells a caller wanting stability to copy, so copying
+    ///     here is what makes every caller's answer stable rather than the ones that read the remark.
+    ///     The shape that matters is a hook holding the collection while something appends — Fisher's
+    ///     own <c>BeforeSaveChangesAsync</c> listeners can do exactly that, since a listener is allowed
+    ///     to extend the unit of work it is bracketing.
+    /// </remarks>
+    [Fact]
+    public void the_collection_is_a_snapshot_rather_than_a_live_view()
+    {
+        using var session = _store.LightweightSession("north");
+        session.Events.StartStream(Guid.NewGuid(), new QuestStarted("First"));
+
+        var taken = ((IDocumentSessionOperations)session).PendingStreams;
+
+        session.Events.StartStream(Guid.NewGuid(), new QuestStarted("Second"));
+
+        taken.ShouldHaveSingleItem();
+        ((IDocumentSessionOperations)session).PendingStreams.Count.ShouldBe(2);
+    }
+
+    /// <remarks>
+    ///     The non-covariance trap, pinned rather than described. Fisher has a member <em>named</em>
+    ///     <c>PendingStreams</c> on <c>EventOperations</c> with a different collection type, so the
+    ///     interesting question is not whether the values agree but whether the contract member is
+    ///     implemented at all — an unimplemented one throws from the shared default, with a clean build
+    ///     either way.
+    /// </remarks>
+    [Fact]
+    public void the_contract_member_and_the_native_spelling_agree()
+    {
+        var streamId = Guid.NewGuid();
+
+        using var session = _store.LightweightSession("north");
+        session.Events.StartStream(streamId, new QuestStarted("North"));
+
+        var native = session.Events.PendingStreams.ShouldHaveSingleItem();
+        var contract = ((IDocumentSessionOperations)session).PendingStreams.ShouldHaveSingleItem();
+
+        contract.ShouldBeSameAs(native);
+        contract.Id.ShouldBe(streamId);
+        contract.ActionType.ShouldBe(StreamActionType.Start);
+    }
+}

--- a/src/Fisher/Internal/FisherSession.cs
+++ b/src/Fisher/Internal/FisherSession.cs
@@ -256,6 +256,43 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
     /// <inheritdoc cref="IDocumentReadOperations.Events" />
     IEventStoreOperations IDocumentSessionOperations.Events => Events;
 
+    /// <summary>
+    ///     jasperfx#673 — the <see cref="StreamAction" />s this unit of work has queued and not yet
+    ///     committed, for a consumer that did not do the appending.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Not free the way the sibling stores' forwards are, in two ways.</b> The contract
+    ///         returns <see cref="IReadOnlyList{T}" /> and <see cref="EventOperations.PendingStreams" />
+    ///         is a <see cref="IReadOnlyCollection{T}" /> over a dictionary's values, so this has to
+    ///         copy; and the copy is wanted anyway, because that collection is a <em>live</em> view of
+    ///         the tracking dictionary and a caller holding it across another <c>Append</c> would see it
+    ///         change underneath them. The contract permits either and says a caller needing stability
+    ///         should copy — doing it here means every caller gets the stable answer.
+    ///     </para>
+    ///     <para>
+    ///         <b>Tenant scopes are included, because this is a question about the unit of work rather
+    ///         than about one tenant.</b> <c>SaveChangesAsync</c> commits the scopes' streams in the
+    ///         same transaction as its own, and <see cref="Services.ChangeSet" /> already reports them
+    ///         together for exactly that reason — a pre-commit hook told "these are the events about to
+    ///         be written" and then handed only the default tenant's would be wrong about the commit it
+    ///         is bracketing. Each action carries its own <c>TenantId</c>, so nothing is ambiguous. A
+    ///         scope holds no scopes of its own (they are flattened), so reading this from one reports
+    ///         that tenant alone.
+    ///     </para>
+    ///     <para>
+    ///         ⚠️ <b>Explicit, and the non-covariance trap is why that matters here more than
+    ///         anywhere.</b> Fisher already has a member <em>named</em> <c>PendingStreams</c> — on
+    ///         <see cref="EventOperations" />, returning a different collection type. Had that shape
+    ///         ever been put on the session itself it would not satisfy this member and would bind to
+    ///         the contract's throwing default with no compile error, which is the same trap
+    ///         jasperfx#669's <c>Events</c> accessor sprang. <c>pending_stream_actions_compliance</c>
+    ///         reads it through a contract-typed session, which is the only caller that would notice.
+    ///     </para>
+    /// </remarks>
+    IReadOnlyList<StreamAction> IDocumentSessionOperations.PendingStreams
+        => Events.PendingStreams.Concat(TenantScopes.SelectMany(x => x.Events.PendingStreams)).ToArray();
+
     internal void QueueOperation(Weasel.Storage.IStorageOperation operation)
     {
         lock (_operationsLock)


### PR DESCRIPTION
Closes #96. Bumps Fisher to **0.8.2**.

jasperfx#673 added `PendingStreams` to the shared document session contract — the `StreamAction`s a session has queued and not yet committed, read by code that did **not** do the appending. A listener, or a pre-commit hook deciding something from the events the session is about to write, without naming a store. (Code at the call site already has the action, because `StartStream` and `Append` return it.)

## Why this one is not free, where Polecat's is

Fisher has the collection and neither the spelling nor the type:

| | |
|---|---|
| Marten | `PendingChanges.Streams()` |
| Polecat | `PendingChanges.Streams` |
| Fisher | `Events.PendingStreams`, `IReadOnlyCollection<StreamAction>`, no `PendingChanges` facade |

The contract returns `IReadOnlyList<StreamAction>` and `Dictionary.ValueCollection` is not a list, so the forward copies. **The copy is wanted anyway**: the native collection is a *live* view of the tracking dictionary, so a caller holding it across another append watches it change. The contract permits either shape and tells a caller wanting stability to copy — doing it here means every caller gets the stable answer rather than the ones who read that remark.

Explicit on `FisherSession`, beside the two `Events` implementations from #94, and for the same reason: **Fisher is the store most exposed to the non-covariance trap here**, because it already has a member *named* `PendingStreams` of a different type. Had that shape ever landed on the session it would bind to the throwing default with no compile error anywhere.

## Two decisions the shared suite cannot see

Covered by `pending_stream_actions`, since a suite written against three stores has no vocabulary for either:

- **Tenant scopes are included.** The scopes' streams commit in the parent's transaction — that is all of fisher#33 — and `IChangeSet` already reports the two together. A hook told "this is what is about to be written" and handed only the default tenant's would be wrong about the commit it is bracketing. Each action carries its own `TenantId`; a scope holds no scopes of its own, so reading it from one reports that tenant alone.
- **The answer is a snapshot**, per the point above.

Deliberately **not** added to Fisher's own `IDocumentSession`. `session.Events.PendingStreams` is the native spelling and predates the contract; a second public member of a different type saying the same thing is how the two drift.

## Compliance

`PendingStreamActionsCompliance` enrolled — 9 tests. **35 of 36 suites, 295 tests.** Only `AggregateWriteCacheCompliance` (#97) is left, and it is next.

**Verified load-bearing rather than assumed**: removing the forward fails all nine on `System.NotSupportedException: Fisher.Internal.FisherSession does not implement IDocumentSessionOperations.PendingStreams`. That default throws rather than answering empty precisely so a store which has not implemented it cannot pass quietly — an empty list is indistinguishable from a session with nothing pending.

While checking counts against a real run, `DocumentLoadAndStoreCompliance` in ROADMAP.md turned out to be carrying its pre-2.49.0 number (8, actually 11); fixed.

## Tests

`dotnet test fisher.slnx`, both TFMs:

- `Fisher.Tests` **1278 passed, 0 failed** (net9.0 and net10.0)
- `Fisher.AspNetCore.Tests` 36 passed
- `Fisher.EntityFrameworkCore.Tests` 13 passed

`npm run docs-build` clean. Docs: a new "Reading what is about to be appended" section in `documents/listeners.md`, which is where the consumer this member exists for would look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs