### PR TITLE
Non-stale waits on the shards the store registers (closes #102)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,7 +425,7 @@ all of it:
 | `IEventStore<IDocumentSession, IQuerySession>` | `DocumentStore.Daemon.cs` | shards, sessions, loaders, batches, progression bookkeeping |
 | `FisherProjectionDaemon` | `Events/Daemon/` | a dozen lines closing `JasperFxAsyncDaemon<,,>` over Fisher's session pair |
 
-Five things that are decisions rather than mechanics:
+Six things that are decisions rather than mechanics:
 
 - **The high-water mark simply is `max(seq_id)`.** Marten and Polecat must distinguish the highest
   sequence *issued* from the highest safe to *read*, because a PostgreSQL sequence or SQL Server
@@ -435,6 +435,26 @@ Five things that are decisions rather than mechanics:
   (`sqlite_sequence` is an ordinary table and rolls back with it). Committed sequences are contiguous,
   so `DetectInSafeZone` has no separate answer to give. **Do not reintroduce gap-skipping** — it would
   guard a state that cannot occur.
+- **Non-stale is decided against the shards the store *registers*, not the rows
+  `fi_event_progression` holds** (fisher#102). Reading it off the rows makes a shard that has not run
+  yet invisible — with no row it has no sequence to be behind — so a store with two async projections
+  was declared non-stale the moment the first reached the head. It is a *window*, from one shard's
+  first commit to the next shard's, which is why it surfaced as an intermittent
+  `rebuild_and_catch_up_compliance` failure on a loaded two-core CI runner and never locally. Behind
+  `QueryForNonStaleData` it tells an application its data is current while a projection has never run.
+  Three consequences, each deliberate:
+  - **A registered shard with no row is stale**, so a wait with no daemon running now times out rather
+    than returning early. That is the honest answer, and the message names the shards that recorded
+    nothing, because "never started" and "still catching up" are different operational situations.
+  - **A store with no async projections returns immediately.** The same rule was broken the other way
+    round: with events present and no rows, the old `shards.Length > 0` clause was false forever, so
+    `QueryForNonStaleData` on a store with no async projections *always* threw `TimeoutException`.
+  - **A row for a shard nothing registers is ignored.** A projection removed from configuration leaves
+    an orphan row that will never advance again — `DeleteProjectionProgressByShardNameAsync` exists for
+    exactly those — and waiting on one would hang every subsequent call.
+  `one_shard_at_the_head_does_not_speak_for_a_shard_that_never_ran` is the discriminating fact, and it
+  needs *two* registered shards: with no rows at all the old rule waited too, so a store where nothing
+  has run cannot tell the two rules apart.
 - **The session's operation queue is guarded, because the daemon is not a single caller.** JasperFx's
   `ExecutionStage` fans its executions out with `Task.WhenAll` and they all queue onto the *same*
   Fisher session, so two projection slices can call `QueueOperation` at the same instant.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.9.0</Version>
+        <Version>0.9.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1349 tests green on net9.0 and net10.0**, with no known intermittent failures — 1300 in
+**1354 tests green on net9.0 and net10.0**, with no known intermittent failures — 1305 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 13 in `Fisher.EntityFrameworkCore.Tests`. 309 of
 them are shared cross-store compliance tests — 250 event sourcing, which as of 2.51.0 is every event
 suite the shared library has, and 59 document. On JasperFx **2.51.0** / Weasel **9.24.0**.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,20 @@
 Where Fisher is, what comes next, and why in this order. See [CLAUDE.md](CLAUDE.md) for
 architecture and the SQLite-specific decisions.
 
-Status: **no open issues** — the JasperFx 2.51.0 wave asked for three and all three are closed.
+Status: **no open issues**. The JasperFx 2.51.0 wave asked for three, and preparing its release found
+a fourth — [#102](https://github.com/JasperFx/fisher/issues/102), which is **0.9.1**.
+
+**0.9.1** is that fix, and it is worth reading as a warning about what an intermittent can hide.
+`WaitForNonStaleProjectionDataAsync` decided it was done from the rows in `fi_event_progression`
+rather than from the shards the store *registers* — so a shard that had not run yet was invisible, and
+a store with two async projections was declared non-stale the moment the first one reached the head.
+Behind `QueryForNonStaleData` that tells an application its data is current while a projection has
+never run. It presented once, as a `rebuild_and_catch_up_compliance` failure on a loaded two-core CI
+runner, and passed 25/25 locally in isolation — the window is the gap between one shard's first commit
+and the next shard's. The same rule was broken the other way round too: with events present and no
+rows at all, a store with **no** async projections waited out its timeout every time. Registered
+shards are now the authority in both directions, and an orphan row from a de-registered projection is
+ignored rather than waited on forever.
 
 That is a milestone and not a finish line, so it is worth being precise about what it does and does not
 mean. Every gap this repository knows about is closed; it is emphatically **not** the same as being
@@ -76,7 +89,7 @@ Fisher's sessions declared `Events` as their own concrete type, which does **not
 member (C# interface implementation is not return-type covariant), so both tiers needed an explicit
 implementation. Two new compliance suites pin both halves. On JasperFx **2.51.0** / Weasel **9.24.0**.
 **All 36 compliance suites, 309 tests, green** — 30 event suites and 250 tests, plus six document
-suites and 59 tests. 1300 tests green on net9.0 and net10.0.
+suites and 59 tests. 1305 tests green on net9.0 and net10.0.
 
 The 2026-08-16 wave is **0.7.2**, and it emptied the tracker again.
 [#88](https://github.com/JasperFx/fisher/issues/88) was a real cross-store divergence found by the

--- a/docs/documents/querying/index.md
+++ b/docs/documents/querying/index.md
@@ -61,3 +61,15 @@ var results = await session.Query<Summary>()
 `QueryForNonStaleData` waits for the **whole store**, where Polecat waits for the projections feeding
 the queried type. Stricter rather than weaker, and it needs no type-to-shard map.
 :::
+
+**"The whole store" means every async shard the store has registered**, not every shard that has
+recorded progress — including one that has never run. A registered shard with no progression row is
+behind by definition, so the wait blocks until it reports rather than treating it as absent.
+
+::: warning
+The consequence is worth knowing before you meet it: **if the async daemon is not running, this waits
+out its timeout and throws `TimeoutException`.** That is the honest answer — the data really is stale
+and nothing is going to advance it — and the message names the shards that have recorded nothing at
+all, so "never started" is distinguishable from "still catching up". A store with no async projections
+returns immediately, because there is nothing to wait for.
+:::

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -155,10 +155,23 @@ Or from a query:
 await session.Query<CustomerSales>().QueryForNonStaleData(TimeSpan.FromSeconds(5)).ToListAsync();
 ```
 
+Non-stale means **every registered async shard** has reached the current high-water mark. A shard that
+has not started yet counts as behind — it has no progression row, and a row is evidence about a shard
+rather than the definition of one. So the wait blocks until it reports, and a store with no async
+projections returns immediately.
+
 ::: warning
 **Non-stale does not imply a post-commit listener has run.** The progression row is written *inside*
 the batch's transaction, so non-stale is true the moment that commits — strictly before any listener.
 Wait on the listener's own signal instead.
+:::
+
+::: warning
+**Waiting without a running daemon throws `TimeoutException`.** Nothing will advance a registered
+shard, so there is no honest early return; the message names the shards that have recorded nothing so
+"never started" reads differently from "still catching up". A progression row for a projection that is
+no longer registered is ignored rather than waited on — that is what
+`DeleteProjectionProgressByShardNameAsync` is for.
 :::
 
 ## Event-emitting projections

--- a/src/Fisher.Tests/Events/event_database_reads.cs
+++ b/src/Fisher.Tests/Events/event_database_reads.cs
@@ -1,4 +1,5 @@
 using Fisher.Tests.Events;
+using Fisher.Tests.Projections;
 using JasperFx;
 using JasperFx.Events;
 using JasperFx.Events.Projections;
@@ -23,6 +24,14 @@ public class event_database_reads : IAsyncLifetime
         {
             options.ConnectionString = _database.ConnectionString;
             options.AutoCreateSchemaObjects = AutoCreate.All;
+
+            // fisher#102. The waiting tests below are about *registered* shards, because that is what
+            // the wait is defined against — a progression row is evidence about a shard rather than the
+            // definition of one. Two of them, because the bug being pinned is only visible with two: one
+            // shard at the head while the other has never run. The daemon is deliberately never started
+            // here, so every row these tests read is one they seeded.
+            options.Projections.Snapshot<AsyncQuestTally>(SnapshotLifecycle.Async);
+            options.Projections.Snapshot<AsyncQuestRoster>(SnapshotLifecycle.Async);
         });
 
         await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
@@ -172,10 +181,137 @@ public class event_database_reads : IAsyncLifetime
     public async Task waiting_times_out_when_a_shard_never_catches_up()
     {
         await AppendAsync(3);
-        await WriteProgressAsync(new ShardName("tally").Identity, 1);
+        await WriteProgressAsync(TheRegisteredShard, 1);
 
         await Should.ThrowAsync<TimeoutException>(async () =>
             await TheDatabase.WaitForNonStaleProjectionDataAsync(TimeSpan.FromMilliseconds(300)));
+    }
+
+    /// <summary>
+    ///     <b>fisher#102, the fact the bug actually lived in: one shard at the head does not make the
+    ///     store non-stale while another has never run.</b>
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This is the discriminating shape, and the one below is not. With <em>no</em> rows at all
+    ///         the old rule also waited — <c>shards.Length > 0</c> was false — so a store where nothing
+    ///         has run cannot tell the two rules apart. It takes a shard that <em>has</em> reported,
+    ///         standing in for the whole set, which is exactly what happened on CI: the turbine shard
+    ///         reached the head and the audit shard had not started, and the wait believed the first
+    ///         one.
+    ///     </para>
+    ///     <para>
+    ///         Seeded rather than raced. The window is the gap between one shard's first commit and
+    ///         another's, so a daemon-driven test would be trying to land inside the bug rather than
+    ///         pinning the rule.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task one_shard_at_the_head_does_not_speak_for_a_shard_that_never_ran()
+    {
+        await AppendAsync(3);
+        await WriteProgressAsync(TheRegisteredShard, 3);
+
+        await Should.ThrowAsync<TimeoutException>(async () =>
+            await TheDatabase.WaitForNonStaleProjectionDataAsync(TimeSpan.FromMilliseconds(300)));
+    }
+
+    /// <summary>
+    ///     <b>fisher#102 — a registered shard that has never run is stale, and used not to be.</b>
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The wait used to read its answer off the rows in <c>fi_event_progression</c>, which makes
+    ///         a shard that has not started <em>invisible</em>: with no row it has no sequence to be
+    ///         behind, so a store with two async projections was declared non-stale the moment the first
+    ///         one reached the head. Behind <c>QueryForNonStaleData</c> that tells an application its
+    ///         data is current while a projection has never run.
+    ///     </para>
+    ///     <para>
+    ///         Seeded rather than raced, because the window is exactly the gap between one shard's first
+    ///         commit and another's — a daemon-driven test would be trying to land inside the bug rather
+    ///         than pinning the rule. Here nothing has run at all, which is the same state at its
+    ///         simplest.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_registered_shard_that_has_never_run_is_stale()
+    {
+        await AppendAsync(3);
+
+        await Should.ThrowAsync<TimeoutException>(async () =>
+            await TheDatabase.WaitForNonStaleProjectionDataAsync(TimeSpan.FromMilliseconds(300)));
+    }
+
+    /// <summary>
+    ///     The timeout says which shards have recorded nothing at all, because "never started" and
+    ///     "still catching up" are different operational situations and a caller should not have to
+    ///     guess which it got.
+    /// </summary>
+    [Fact]
+    public async Task the_timeout_names_a_shard_that_recorded_nothing()
+    {
+        await AppendAsync(3);
+
+        var timeout = await Should.ThrowAsync<TimeoutException>(async () =>
+            await TheDatabase.WaitForNonStaleProjectionDataAsync(TimeSpan.FromMilliseconds(300)));
+
+        timeout.Message.ShouldContain(TheRegisteredShard);
+        timeout.Message.ShouldContain("the daemon may not be running");
+    }
+
+    /// <summary>
+    ///     A store with no async projections has nothing to wait for, so the wait returns rather than
+    ///     timing out (fisher#102, second half).
+    /// </summary>
+    /// <remarks>
+    ///     This was broken the other way round by the same rule: with events present and no rows,
+    ///     <c>shards.Length > 0</c> was false forever, so <c>QueryForNonStaleData</c> against a store
+    ///     with no async projections <em>always</em> threw <see cref="TimeoutException" /> — a wait for
+    ///     something that could never happen.
+    /// </remarks>
+    [Fact]
+    public async Task a_store_with_no_async_projections_never_waits()
+    {
+        using var database = TemporaryDatabase.Create("eventdb-no-projections");
+        await using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid(), new QuestStarted("Quest"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await Should.NotThrowAsync(async () =>
+            await store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    /// <summary>
+    ///     A progression row for a shard nothing registers does not make the store stale.
+    /// </summary>
+    /// <remarks>
+    ///     A projection removed from configuration leaves its row behind — that is what
+    ///     <c>DeleteProjectionProgressByShardNameAsync</c> exists to clean up, and its own remarks say
+    ///     the abstraction targets orphans that may never have been registered. Blocking on one would
+    ///     make every subsequent wait hang on a shard that will never advance again, so the registered
+    ///     set is the authority in both directions.
+    /// </remarks>
+    [Fact]
+    public async Task a_row_for_a_shard_nothing_registers_is_ignored()
+    {
+        await AppendAsync(3);
+        await WriteProgressAsync(TheRegisteredShard, 3);
+        await WriteProgressAsync(TheOtherRegisteredShard, 3);
+        await WriteProgressAsync(new ShardName("removed_projection").Identity, 1);
+
+        await Should.NotThrowAsync(async () =>
+            await TheDatabase.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(5)));
     }
 
     /// <summary>
@@ -193,7 +329,7 @@ public class event_database_reads : IAsyncLifetime
     public async Task waiting_reports_a_timeout_even_when_the_clock_elapses_inside_a_query()
     {
         await AppendAsync(3);
-        await WriteProgressAsync(new ShardName("tally").Identity, 1);
+        await WriteProgressAsync(TheRegisteredShard, 1);
 
         await Should.ThrowAsync<TimeoutException>(async () =>
             await TheDatabase.WaitForNonStaleProjectionDataAsync(TimeSpan.Zero));
@@ -203,11 +339,25 @@ public class event_database_reads : IAsyncLifetime
     public async Task waiting_returns_once_every_shard_has_reached_the_head()
     {
         await AppendAsync(3);
-        await WriteProgressAsync(new ShardName("tally").Identity, 3);
+        await WriteProgressAsync(TheRegisteredShard, 3);
+        await WriteProgressAsync(TheOtherRegisteredShard, 3);
 
         await Should.NotThrowAsync(async () =>
             await TheDatabase.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(5)));
     }
+
+    /// <summary>
+    ///     The identity of a registered async shard — taken from the store rather than spelled out, so
+    ///     a change to how a shard is named cannot leave these tests seeding a row that matches nothing
+    ///     and passing for the wrong reason.
+    /// </summary>
+    private string ShardFor<T>()
+        => _store.Options.Projections.AllShards()
+            .Single(x => x.Name.Name == typeof(T).Name).Name.Identity;
+
+    private string TheRegisteredShard => ShardFor<AsyncQuestTally>();
+
+    private string TheOtherRegisteredShard => ShardFor<AsyncQuestRoster>();
 
     private async Task WriteProgressAsync(string name, long sequence)
     {

--- a/src/Fisher.Tests/Projections/async_projections.cs
+++ b/src/Fisher.Tests/Projections/async_projections.cs
@@ -360,3 +360,15 @@ internal sealed class FailOnceBatch : Fisher.Events.Messaging.IMessageBatch
 }
 
 internal sealed class TransientBatchFailure : Exception;
+
+/// <summary>
+///     A second async-snapshotted aggregate over the same events, for tests that need two shards
+///     rather than one — fisher#102's rule is only visible when one shard can stand in for another.
+/// </summary>
+public class AsyncQuestRoster
+{
+    public Guid Id { get; set; }
+    public int Members { get; set; }
+
+    public void Apply(MemberJoined joined) => Members++;
+}

--- a/src/Fisher/Storage/FisherDatabase.EventDatabase.cs
+++ b/src/Fisher/Storage/FisherDatabase.EventDatabase.cs
@@ -204,6 +204,31 @@ public partial class FisherDatabase : IEventDatabase
     ///         caller that asked to wait for non-stale data and got stale data anyway has no way to tell.
     ///     </para>
     ///     <para>
+    ///         <b>"Every registered shard" means the shards the store has registered, not the rows
+    ///         <c>fi_event_progression</c> happens to hold</b> (fisher#102). Reading the answer off the
+    ///         rows makes a shard that has not run yet <em>invisible</em>, because a shard with no row
+    ///         has no sequence to be behind — so with two async projections the wait returned the moment
+    ///         the first one reached the head, while the second had never started. That is a window
+    ///         rather than a state: it lasts from the first shard committing its progression row to the
+    ///         second committing its first, which is why it presented as an intermittent on a loaded
+    ///         two-core CI runner and never locally. What it costs is the whole point of the call —
+    ///         behind <c>QueryForNonStaleData</c> an application is told its data is current while a
+    ///         projection has never run, and reads empty documents that look like answers.
+    ///     </para>
+    ///     <para>
+    ///         The consequence worth knowing: <b>a store with a registered async projection whose daemon
+    ///         is not running now waits out the timeout</b> where it used to return early. That is the
+    ///         honest answer — the data really is stale — but it turns a fast bogus success into a
+    ///         <see cref="TimeoutException" />, and the message names the shards that are missing rather
+    ///         than only the ones that are behind, because "never started" and "still catching up" are
+    ///         different operational situations.
+    ///     </para>
+    ///     <para>
+    ///         Subscriptions are shards too and are included, since the daemon runs them and they record
+    ///         progression exactly as a projection does — a subscription left behind is as much a reason
+    ///         to call the data stale.
+    ///     </para>
+    ///     <para>
     ///         <strong>Every cancellation this method's own clock causes becomes that
     ///         <see cref="TimeoutException" />, wherever in the cycle it lands.</strong> The two reads
     ///         take the same token as the delay, so translating only the delay's cancellation meant the
@@ -215,6 +240,10 @@ public partial class FisherDatabase : IEventDatabase
     public async Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout)
     {
         using var cancellation = new CancellationTokenSource(timeout);
+
+        // Resolved once: the registration is fixed for the store's lifetime, and the whole point is
+        // that this set does not shrink to whatever has managed to write a row yet.
+        var expected = _options.Projections.AllShards().Select(x => x.Name.Identity).ToArray();
 
         var highWater = 0L;
         var shards = Array.Empty<ShardState>();
@@ -231,8 +260,17 @@ public partial class FisherDatabase : IEventDatabase
                         StringComparison.OrdinalIgnoreCase))
                     .ToArray();
 
-                // No events means nothing can be stale. Shards that exist must all have reached the head.
-                if (highWater == 0 || (shards.Length > 0 && shards.All(x => x.Sequence >= highWater)))
+                // No events means nothing can be stale, whatever any shard has recorded.
+                if (highWater == 0)
+                {
+                    return;
+                }
+
+                // Every registered shard, present and at the head. A shard with no row is behind by
+                // definition, which is exactly the case the row-derived version could not see.
+                if (expected.All(identity =>
+                        shards.FirstOrDefault(x => string.Equals(x.ShardName, identity,
+                            StringComparison.OrdinalIgnoreCase)) is { } state && state.Sequence >= highWater))
                 {
                     return;
                 }
@@ -245,9 +283,20 @@ public partial class FisherDatabase : IEventDatabase
         {
             // Filtered on this method's own token so that if an overload ever accepts the caller's,
             // their cancellation still surfaces as a cancellation rather than as a timeout.
+            var missing = expected
+                .Where(identity => shards.All(x => !string.Equals(x.ShardName, identity,
+                    StringComparison.OrdinalIgnoreCase)))
+                .ToArray();
+
+            var detail = missing.Length > 0
+                ? $" Registered shards that have not recorded any progress: [{string.Join(", ", missing)}]"
+                  + " — the daemon may not be running."
+                : string.Empty;
+
             throw new TimeoutException(
                 $"Projection data was still stale after {timeout}. High water is at {highWater}; "
-                + $"shards are at [{string.Join(", ", shards.Select(x => $"{x.ShardName}:{x.Sequence}"))}].");
+                + $"shards are at [{string.Join(", ", shards.Select(x => $"{x.ShardName}:{x.Sequence}"))}]."
+                + detail);
         }
     }
 


### PR DESCRIPTION
Closes #102. Bumps Fisher to **0.9.1**.

## The defect

`WaitForNonStaleProjectionDataAsync` decided it was done from the rows in `fi_event_progression`:

```csharp
if (highWater == 0 || (shards.Length > 0 && shards.All(x => x.Sequence >= highWater)))
```

`shards` is **the shards that have already written a row**, not the shards the store has registered. A shard that has not started has no row and therefore no sequence to be behind, so it was invisible — with two async projections the wait returned the moment the *first* reached the head. The method's own doc comment says "every registered async shard", so the code and the contract disagreed and the contract was right.

Behind `QueryForNonStaleData` this tells an application its data is current while a projection has never run, and it reads empty documents that look like answers. That is the bad direction: the caller asked precisely so it would not have to guess.

**Found from one intermittent CI failure** while preparing 0.9.0 — `rebuild_and_catch_up_compliance.rebuilding_one_projection_leaves_another_alone` on net10.0, green on net9.0 in the same run and 25/25 locally in isolation. The window is the gap between one shard's first commit and the next shard's, which a loaded two-core runner lands in and a workstation does not.

## The second half, which the fix surfaced

The same rule was broken the other way round: with events present and **no** rows, `shards.Length > 0` was false forever — so `QueryForNonStaleData` on a store with no async projections *always* threw `TimeoutException`, waiting for something that could never happen.

## The rule now

Registered shards are the authority in both directions:

| | |
|---|---|
| registered shard, no row | **stale** — this is #102 |
| registered shard, behind | stale (unchanged) |
| no async projections registered | **returns immediately** |
| row for a shard nothing registers | **ignored** |

The last one is deliberate: a projection removed from configuration leaves an orphan that will never advance again, and `DeleteProjectionProgressByShardNameAsync` exists for exactly those — waiting on one would hang every subsequent call. Subscriptions are included, since the daemon runs them and they record progression the same way.

⚠️ **The behaviour change worth putting in the release notes:** a wait with a registered async projection and **no daemon running** now waits out its timeout instead of returning early. That is the honest answer — nothing is going to advance it — and the message names the shards that recorded nothing, so "never started" is distinguishable from "still catching up".

## Tests

`one_shard_at_the_head_does_not_speak_for_a_shard_that_never_ran` is the discriminating fact, and it **needs two registered shards**: with no rows at all the old rule waited too, so a store where nothing has run cannot tell the two rules apart. That is why the fixture now registers two async projections. Seeded rather than raced — a daemon-driven test would be trying to land inside the window rather than pinning the rule.

**Mutation-checked**: reverting to the row-derived rule fails that fact, plus `a_store_with_no_async_projections_never_waits` and `a_row_for_a_shard_nothing_registers_is_ignored`.

The two pre-existing timeout tests were seeding a row for an unregistered `tally` shard; they now use a registered shard's identity, taken from the store rather than spelled out, so they cannot pass by way of a row that matches nothing.

- `Fisher.Tests` **1305 passed, 0 failed** (net9.0 and net10.0)
- `Fisher.AspNetCore.Tests` 36 · `Fisher.EntityFrameworkCore.Tests` 13
- 12 consecutive Release runs of the compliance namespace clean, since the bug this fixes was an intermittent
- `npm run docs-build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpEyfCiFuKvw56bLsvCfXs