### PR TITLE
The shared aggregate write cache behind FetchForWriting (closes #97)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,9 @@ Working, with tests:
   self-aggregating types
 - Inline projections: `Projections.Snapshot<T>` and `Projections.Add`, applied during
   `SaveChangesAsync` in the same transaction as the events
-- `FetchForWriting` / `WriteToAggregate` / `AppendOptimistic` / `FetchLatest` / `ProjectLatest`
+- `FetchForWriting` / `WriteToAggregate` / `AppendOptimistic` / `FetchLatest` / `ProjectLatest`, with
+  the shared opt-in second-level aggregate cache behind `FetchForWriting`
+  (`Events.CacheAggregatesForWriting<T>()`)
 - `EventOperations` implements the full `IEventStoreOperations` — see below for which members throw
 - Document storage over Guid, string, int and long ids; numeric ids via Hi-Lo sequences (`fi_hilo`)
 - `EventProjection.storeEntity` — an `EventProjection`'s `Create`/`Project` results are stored inline
@@ -2700,6 +2702,78 @@ identity**, where Polecat uses a list. `FetchForWriting` must therefore reuse an
 `StreamAction` rather than construct a fresh one — replacing the dictionary entry would silently drop
 events an earlier `Append` had queued for the same stream in the same session.
 
+#### The aggregate write cache
+
+`Events.CacheAggregatesForWriting<T>()` and `EventOperations.AggregateForWritingAsync` (fisher#97 /
+jasperfx#674) — a node-local, opt-in, second-level cache of aggregate snapshots between
+`FetchForWriting` calls. The contract, the key, the default bounded implementation and the registration
+surface are all JasperFx's; what Fisher supplies is the fetch path, which is the same division as the
+async daemon.
+
+**Grade 1 and only grade 1.** The cached snapshot is a *baseline*: the stream version is read on every
+call whether the take hit or missed, the events after the baseline are folded on, and the optimistic
+guard still runs inside the write transaction. A stale entry costs a larger fold — never a wrong
+aggregate, never a suppressed concurrency failure. The "trusted" variant that also skips the version
+read is retired upstream against a measurement (0.19 ms of a 13.2 ms round); **do not reintroduce it**,
+and if `a_cached_baseline_cannot_suppress_a_concurrency_exception` ever fails, that is what has
+happened.
+
+- **What a hit removes here is bigger than on either sibling, and it is a different thing.** Marten and
+  Polecat load a stored snapshot and fold what follows, so the cache removes a *document read*. Fisher's
+  `FetchForWriting` deliberately folds the whole stream on every call — see `CanReadInlineDocument` for
+  why it does not read the Inline document the way `FetchLatest` does — so a hit removes *the fold of
+  the history*. The measurements behind jasperfx#674 are PostgreSQL round trips and do not transfer;
+  the saving is real here for a different reason.
+- **No enabled/disabled branch anywhere.** `ResolveCache(Type)` hands back `NulloAggregateWriteCache`
+  for an unenrolled type, so the ordinary path is unchanged: every take misses and every store is
+  dropped. `RecordAggregateCacheWriteBack` returns early on the nullo cache, so an unenrolled fetch also
+  allocates nothing.
+- **Nothing is stored at fetch time, and the reason is take-on-read rather than poisoning.** An entry
+  written while the caller still holds the instance can be claimed by a second session, which folds
+  *its* delta onto the very object the first caller is still reading — the aggregate would silently gain
+  state nobody in that session appended. Since the whole subject is that caching is unobservable except
+  in latency, that is disqualifying. The write-back is deferred to the end of the unit of work, as
+  Marten's is.
+- **The version stored is the one read *before* the unit of work appended anything**, which is where
+  Fisher diverges from the issue's advice to take it from the committed `StreamAction`. That advice is
+  for a store whose inline projection mutates the very instance `FetchForWriting` handed out; **Fisher's
+  does not** — it loads the snapshot document and builds its own — so labelling the instance with the
+  committed version would claim events it has not applied, and the next fetch would fold them twice.
+  `aggregate_write_cache.the_inline_projection_leaves_the_fetched_aggregate_alone` pins the premise,
+  because it is a fact about Fisher rather than a choice, and the write-back is wrong the moment it
+  stops holding.
+- **A failed commit therefore needs no compensation.** The baseline describes committed state that
+  existed either way, so there is no poisoned entry — which is also why the flush runs for an enlisted
+  session, where the post-commit hooks do not. It runs outside the resilience pipeline for fisher#12's
+  reason.
+- **A fetch that never commits leaves nothing behind**, having consumed the entry it claimed. The
+  contract expects that: an implementation may evict whenever it likes, and dropping an entry is always
+  sound.
+- **The key's database identifier carries the logical store as well as the file.** Under
+  database-per-tenant `FisherDatabase.Identifier` already separates two files; within one file two
+  logical stores are separated by the table prefix rather than by a schema, so `DatabaseSchemaName` is
+  folded in. `AggregateWriteCacheOptions.Cache` names exactly that collision as the one its key cannot
+  close. The tenant component is always the session's — Fisher has no aggregate registered as global,
+  and under conjoined tenancy two tenants share a stream id space.
+- **A rewritten event below a baseline is the one real hole, and it is not closable here.** A cached
+  baseline is derived state, so masking or overwriting an event body leaves it holding what the old body
+  produced — the same caveat a snapshot, document or flat table already carries, and the caveat masking
+  is documented under. Evicting on rewrite would close it only within the rewriting process: the cache
+  is node-local by construction, so another node's entry is unreachable. Documented as a reason to leave
+  a rewritten aggregate unenrolled rather than half-closed with a guarantee the design cannot make.
+- **Compacting needs nothing**, and that is worth knowing rather than assuming: JasperFx's aggregator
+  calls `Compacted<T>.MaybeFastForward` before folding, so a delta that reaches the snapshot event
+  *replaces* the baseline outright. A baseline below a compaction point heals on the next fetch for
+  free.
+
+`AggregateWriteCacheCompliance` (14 tests) is the definition — its subject is that a hit is
+indistinguishable from a miss, including when the baseline is stale, ahead of the stream, or evicted.
+Every one of those facts is vacuously true of a store that ignored the opt-in, which is why the suite
+brings its own recording cache and asserts a nonzero hit count. Verified by disabling the take: exactly
+the two hit-count facts fail. `aggregate_write_cache` covers what the suite cannot see — the premise
+above, the write-back's timing and version, the tenant and logical-store components of the key, and
+that an unenrolled type never reaches the cache at all.
+
 ### Live aggregation
 
 `EventGraph` implements `IAggregationSourceFactory<IQuerySession>`: given an aggregate type it closes
@@ -3131,15 +3205,14 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**35 of the 36 suites are enrolled, 295 tests, as of 2.51.0.** `JasperFx.Events.ComplianceTests` is
-referenced unconditionally — the old `$(EnableComplianceTests)` gate is gone. The most recently
-enrolled are `BinaryEventSerializationCompliance` (6, the event half's twenty-ninth) and
-`DocumentSessionEventsCompliance` (5) from 2.50.0, and `PendingStreamActionsCompliance` (9, fisher#96)
-from 2.51.0. All three are **opt-in** — their contract members carry throwing defaults, so enrolling is
-a deliberate line rather than something a bump does to you.
+**Fisher is enrolled, in full — all 36 suites, 309 tests, as of 2.51.0.**
+`JasperFx.Events.ComplianceTests` is referenced unconditionally — the old `$(EnableComplianceTests)`
+gate is gone. The most recently enrolled are `BinaryEventSerializationCompliance` (6, the event half's
+twenty-ninth) and `DocumentSessionEventsCompliance` (5) from 2.50.0, and 2.51.0's two:
+`PendingStreamActionsCompliance` (9, fisher#96) and `AggregateWriteCacheCompliance` (14, fisher#97).
+All four are **opt-in** — their contract members carry throwing defaults, so enrolling is a deliberate
+line rather than something a bump does to you.
 
-**The one that is not enrolled is `AggregateWriteCacheCompliance`** (fisher#97, the shared second-level
-`FetchForWriting` snapshot cache), opt-in the same way and with production work of its own to do.
 2.51.0's third change is fisher#98 and is fixture-side: `DocumentComplianceConfig.StreamIdentity`
 (jasperfx#672) replaced an inference `FisherDocumentComplianceFixture` was making — string identity
 whenever the config declared event types, right only for as long as `DocumentSessionEventsCompliance`

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.8.2</Version>
+        <Version>0.9.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,14 +12,10 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1327 tests green on net9.0 and net10.0**, with no known intermittent failures — 1278 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 13 in `Fisher.EntityFrameworkCore.Tests`. 295 of
-them are shared cross-store compliance tests — 236 event sourcing and 59 document. On JasperFx
-**2.51.0** / Weasel **9.24.0**.
-
-**One of 2.51.0's suites is not enrolled**: `AggregateWriteCacheCompliance` (fisher#97). It is opt-in
-with a throwing contract default, so nothing here reports it as missing — it is the only shared suite
-Fisher does not run.
+**1349 tests green on net9.0 and net10.0**, with no known intermittent failures — 1300 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 13 in `Fisher.EntityFrameworkCore.Tests`. 309 of
+them are shared cross-store compliance tests — 250 event sourcing, which as of 2.51.0 is every event
+suite the shared library has, and 59 document. On JasperFx **2.51.0** / Weasel **9.24.0**.
 
 ## Closed since the comparison
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,12 +3,10 @@
 Where Fisher is, what comes next, and why in this order. See [CLAUDE.md](CLAUDE.md) for
 architecture and the SQLite-specific decisions.
 
-Status: **one open issue**, [#97](https://github.com/JasperFx/fisher/issues/97) — the JasperFx 2.51.0
-bump asking for production work, which is exactly the pattern this file has predicted for eight bumps
-running.
+Status: **no open issues** — the JasperFx 2.51.0 wave asked for three and all three are closed.
 
-The tracker was empty before them, and that is a milestone rather than a finish line, so it is worth
-being precise about what it does and does not mean. Every gap this repository knows about is closed; it is emphatically **not** the same as being
+That is a milestone and not a finish line, so it is worth being precise about what it does and does not
+mean. Every gap this repository knows about is closed; it is emphatically **not** the same as being
 feature-complete against Marten, and the deliberate gaps in [HANDOFF.md](HANDOFF.md) are still gaps —
 they are decisions rather than omissions, which is why they are not issues. The live work that remains
 lives elsewhere: `Wolverine.Fisher` is built in the wolverine repo against
@@ -43,8 +41,25 @@ view. **Tenant scopes are included**, because the scopes' streams commit in the 
 one tenant. `PendingStreamActionsCompliance` (9 tests) enrolled, and verified load-bearing by removing
 the forward: every one of the nine fails on the contract's throwing default.
 
-`AggregateWriteCacheCompliance` ([#97](https://github.com/JasperFx/fisher/issues/97), the shared
-second-level `FetchForWriting` snapshot cache) is the other, and is next.
+**0.9.0** is the other, and it is a feature rather than a forward.
+[#97](https://github.com/JasperFx/fisher/issues/97) / jasperfx#674 moved `IAggregateWriteCache` into
+`JasperFx.Events`, so the three stores share one second-level snapshot cache behind `FetchForWriting`
+instead of a consumer targeting all three writing one per flavour. Opt-in per aggregate type through
+`Events.CacheAggregatesForWriting<T>()`, off by default, and **grade 1 only**: the cached snapshot is a
+*baseline*, the stream version and every event after it are still read on every call, and the
+optimistic guard is untouched — so a stale entry costs a larger fold, never a wrong aggregate.
+
+**What a hit removes is bigger here than the issue's PostgreSQL measurements suggest, and it is a
+different thing.** On the siblings the cache removes a snapshot *load*; Fisher's `FetchForWriting` folds
+the stream on every call by design, so a hit removes *the fold of the history*. Two decisions are
+Fisher's rather than the shared design's: nothing is written back at fetch time, because an entry
+written while the caller still holds the instance defeats take-on-read and lets a second session fold
+its delta onto the object the first is reading; and the version stored is the one read *before* the
+unit of work, because Fisher's inline projection — unlike Marten's — leaves the fetched instance alone,
+so the committed version would claim events it has not applied.
+`aggregate_write_cache.the_inline_projection_leaves_the_fetched_aggregate_alone` pins that premise.
+`AggregateWriteCacheCompliance` (14 tests) enrolled, and verified load-bearing by disabling the take:
+exactly the two hit-count facts fail.
 
 The 2026-08-17 wave is **0.8.0**, and it is the pattern above playing out exactly: the issue came from
 a JasperFx release. [#93](https://github.com/JasperFx/fisher/issues/93) asked for Marten's binary event
@@ -60,8 +75,8 @@ not do. 2.50.0's other half is jasperfx#669, an `Events` accessor on the documen
 Fisher's sessions declared `Events` as their own concrete type, which does **not** satisfy a contract
 member (C# interface implementation is not return-type covariant), so both tiers needed an explicit
 implementation. Two new compliance suites pin both halves. On JasperFx **2.51.0** / Weasel **9.24.0**.
-**35 of the 36 compliance suites, 295 tests, green** — 29 event suites and 236 tests, plus six document
-suites and 59 tests. 1278 tests green on net9.0 and net10.0.
+**All 36 compliance suites, 309 tests, green** — 30 event suites and 250 tests, plus six document
+suites and 59 tests. 1300 tests green on net9.0 and net10.0.
 
 The 2026-08-16 wave is **0.7.2**, and it emptied the tracker again.
 [#88](https://github.com/JasperFx/fisher/issues/88) was a real cross-store divergence found by the
@@ -141,6 +156,7 @@ than a lookalike. Every event suite it ships is green — twenty-eight from 2.45
 | `AsyncDaemonCompliance` | 2 |
 | `AutoDiscoveredAggregateCompliance` | 2 |
 | `BinaryEventSerializationCompliance` | 6 |
+| `AggregateWriteCacheCompliance` | 14 |
 
 **2.47.0 opened a second front rather than adding a twenty-ninth event suite.** `JasperFx.Events.Documents`
 (jasperfx#647) is the store-agnostic *document* contract behind the Wolverine aggregate-handler

--- a/docs/events/appending.md
+++ b/docs/events/appending.md
@@ -88,14 +88,54 @@ await session.Events.WriteToAggregate<Order>(orderId, stream =>
 });
 ```
 
-`FetchForWriting` returns the aggregate from a snapshot if one is stored, and by live aggregation
-otherwise.
+**`FetchForWriting` folds the stream on every call**, whatever the aggregate's projection lifecycle.
+That is deliberate and differs from [`FetchLatest`](/events/snapshots), which reads an `Inline`
+aggregate's projected document: the two ask different questions. `FetchLatest` reports current state,
+while this is the read half of a read-modify-write whose guard is the stream's version — so folding
+the stream is what the version it hands back has to agree with.
 
 ::: warning
 Fisher tracks pending streams in a **dictionary keyed by identity**, where Polecat uses a list. So
 `FetchForWriting` reuses an already-tracked `StreamAction` rather than constructing a fresh one —
 replacing the dictionary entry would silently drop events an earlier `Append` had queued for the same
 stream in the same session.
+:::
+
+### Caching the aggregate between fetches
+
+A hot stream re-folds its whole history on every command. `CacheAggregatesForWriting<T>()` keeps
+recently fetched snapshots in a node-local cache, so a later fetch folds only the events after the
+cached one:
+
+```cs
+opts.Events.CacheAggregatesForWriting<Order>();          // off for every type by default
+opts.Events.CacheAggregatesForWriting<Order>(sizeLimit: 5000);
+```
+
+**The cached snapshot is only ever a baseline.** The stream's version and every event after the cached
+one are still read on every call, and the optimistic concurrency assertion on append is untouched — so
+a stale entry costs a larger fold, never a wrong aggregate and never a suppressed concurrency failure.
+Turning it on is unobservable except in latency.
+
+::: tip
+**This is worth more on Fisher than on Marten or Polecat.** There the cache removes a snapshot *load*;
+here it removes the fold itself, because `FetchForWriting` folds by design. It is opt-in per aggregate
+type because the win is proportional to how often one stream is fetched for writing — real on a hot
+aggregate under load, and only overhead on one written once.
+:::
+
+The contract is `JasperFx.Events.Fetching.IAggregateWriteCache`, shared with Marten and Polecat, so a
+consumer targeting more than one store configures caching once. Supply your own implementation — an
+adapter over a shared `IMemoryCache`, say — through `opts.Events.AggregateWriteCaching.Cache`.
+
+::: warning
+**A cached baseline is derived state, and [event rewriting](/events/rewriting) does not reach derived
+state.** Masking or overwriting an event body below a cached baseline leaves that baseline holding
+what the old body produced, exactly as it leaves an already-written snapshot, document or flat table
+holding it. The cache is node-local by design — masking on one node could not evict another's — so
+this is the same caveat masking already carries, one place further along. Leave an aggregate whose
+history you rewrite unenrolled, or treat a rewrite as requiring a restart of the processes holding
+it.
 :::
 
 ### By natural key or strong-typed id

--- a/docs/events/rewriting.md
+++ b/docs/events/rewriting.md
@@ -112,6 +112,11 @@ expression. That asymmetry is the shared interface's, not Fisher's — the param
 **Masking does not reach anything derived from the events.** A snapshot, document or flat table that
 already folded the unmasked body still holds the protected information until that projection is
 rebuilt. Marten is the same.
+
+That includes a baseline held by the
+[`FetchForWriting` aggregate cache](/events/appending#caching-the-aggregate-between-fetches), which is
+node-local and therefore not reachable from the process doing the masking at all. Leave an aggregate
+whose history you mask unenrolled.
 :::
 
 ## Stream compacting

--- a/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
+++ b/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
@@ -342,6 +342,25 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
         }
 
         /// <summary>
+        ///     fisher#97 — enroll an aggregate type in the second-level <c>FetchForWriting</c> snapshot
+        ///     cache, using the cache instance the suite supplied so it can see what the store did with
+        ///     it.
+        /// </summary>
+        /// <remarks>
+        ///     Both halves are on JasperFx's own <c>EventRegistry</c>, which <c>EventGraph</c> derives
+        ///     from, so this is the two lines the shared registrar's remarks predict. The suite supplies
+        ///     the instance rather than reading the store's own because every behavioural fact about
+        ///     caching is vacuously true of a store that ignored the opt-in — an uncached fetch being
+        ///     correct by construction — so the hit count is the only thing that separates the two.
+        /// </remarks>
+        public void CacheAggregatesForWriting<TDoc>(JasperFx.Events.Fetching.IAggregateWriteCache cache)
+            where TDoc : class
+        {
+            _options.Events.AggregateWriteCaching.Cache = cache;
+            _options.Events.CacheAggregatesForWriting<TDoc>();
+        }
+
+        /// <summary>
         ///     Delegates to <c>StoreOptions.RegisterValueType&lt;T&gt;()</c> (fisher#75).
         /// </summary>
         /// <remarks>

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -115,6 +115,21 @@ public class binary_event_serialization_compliance
     : BinaryEventSerializationCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
 
 /*
+ * fisher#97 / jasperfx#674 — the second-level FetchForWriting snapshot cache, opt-in the same way.
+ *
+ * The suite's subject is that turning caching on is unobservable except in latency: a hit is
+ * indistinguishable from a miss, including when the baseline is stale, ahead of the stream, or
+ * evicted, and a cached baseline can never suppress a concurrency failure. Every one of those facts
+ * is vacuously true of a store that dropped the opt-in on the floor, since an uncached fetch is
+ * correct by construction — which is why the suite brings its own recording cache and asserts a
+ * nonzero hit count. `the_cache_is_actually_consulted_when_a_type_opts_in` is the fact holding that,
+ * and it is the only one Fisher could fail by doing nothing.
+ */
+
+public class aggregate_write_cache_compliance
+    : AggregateWriteCacheCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
+
+/*
  * fisher#68 / jasperfx#647 — the DOCUMENT compliance suites, which arrived in
  * JasperFx.Events.ComplianceTests 2.47.0 and cover the slice JasperFx.Events did not before.
  *

--- a/src/Fisher.Tests/Events/aggregate_write_cache.cs
+++ b/src/Fisher.Tests/Events/aggregate_write_cache.cs
@@ -1,0 +1,386 @@
+using System.Diagnostics.CodeAnalysis;
+using Fisher.Linq;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Fetching;
+using JasperFx.Events.Projections;
+using JasperFx.MultiTenancy;
+
+namespace Fisher.Tests.Events;
+
+public record TabOpened(string Owner);
+
+public record TabCharged(decimal Amount);
+
+/// <summary>
+///     Deliberately mutable and snapshotted <c>Inline</c> — the two properties the write-back's
+///     correctness rests on.
+/// </summary>
+public partial class BarTab
+{
+    public Guid Id { get; set; }
+    public string Owner { get; set; } = "";
+    public decimal Balance { get; set; }
+
+    public static BarTab Create(TabOpened e) => new() { Owner = e.Owner };
+
+    public void Apply(TabCharged e) => Balance += e.Amount;
+}
+
+/// <summary>
+///     Identical, and never enrolled in the cache.
+/// </summary>
+public partial class SideTab
+{
+    public Guid Id { get; set; }
+    public string Owner { get; set; } = "";
+    public decimal Balance { get; set; }
+
+    public static SideTab Create(TabOpened e) => new() { Owner = e.Owner };
+
+    public void Apply(TabCharged e) => Balance += e.Amount;
+}
+
+/// <summary>
+///     fisher#97 / jasperfx#674 — the second-level <c>FetchForWriting</c> snapshot cache.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>AggregateWriteCacheCompliance</c> is the definition, and it covers the semantics: a hit is
+///         indistinguishable from a miss, a baseline ahead of the stream heals, an evicted entry falls
+///         back, and a cached baseline can never suppress a concurrency failure. What it cannot see is
+///         what Fisher's implementation of those semantics <em>rests on</em>, which is what this file
+///         pins.
+///     </para>
+///     <para>
+///         Two things in particular. <b>The entry is written back after the unit of work with the
+///         version read before it</b>, and that is only honest while nothing applies this session's
+///         events to the instance that was handed out — which is a fact about Fisher's inline
+///         projection rather than about the cache. And <b>what a hit removes here is the fold of the
+///         whole stream</b>, not a snapshot load, because Fisher's <c>FetchForWriting</c> folds on every
+///         call; that is what makes the feature worth more here than the measurements behind
+///         jasperfx#674 suggest.
+///     </para>
+/// </remarks>
+public class aggregate_write_cache : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("aggregate-write-cache");
+    private readonly CountingAggregateWriteCache _cache = new();
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+
+            options.Projections.Snapshot<BarTab>(SnapshotLifecycle.Inline);
+            options.Projections.Snapshot<SideTab>(SnapshotLifecycle.Inline);
+
+            options.Events.AggregateWriteCaching.Cache = _cache;
+            options.Events.CacheAggregatesForWriting<BarTab>();
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private async Task<Guid> anOpenTabAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = _store.LightweightSession();
+        session.Events.StartStream<BarTab>(streamId, new TabOpened("Hilda"), new TabCharged(100));
+        await session.SaveChangesAsync(Token);
+
+        return streamId;
+    }
+
+    /// <remarks>
+    ///     <b>The premise the write-back rests on, and it is a fact about Fisher rather than a choice.</b>
+    ///     Marten's inline projection mutates the very instance <c>FetchForWriting</c> handed out, which
+    ///     is why Marten has to defer its write-back and take the version off the committed
+    ///     <c>StreamAction</c>. Fisher's inline projection loads the snapshot document and builds its own
+    ///     instance, so the fetched aggregate is untouched by the commit — which is what makes storing it
+    ///     against the version read <em>before</em> the append the honest label rather than an
+    ///     off-by-one. If this ever stops being true, the write-back is wrong and the next fetch folds
+    ///     this session's events onto an aggregate that already has them.
+    /// </remarks>
+    [Fact]
+    public async Task the_inline_projection_leaves_the_fetched_aggregate_alone()
+    {
+        var streamId = await anOpenTabAsync();
+
+        await using var session = _store.LightweightSession();
+        var stream = await session.Events.FetchForWriting<BarTab>(streamId, Token);
+        stream.Aggregate.ShouldNotBeNull().Balance.ShouldBe(100);
+
+        stream.AppendOne(new TabCharged(10));
+        await session.SaveChangesAsync(Token);
+
+        // The committed snapshot has the charge; the instance the fetch handed back does not.
+        stream.Aggregate.Balance.ShouldBe(100);
+
+        await using var reader = _store.QuerySession();
+        (await reader.LoadAsync<BarTab>(streamId, Token)).ShouldNotBeNull().Balance.ShouldBe(110);
+    }
+
+    /// <remarks>
+    ///     Nothing is stored at fetch time — see <c>RecordAggregateCacheWriteBack</c>. An entry written
+    ///     while the caller still holds the instance can be claimed by another session, which folds its
+    ///     delta onto the object the first caller is still reading.
+    /// </remarks>
+    [Fact]
+    public async Task a_fetch_that_never_commits_leaves_nothing_behind()
+    {
+        var streamId = await anOpenTabAsync();
+
+        await using (var session = _store.LightweightSession())
+        {
+            await session.Events.FetchForWriting<BarTab>(streamId, Token);
+        }
+
+        _cache.Stored.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task the_entry_is_written_back_once_the_unit_of_work_is_written()
+    {
+        var streamId = await anOpenTabAsync();
+
+        await using var session = _store.LightweightSession();
+        var stream = await session.Events.FetchForWriting<BarTab>(streamId, Token);
+        stream.AppendOne(new TabCharged(10));
+        await session.SaveChangesAsync(Token);
+
+        var (aggregate, version) = _cache.Stored.ShouldHaveSingleItem().Value;
+
+        // The version read *before* this unit of work appended anything, and the aggregate as of it.
+        // Behind the stream by exactly what was appended, which is the delta the next fetch folds.
+        version.ShouldBe(2);
+        aggregate.ShouldBeOfType<BarTab>().Balance.ShouldBe(100);
+    }
+
+    /// <remarks>
+    ///     A cached baseline saves the fold of everything below it, which on Fisher is the whole point:
+    ///     <c>FetchForWriting</c> folds the stream on every call, so a hit is the difference between
+    ///     reading one event and reading the stream. Counted through the store's own query surface rather
+    ///     than by timing anything.
+    /// </remarks>
+    [Fact]
+    public async Task a_hit_reads_only_the_events_after_the_baseline()
+    {
+        var streamId = await anOpenTabAsync();
+
+        // Warm: fetch, append, commit. The entry lands at version 2 with a balance of 100.
+        await using (var warming = _store.LightweightSession())
+        {
+            var warm = await warming.Events.FetchForWriting<BarTab>(streamId, Token);
+            warm.AppendOne(new TabCharged(10));
+            await warming.SaveChangesAsync(Token);
+        }
+
+        _cache.Takes = 0;
+
+        await using var session = _store.LightweightSession();
+        var stream = await session.Events.FetchForWriting<BarTab>(streamId, Token);
+
+        _cache.Hits.ShouldBe(1);
+        _cache.Takes.ShouldBe(1);
+
+        // Folded onto the baseline rather than from nothing, and the answer is the same either way —
+        // which is the entire subject of the feature.
+        stream.Aggregate.ShouldNotBeNull().Balance.ShouldBe(110);
+        stream.Aggregate.Owner.ShouldBe("Hilda");
+        stream.StartingVersion.ShouldBe(3);
+    }
+
+    /// <remarks>
+    ///     Caching is per aggregate type. A store that turned it on globally the moment one type opted in
+    ///     would pass every behavioural fact, since an uncached fetch is correct by construction — so
+    ///     this asserts on the cache rather than on the aggregate.
+    /// </remarks>
+    [Fact]
+    public async Task a_type_that_did_not_opt_in_never_reaches_the_cache()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream<SideTab>(streamId, new TabOpened("Hilda"), new TabCharged(100));
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using (var session = _store.LightweightSession())
+        {
+            var stream = await session.Events.FetchForWriting<SideTab>(streamId, Token);
+            stream.AppendOne(new TabCharged(10));
+            await session.SaveChangesAsync(Token);
+        }
+
+        _cache.Takes.ShouldBe(0);
+        _cache.Stored.ShouldBeEmpty();
+    }
+
+    /// <remarks>
+    ///     The delta fold is what a hit turns the read into, so an aggregate whose fold deletes it must
+    ///     leave no entry — otherwise the next fetch resurrects it from a baseline. Nothing is stored
+    ///     because there is nothing to store; <c>TryTake</c> has already removed whatever was there.
+    /// </remarks>
+    [Fact]
+    public async Task a_new_stream_stores_nothing()
+    {
+        await using var session = _store.LightweightSession();
+        var stream = await session.Events.FetchForWriting<BarTab>(Guid.NewGuid(), Token);
+
+        stream.Aggregate.ShouldBeNull();
+        stream.AppendOne(new TabOpened("Hilda"));
+        await session.SaveChangesAsync(Token);
+
+        _cache.Stored.ShouldBeEmpty();
+    }
+
+    /// <remarks>
+    ///     The key has to carry the tenant, or under conjoined tenancy two tenants' streams — which share
+    ///     an id space — would share an entry, and one tenant would read the other's aggregate. Checked
+    ///     on the keys rather than through a read, because a read would have to be wrong twice to fail.
+    /// </remarks>
+    [Fact]
+    public async Task the_key_separates_two_tenants_sharing_a_stream_id()
+    {
+        using var tenanted = TemporaryDatabase.Create("tenanted-aggregate-cache");
+        var cache = new CountingAggregateWriteCache();
+
+        await using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = tenanted.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+            options.Projections.Snapshot<BarTab>(SnapshotLifecycle.Inline);
+            options.Events.AggregateWriteCaching.Cache = cache;
+            options.Events.CacheAggregatesForWriting<BarTab>();
+        });
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        var streamId = Guid.NewGuid();
+
+        foreach (var tenant in new[] { "north", "south" })
+        {
+            await using var opening = store.LightweightSession(tenant);
+            opening.Events.StartStream<BarTab>(streamId, new TabOpened(tenant), new TabCharged(100));
+            await opening.SaveChangesAsync(Token);
+
+            await using var session = store.LightweightSession(tenant);
+            var stream = await session.Events.FetchForWriting<BarTab>(streamId, Token);
+            stream.AppendOne(new TabCharged(10));
+            await session.SaveChangesAsync(Token);
+        }
+
+        cache.Stored.Keys.Select(x => x.TenantId).OrderBy(x => x).ShouldBe(["north", "south"]);
+        cache.Stored.Keys.Select(x => x.Id).Distinct().ShouldHaveSingleItem().ShouldBe(streamId);
+    }
+
+    /// <remarks>
+    ///     SQLite has no schemas, so two logical stores in one file are separated by the table prefix —
+    ///     which means the shared key's database identifier has to carry it, or the two collide when they
+    ///     are handed the same cache. <see cref="AggregateWriteCacheOptions.Cache" /> names that
+    ///     collision as the one its key cannot close; Fisher closes it.
+    /// </remarks>
+    [Fact]
+    public async Task two_logical_stores_in_one_file_do_not_share_an_entry()
+    {
+        var cache = new CountingAggregateWriteCache();
+        var streamId = Guid.NewGuid();
+
+        foreach (var schema in new[] { "first", "second" })
+        {
+            await using var store = DocumentStore.For(options =>
+            {
+                options.ConnectionString = _database.ConnectionString;
+                options.AutoCreateSchemaObjects = AutoCreate.All;
+                options.DatabaseSchemaName = schema;
+                options.Projections.Snapshot<BarTab>(SnapshotLifecycle.Inline);
+                options.Events.AggregateWriteCaching.Cache = cache;
+                options.Events.CacheAggregatesForWriting<BarTab>();
+            });
+
+            await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+            await using var opening = store.LightweightSession();
+            opening.Events.StartStream<BarTab>(streamId, new TabOpened(schema), new TabCharged(100));
+            await opening.SaveChangesAsync(Token);
+
+            await using var session = store.LightweightSession();
+            var stream = await session.Events.FetchForWriting<BarTab>(streamId, Token);
+            stream.AppendOne(new TabCharged(10));
+            await session.SaveChangesAsync(Token);
+        }
+
+        cache.Stored.Keys.Select(x => x.DatabaseIdentifier).Distinct().Count().ShouldBe(2);
+    }
+}
+
+/// <summary>
+///     A cache that answers correctly and counts what it was asked, so a test can assert that Fisher
+///     consulted it rather than that an uncached fetch happened to be right.
+/// </summary>
+/// <remarks>
+///     Take-on-read, exactly as the contract requires: an entry is removed as it is claimed. The
+///     compliance suite ships its own recorder of the same shape; this one exists so Fisher's tests can
+///     see the stored version and the keys, which that one does not expose.
+/// </remarks>
+internal class CountingAggregateWriteCache : IAggregateWriteCache
+{
+    private readonly Lock _lock = new();
+
+    public Dictionary<AggregateCacheKey, (object Aggregate, long Version)> Stored { get; } = new();
+
+    public int Takes { get; set; }
+
+    public int Hits { get; private set; }
+
+    public bool TryTake(AggregateCacheKey key, [NotNullWhen(true)] out object? aggregate, out long version)
+    {
+        lock (_lock)
+        {
+            Takes++;
+
+            if (Stored.Remove(key, out var entry))
+            {
+                Hits++;
+                aggregate = entry.Aggregate;
+                version = entry.Version;
+                return true;
+            }
+
+            aggregate = null;
+            version = 0;
+            return false;
+        }
+    }
+
+    public void Store(AggregateCacheKey key, object aggregate, long version)
+    {
+        lock (_lock)
+        {
+            Stored[key] = (aggregate, version);
+        }
+    }
+
+    public void Evict(AggregateCacheKey key)
+    {
+        lock (_lock)
+        {
+            Stored.Remove(key);
+        }
+    }
+}

--- a/src/Fisher/Events/EventOperations.Writing.cs
+++ b/src/Fisher/Events/EventOperations.Writing.cs
@@ -1,6 +1,7 @@
 using Fisher.Exceptions;
 using Fisher.Storage;
 using JasperFx.Events;
+using JasperFx.Events.Fetching;
 using JasperFx.Events.Projections;
 using Microsoft.Data.Sqlite;
 
@@ -13,6 +14,14 @@ namespace Fisher.Events;
 /// </summary>
 public partial class EventOperations
 {
+    /// <summary>
+    ///     Aggregates fetched for writing in this unit of work, waiting to be written back to the
+    ///     <see cref="IAggregateWriteCache" /> once it commits. Null until a type that opted in is
+    ///     fetched, which is the overwhelmingly common case.
+    /// </summary>
+    private List<(IAggregateWriteCache Cache, AggregateCacheKey Key, object Aggregate, long Version)>?
+        _pendingCacheWrites;
+
     // ---- AppendOptimistic ----
 
     /// <summary>
@@ -510,7 +519,7 @@ public partial class EventOperations
         T? aggregate = null;
         if (version > 0)
         {
-            aggregate = await AggregateStreamAsync<T>(streamId, 0, null, null, 0, token).ConfigureAwait(false);
+            aggregate = await AggregateForWritingAsync<T>(streamId, version.Value, token).ConfigureAwait(false);
         }
 
         var action = TrackForWriting(streamId, version);
@@ -518,6 +527,158 @@ public partial class EventOperations
         return streamId is Guid guid
             ? EventStream<T>.ForGuid(this, action, guid, aggregate, token)
             : EventStream<T>.ForString(this, action, (string)streamId, aggregate, token);
+    }
+
+    /// <summary>
+    ///     The aggregate a <c>FetchForWriting</c> hands back, folded onto a cached baseline where one is
+    ///     available (fisher#97 / jasperfx#674).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>The cached snapshot is a baseline and nothing more.</b> The stream's version has
+    ///         already been read by the caller above, and it is read on every call whether the cache hit
+    ///         or missed; the optimistic guard still runs inside the write transaction. So a stale entry
+    ///         costs a larger delta fold — never a wrong aggregate, and never a suppressed concurrency
+    ///         failure. The "trusted" variant that also skips the version read is retired upstream and
+    ///         must not be reintroduced here.
+    ///     </para>
+    ///     <para>
+    ///         <b>What it removes is bigger on Fisher than on the siblings, and for a structural
+    ///         reason.</b> Marten and Polecat load a stored snapshot and fold the events after it, so
+    ///         the cache removes a document read. Fisher's <c>FetchForWriting</c> deliberately folds the
+    ///         whole stream on every call — see the remarks on <c>FetchForWriting</c> for why it does
+    ///         not read the Inline document the way <c>FetchLatest</c> does — so what a hit removes here
+    ///         is the fold of the stream's entire history, leaving only the events after the baseline.
+    ///         The measurements behind jasperfx#674 are PostgreSQL round trips and do not transfer;
+    ///         this is a different saving on a different axis.
+    ///     </para>
+    ///     <para>
+    ///         <b>No enabled/disabled branch.</b> <c>ResolveCache(Type)</c> hands back
+    ///         <c>NulloAggregateWriteCache</c> for a type nobody enrolled, so an unenrolled aggregate
+    ///         takes exactly the path it took before: every take misses and every store is dropped.
+    ///         Resolved per call rather than once, because Fisher has no fetch-plan object to hang it on
+    ///         — it is a hash-set probe under a lock, next to two SQL statements.
+    ///     </para>
+    ///     <para>
+    ///         <b>A baseline ahead of the stream heals on this call.</b> That is what a restore or a
+    ///         rollback leaves behind, and a negative delta cannot be folded — so the entry is dropped
+    ///         (<c>TryTake</c> has already removed it) and the fetch redone from nothing, which then
+    ///         writes the correct baseline back.
+    ///     </para>
+    /// </remarks>
+    private async Task<T?> AggregateForWritingAsync<T>(object streamId, long version, CancellationToken token)
+        where T : class
+    {
+        var cache = Graph.AggregateWriteCaching.ResolveCache(typeof(T));
+        var key = AggregateCacheKeyFor<T>(streamId);
+
+        // Take-on-read is a contract requirement rather than an implementation detail: the fold below
+        // mutates the instance it is handed, so exactly one caller may ever win an entry. A loser
+        // simply misses and takes the uncached path, which is always correct.
+        var aggregate = cache.TryTake(key, out var claimed, out var baseline) && claimed is T typed
+                        && baseline > 0 && baseline <= version
+            ? await AggregateStreamAsync<T>(streamId, 0, null, typed, baseline + 1, token).ConfigureAwait(false)
+            : await AggregateStreamAsync<T>(streamId, 0, null, null, 0, token).ConfigureAwait(false);
+
+        if (aggregate is not null)
+        {
+            RecordAggregateCacheWriteBack(cache, key, aggregate, version);
+        }
+
+        return aggregate;
+    }
+
+    /// <summary>
+    ///     The cache key for one aggregate of one stream.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>The database identifier carries the logical store as well as the file</b>, which is a
+    ///         Fisher-shaped widening of what the shared key means by "database". Under
+    ///         database-per-tenant the identifier already distinguishes two files holding the same
+    ///         stream id; within one file, two logical stores are separated by the table prefix rather
+    ///         than by a schema, so folding <c>DatabaseSchemaName</c> in is what stops them colliding
+    ///         when they are handed the same cache instance. <see cref="AggregateWriteCacheOptions" />
+    ///         names that collision as the one its own key cannot close.
+    ///     </para>
+    ///     <para>
+    ///         <b>The tenant is always the session's, never <c>GlobalTenant</c>.</b> Fisher has no
+    ///         aggregate registered as global, so claiming one would be a wider key than the store can
+    ///         justify: under conjoined tenancy two tenants' streams share an id space and must not
+    ///         share an entry. Where a store is single-tenanted every session resolves the same tenant
+    ///         id anyway, so nothing is lost.
+    ///     </para>
+    /// </remarks>
+    private AggregateCacheKey AggregateCacheKeyFor<T>(object streamId) where T : class
+        => new(typeof(T), $"{_session.FisherDatabase.Identifier}/{_session.Options.DatabaseSchemaName}",
+            TenantId, streamId);
+
+    /// <summary>
+    ///     Hold a fetched aggregate to be written back to the cache once the unit of work has been
+    ///     written.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Nothing is stored at fetch time, and the reason is take-on-read rather than
+    ///         poisoning.</b> An entry written while the caller still holds the instance can be claimed
+    ///         by a second session, which folds <em>its</em> delta onto the very object the first
+    ///         caller is still reading — the aggregate would silently gain state nobody in that session
+    ///         appended. Since the whole subject of this feature is that caching is unobservable except
+    ///         in latency, that is disqualifying. Deferring to the end of the unit of work is also what
+    ///         Marten does.
+    ///     </para>
+    ///     <para>
+    ///         <b>The version stored is the one read <em>before</em> this unit of work appended
+    ///         anything</b>, which is what makes a failed commit a non-event here: the baseline
+    ///         describes committed state that existed either way, so there is no poisoned entry to
+    ///         compensate for and no eviction to arrange. It also means the entry is behind the stream
+    ///         by whatever this session appended, which is exactly the case
+    ///         <c>AggregateForWritingAsync</c> exists to fold — and it is the honest label, since
+    ///         nothing applies this session's events to the instance handed out (see
+    ///         <c>aggregate_write_cache.the_inline_projection_leaves_the_fetched_aggregate_alone</c>,
+    ///         which pins the premise).
+    ///     </para>
+    ///     <para>
+    ///         A fetch that never commits therefore leaves no entry, having consumed the one it claimed.
+    ///         That is the contract's own expectation — an implementation is free to evict whenever it
+    ///         likes, and dropping an entry is always sound.
+    ///     </para>
+    /// </remarks>
+    private void RecordAggregateCacheWriteBack(IAggregateWriteCache cache, AggregateCacheKey key,
+        object aggregate, long version)
+    {
+        // The unenrolled path allocates nothing: ResolveCache hands back the nullo cache for a type
+        // nobody opted in, and storing into it would be a list of work to discard later.
+        if (cache is NulloAggregateWriteCache)
+        {
+            return;
+        }
+
+        (_pendingCacheWrites ??= []).Add((cache, key, aggregate, version));
+    }
+
+    /// <summary>
+    ///     Write every aggregate fetched for writing in this unit of work back to its cache.
+    /// </summary>
+    /// <remarks>
+    ///     Called by <c>FisherSession.SaveChangesAsync</c> once the write has succeeded, and outside
+    ///     the resilience pipeline — a retried <c>SQLITE_BUSY</c> re-executes the whole write delegate,
+    ///     and this is not work that should happen once per attempt. Nothing here can fail in a way the
+    ///     caller should hear about: a cache is free to drop anything it is given.
+    /// </remarks>
+    internal void FlushAggregateCacheWriteBacks()
+    {
+        if (_pendingCacheWrites is null)
+        {
+            return;
+        }
+
+        foreach (var (cache, key, aggregate, version) in _pendingCacheWrites)
+        {
+            cache.Store(key, aggregate, version);
+        }
+
+        _pendingCacheWrites.Clear();
     }
 
     /// <summary>

--- a/src/Fisher/Internal/FisherSession.cs
+++ b/src/Fisher/Internal/FisherSession.cs
@@ -537,6 +537,19 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
         // publishing through it would flush the same messages again.
         _messageBatch = null;
 
+        // fisher#97. The aggregates this unit of work fetched for writing go back to the second-level
+        // cache here, after the write and outside the resilience pipeline — a retried SQLITE_BUSY
+        // re-executes the whole write delegate, and this is not work to repeat per attempt. It runs for
+        // an enlisted session too, unlike the post-commit hooks below: what is stored is the baseline
+        // as of the version read *before* this unit of work appended anything, so it describes state
+        // that is committed whether or not the caller's transaction ever is.
+        Events.FlushAggregateCacheWriteBacks();
+
+        foreach (var scope in TenantScopes)
+        {
+            scope.Events.FlushAggregateCacheWriteBacks();
+        }
+
         ResetChangeTracking(queued);
 
         foreach (var scope in TenantScopes)

--- a/src/Fisher/StoreOptions.cs
+++ b/src/Fisher/StoreOptions.cs
@@ -6,6 +6,7 @@ using JasperFx;
 using JasperFx.MultiTenancy;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Fetching;
 using JasperFx.Events.Tags;
 using Polly;
 using Weasel.Core;
@@ -458,6 +459,46 @@ public class EventStoreOptions : IEventStoreInstrumentation
         EventGraph!.UseBinarySerializer<TEvent>(serializer);
         return this;
     }
+
+    /// <summary>
+    ///     Keep recently fetched snapshots of <typeparamref name="T" /> in a node-local cache, so that a
+    ///     later <c>FetchForWriting&lt;T&gt;</c> folds only the events after the cached one rather than
+    ///     the stream's whole history (fisher#97 / jasperfx#674). <b>Off for every aggregate type by
+    ///     default.</b>
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>The cached snapshot is only ever a baseline.</b> The stream's version and every event
+    ///         after the cached one are still read on every call, and the optimistic concurrency
+    ///         assertion on append is untouched — so a stale entry costs a larger delta fold, never a
+    ///         wrong aggregate and never a suppressed concurrency failure.
+    ///     </para>
+    ///     <para>
+    ///         <b>Worth more here than the same option is on Marten or Polecat.</b> There the cache
+    ///         removes a snapshot <em>load</em>; Fisher's <c>FetchForWriting</c> folds the stream on
+    ///         every call by design, so what a hit removes is the fold itself. That also makes it per
+    ///         aggregate type rather than store-wide: the win is proportional to how often one stream is
+    ///         fetched for writing, so it is real on a hot aggregate and only overhead on one written
+    ///         once.
+    ///     </para>
+    ///     <para>
+    ///         The cache is node-local and deliberately incoherent between processes, which is sound for
+    ///         exactly the reason above. Supply your own implementation — or a size limit for the
+    ///         default bounded one — through <see cref="AggregateWriteCaching" />.
+    ///     </para>
+    /// </remarks>
+    public EventStoreOptions CacheAggregatesForWriting<T>(int sizeLimit = 1000) where T : class
+    {
+        EventGraph!.CacheAggregatesForWriting<T>(sizeLimit);
+        return this;
+    }
+
+    /// <summary>
+    ///     The <c>FetchForWriting</c> snapshot cache's own configuration — which types are enrolled, the
+    ///     default cache's size limit, and the seam for supplying a cache of your own.
+    /// </summary>
+    /// <inheritdoc cref="CacheAggregatesForWriting{T}" />
+    public AggregateWriteCacheOptions AggregateWriteCaching => EventGraph!.AggregateWriteCaching;
 
     /// <summary>
     ///     Run inline projections' side effects when an inline projection is applied during


### PR DESCRIPTION
Closes #97. Bumps Fisher to **0.9.0**, and takes Fisher to **all 36 compliance suites green**.

jasperfx#674 moved `IAggregateWriteCache` into `JasperFx.Events` so the three stores share one second-level snapshot cache instead of a consumer targeting all three writing one per flavour. This is Fisher's fetch path.

```cs
opts.Events.CacheAggregatesForWriting<Order>();               // off for every type by default
opts.Events.AggregateWriteCaching.Cache = myOwnCache;         // or bring your own
```

**Grade 1 and only grade 1.** The cached snapshot is a *baseline*: the stream version and every event after the cached one are read on every call, and the optimistic guard still runs inside the write transaction. A stale entry costs a larger fold — never a wrong aggregate, never a suppressed concurrency failure. The retired "trusted" variant that also skips the version read stays retired.

## What a hit removes here is a different thing

Marten and Polecat load a stored snapshot and fold what follows, so the cache removes a **document read**. Fisher's `FetchForWriting` folds the whole stream on every call by design — see `CanReadInlineDocument` for why it does not read the Inline document the way `FetchLatest` does — so a hit removes **the fold of the history**. The measurements behind jasperfx#674 are PostgreSQL round trips and do not transfer; the saving is real here for a different reason, which is worth stating rather than inheriting the issue's framing.

## Two decisions that are Fisher's, and would be silently wrong the other way

- **Nothing is written back at fetch time.** An entry written while the caller still holds the instance can be claimed by a second session, which folds *its* delta onto the very object the first caller is still reading — which is what take-on-read exists to prevent. Deferred to the end of the unit of work, as Marten's is.
- **The version stored is the one read *before* the unit of work appended anything**, not the committed `StreamAction`'s. The issue's advice is for a store whose inline projection mutates the instance `FetchForWriting` handed out; **Fisher's does not** — it loads the snapshot document and builds its own — so the committed version would label the instance with events it has not applied, and the next fetch would fold them twice. `aggregate_write_cache.the_inline_projection_leaves_the_fetched_aggregate_alone` pins that premise, because it is a fact about Fisher rather than a choice, and the write-back is wrong the moment it stops holding.

A failed commit therefore needs no compensation — the baseline describes state that is committed either way — which is also why the flush runs for an enlisted session, where the post-commit hooks do not. It runs outside the resilience pipeline, fisher#12's rule.

The key's `DatabaseIdentifier` carries the logical store as well as the file: database-per-tenant is already separated by `FisherDatabase.Identifier`, and within one file two logical stores are separated by the table prefix rather than by a schema. `AggregateWriteCacheOptions.Cache` names exactly that as the collision its own key cannot close; on SQLite it is closable, so it is closed.

## Two interactions, checked rather than assumed

- **Compacting needs nothing.** JasperFx's aggregator calls `Compacted<T>.MaybeFastForward` before folding, so a delta reaching the snapshot event replaces the baseline outright — a baseline below a compaction point heals on the next fetch for free.
- **A masked or overwritten body below a baseline is the one real hole, and it is not closable here.** A cached baseline is derived state, exactly like a snapshot, document or flat table, and event rewriting does not reach derived state. Evicting on rewrite would close it only inside the rewriting process — the cache is node-local by construction. Documented in `events/rewriting.md` and `events/appending.md` as a reason to leave a rewritten aggregate unenrolled, rather than half-closed with a guarantee the design cannot make.

## Compliance

`AggregateWriteCacheCompliance` enrolled — 14 tests, green on the first run. **36 of 36 suites, 309 tests.**

**Verified load-bearing twice**, since a suite passing on the first run is exactly where a seam quietly doing nothing hides:

- never taking from the cache → exactly `the_cache_is_actually_consulted_when_a_type_opts_in` and `an_async_snapshotted_aggregate_is_cached_too` fail, which are the two hit-count facts the suite's own notes say are the only ones a store ignoring the opt-in could fail.
- dropping the ahead-of-the-stream guard → `a_cached_baseline_ahead_of_the_stream_heals_itself` fails.

`aggregate_write_cache` covers the eight things the shared suite cannot see: the premise above, the write-back's timing and version, the tenant and logical-store components of the key, that an unenrolled type never reaches the cache at all, and that a new stream stores nothing.

## Tests

`dotnet test fisher.slnx`, both TFMs:

- `Fisher.Tests` **1300 passed, 0 failed** (net9.0 and net10.0)
- `Fisher.AspNetCore.Tests` 36 passed
- `Fisher.EntityFrameworkCore.Tests` 13 passed

`npm run docs-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs