### PR TITLE
IDocumentCommitListener — the shared post-commit session hook (closes #104)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.51.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.51.0" />
+        <PackageVersion Include="JasperFx" Version="2.52.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.52.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.51.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.51.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.52.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.52.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage

--- a/docs/documents/listeners.md
+++ b/docs/documents/listeners.md
@@ -82,6 +82,43 @@ that had already committed.
   `AfterCommitAsync` on the daemon's threads for every batch of every shard. JasperFx's
   `IDaemonChangeListener` is the hook for that side, and Fisher supports it.
 
+## The store-agnostic contract
+
+`JasperFx.Events.Documents.IDocumentCommitListener` is the shared spelling of the after-commit hook,
+so a post-commit side effect can be written once and registered with Marten, Polecat or Fisher.
+Fisher's `IDocumentSessionListener` **derives from it**, which makes both directions work:
+
+```cs
+// Outbound: a Fisher listener already IS a contract listener. Nothing to do.
+IDocumentCommitListener asContract = new MyFisherListener();
+
+// Inbound: a listener that implements only the shared contract, registered with AsSessionListener().
+options.Listeners.Add(myCommitListener.AsSessionListener());
+```
+
+`ChangeSet` implements `IDocumentChangeSet` alongside `IChangeSet`, and `IDocumentDeletion` derives
+from the contract's identically-named type — so nothing is copied or converted on the way through.
+
+::: tip
+There is **no second `CommitListeners` collection**. A contract listener is adapted onto
+`IDocumentSessionListener` and joins the same `Listeners` list, so it runs in the same order, is
+cached per session the same way, and obeys every rule below without exception.
+:::
+
+::: warning
+`IDocumentChangeSet` declares `Inserted`, `Updated` and `Deleted` as `IReadOnlyList<>` where Fisher's
+own `IChangeSet` says `IEnumerable<>`. That is the contract insisting on a *materialised* snapshot,
+because on Marten the change set is the live unit of work and a lazy sequence taken out of one is
+wrong by the time a listener reads it again. Fisher's is a snapshot either way.
+:::
+
+::: warning
+**The rules below are Fisher's, and two of them are not shared.** An empty unit of work and an
+enlisted session both fire nothing here; Marten fires unconditionally for the latter. The shared
+contract permits both answers and deliberately asserts neither, so a listener that must hear about a
+commit made under your own transaction has to check its store.
+:::
+
 ## Reading what is about to be appended
 
 `IChangeSet` describes a commit that has happened. Before one has, the streams a session has enlisted

--- a/src/Fisher.Tests/Compliance/FisherDocumentComplianceFixture.cs
+++ b/src/Fisher.Tests/Compliance/FisherDocumentComplianceFixture.cs
@@ -98,6 +98,17 @@ public class FisherDocumentComplianceFixture : DocumentStorageComplianceFixture
             {
                 options.Events.AddEventType(eventType);
             }
+
+            // jasperfx#679. The one config member that carries instances rather than Types, because
+            // the suite has to hold the very listener it registered in order to read back what the
+            // store handed it. Adapted onto Fisher's own listener type and added to the same
+            // Listeners collection every other listener uses — Fisher deliberately grew no second
+            // list for the shared contract, so this is the shipped registration route rather than a
+            // test-only one.
+            foreach (var listener in config.CommitListeners)
+            {
+                options.Listeners.Add(listener.AsSessionListener());
+            }
         });
 
         await _store.ApplyAllConfiguredChangesToDatabaseAsync(Cancellation).ConfigureAwait(false);

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -183,3 +183,24 @@ public class document_session_events_compliance
 
 public class pending_stream_actions_compliance
     : PendingStreamActionsCompliance<FisherDocumentComplianceFixture>;
+
+/*
+ * jasperfx#679 — the post-commit session hook, and the change set it is handed. Fisher enrolls
+ * because the suite needs documents and nothing else.
+ *
+ * ⚠️ This is the one document suite a green build says nothing about. Unlike jasperfx#669 and #673
+ * the shared contract declares no default implementation, so a near-miss member is CS0535 rather
+ * than a silent bind — but the *wiring* is invisible to the compiler at every point. A store that
+ * declares IDocumentCommitListener and IDocumentChangeSet perfectly and never invokes a listener
+ * compiles clean and passes every other suite in the library. These ten facts are the only thing
+ * standing between the contract and a no-op.
+ *
+ * Two of Fisher's firing rules are deliberately NOT exercised here, and the suite says so in its own
+ * remarks: it asserts nothing about an empty unit of work, and nothing about a session enlisted in a
+ * caller's transaction. Fisher skips the hook for both (SaveChangesAsync's early return, and
+ * `EnlistedTransaction is null` on the post-commit branch), which the contract permits and Marten
+ * does not do. Fisher's own tests own those two — see the session listener tests.
+ */
+
+public class document_commit_listener_compliance
+    : DocumentCommitListenerCompliance<FisherDocumentComplianceFixture>;

--- a/src/Fisher.Tests/Documents/commit_listener_contract.cs
+++ b/src/Fisher.Tests/Documents/commit_listener_contract.cs
@@ -1,0 +1,175 @@
+using System.Data;
+using Fisher.Services;
+using JasperFx;
+using JasperFx.Events.Documents;
+using Microsoft.Data.Sqlite;
+
+namespace Fisher.Tests.Documents;
+
+/// <summary>
+///     fisher#104 / jasperfx#679 — the two halves of the shared commit-listener contract that
+///     <c>DocumentCommitListenerCompliance</c> cannot reach.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The shared suite proves the middle of the story: a listener registered through the
+///         contract is invoked, once per commit, with a snapshot of what the commit wrote. It cannot
+///         prove the two ends, and both are silent when broken.
+///     </para>
+///     <para>
+///         <b>The outbound half</b> is the default interface implementation on
+///         <see cref="IDocumentSessionListener" /> that makes every Fisher listener an
+///         <see cref="IDocumentCommitListener" />. Nothing inside Fisher calls it — Fisher's firing
+///         site calls Fisher's own member — so a wrong forward there compiles, ships, and is never
+///         executed by any test in the library.
+///     </para>
+///     <para>
+///         <b>The two firing divergences</b> are the other end. The shared suite deliberately
+///         asserts nothing about an empty unit of work or about a session enlisted in a caller's
+///         transaction, because the contract permits either answer and Marten's differs from
+///         Fisher's. <c>session_listeners</c> pins both through Fisher's own interface; these pin
+///         them through the contract, which is the surface a store-agnostic consumer sees and the
+///         one that could drift independently.
+///     </para>
+/// </remarks>
+public class commit_listener_contract : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("commit_contract");
+    private readonly RecordingCommitContractListener _listener = new();
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<ListenerFly>();
+
+            // The shipped registration route for a listener that implements only the shared
+            // contract: adapted onto Fisher's own listener type and added to the one Listeners
+            // collection. There is no second list to add it to, on purpose.
+            options.Listeners.Add(_listener.AsSessionListener());
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <remarks>
+    ///     The outbound forward. A Fisher listener handed to code that only knows the shared type
+    ///     has to arrive at the Fisher member with both arguments intact — and the forward casts
+    ///     both, so a wrong one is an <see cref="InvalidCastException" /> rather than a wrong value.
+    /// </remarks>
+    [Fact]
+    public async Task a_fisher_listener_is_reachable_through_the_shared_contract()
+    {
+        var fisherListener = new RecordingListener();
+        IDocumentCommitListener asContract = fisherListener;
+
+        await using var session = _store.LightweightSession();
+        session.Store(new ListenerFly { Id = Guid.NewGuid(), Pattern = "Outbound" });
+        await session.SaveChangesAsync(Token);
+
+        var commit = _listener.Commits.ShouldHaveSingleItem();
+
+        await asContract.AfterCommitAsync(commit.Session, commit.Commit, Token);
+
+        // Reached the Fisher member, not a default and not the contract member recursing.
+        fisherListener.Hooks.ShouldBe(["after"]);
+    }
+
+    /// <remarks>
+    ///     A Fisher listener already satisfies the contract, so adapting one would wrap a listener
+    ///     that needs no wrapping — and, registered alongside itself, would fire it twice.
+    /// </remarks>
+    [Fact]
+    public void adapting_a_listener_that_is_already_a_fisher_listener_returns_it_unchanged()
+    {
+        var fisherListener = new RecordingListener();
+
+        ((IDocumentCommitListener)fisherListener).AsSessionListener().ShouldBeSameAs(fisherListener);
+    }
+
+    [Fact]
+    public async Task the_contract_listener_sees_what_the_commit_wrote()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new ListenerFly { Id = id, Pattern = "Royal Coachman" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        var commit = _listener.Commits.ShouldHaveSingleItem().Commit;
+
+        commit.Updated.ShouldHaveSingleItem().ShouldBeOfType<ListenerFly>().Id.ShouldBe(id);
+        commit.Inserted.ShouldBeEmpty();
+        commit.Deleted.ShouldBeEmpty();
+    }
+
+    /// <remarks>
+    ///     Fisher's divergence #1, seen through the contract. The shared suite says nothing about
+    ///     this case because Marten's answer was never stated; Fisher's is stated, so it is pinned
+    ///     here rather than left to be rediscovered.
+    /// </remarks>
+    [Fact]
+    public async Task an_empty_unit_of_work_does_not_reach_the_contract_listener()
+    {
+        await using var session = _store.LightweightSession();
+        await session.SaveChangesAsync(Token);
+
+        _listener.Commits.ShouldBeEmpty();
+    }
+
+    /// <remarks>
+    ///     Fisher's divergence #2, and the sharper one: Marten fires unconditionally here.
+    ///     <c>SaveChangesAsync</c> on an enlisted session is not the point at which the data becomes
+    ///     durable, and Fisher is never told when the caller's transaction commits — so the callback
+    ///     would be announcing writes an outer rollback can still discard. The contract explicitly
+    ///     permits both answers; this is Fisher's.
+    /// </remarks>
+    [Fact]
+    public async Task an_enlisted_session_does_not_reach_the_contract_listener()
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var transaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(IsolationLevel.Serializable, Token);
+
+        await using (var session = _store.OpenSession(SessionOptions.ForTransaction(transaction)))
+        {
+            session.Store(new ListenerFly { Id = Guid.NewGuid(), Pattern = "Enlisted" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        _listener.Commits.ShouldBeEmpty();
+
+        await transaction.CommitAsync(Token);
+    }
+}
+
+/// <summary>
+///     A listener that implements the shared contract and nothing else — the store-agnostic shape
+///     jasperfx#679 exists to make registrable.
+/// </summary>
+public class RecordingCommitContractListener : IDocumentCommitListener
+{
+    public List<(IDocumentSessionOperations Session, IDocumentChangeSet Commit)> Commits { get; } = [];
+
+    public Task AfterCommitAsync(IDocumentSessionOperations session, IDocumentChangeSet commit,
+        CancellationToken token)
+    {
+        Commits.Add((session, commit));
+        return Task.CompletedTask;
+    }
+}

--- a/src/Fisher/DocumentCommitListenerExtensions.cs
+++ b/src/Fisher/DocumentCommitListenerExtensions.cs
@@ -1,0 +1,68 @@
+using Fisher.Services;
+using JasperFx.Events.Documents;
+
+namespace Fisher;
+
+/// <summary>
+///     Registers a store-agnostic <see cref="IDocumentCommitListener" /> (jasperfx#679) with Fisher
+///     (fisher#104).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>An adapter onto the existing listener list, deliberately, rather than a second list.</b>
+///         The shape this could have taken instead — a <c>CommitListeners</c> collection on
+///         <see cref="StoreOptions" /> and another on <see cref="SessionOptions" />, with a second
+///         loop beside the one in <c>SaveChangesAsync</c> — would have doubled the registration
+///         surface, doubled the per-session composition <c>FisherSession.Listeners</c> caches, and
+///         created two firing loops with an undefined order between them. Adapting instead means a
+///         contract listener is a listener: one list, one cache, one loop, one order, and every
+///         behaviour documented on <see cref="IDocumentSessionListener" /> applies to it unchanged
+///         because it <em>is</em> one.
+///     </para>
+///     <para>
+///         The reverse direction needs no adapter at all: <see cref="IDocumentSessionListener" />
+///         derives from <see cref="IDocumentCommitListener" />, so every Fisher listener already
+///         satisfies the shared type.
+///     </para>
+/// </remarks>
+public static class DocumentCommitListenerExtensions
+{
+    /// <summary>
+    ///     Wrap a shared-contract commit listener as a Fisher session listener, for
+    ///     <see cref="StoreOptions.Listeners" /> or <see cref="SessionOptions.Listeners" />.
+    /// </summary>
+    /// <example>
+    ///     <code>options.Listeners.Add(myCommitListener.AsSessionListener());</code>
+    /// </example>
+    public static IDocumentSessionListener AsSessionListener(this IDocumentCommitListener listener)
+        => listener as IDocumentSessionListener ?? new CommitListenerAdapter(listener);
+
+    /// <summary>
+    ///     A commit listener seen as a session listener: the commit hook forwards, the other three do
+    ///     nothing.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>The session is widened and the change set is not converted.</b>
+    ///         <see cref="IDocumentSession" /> already derives from
+    ///         <see cref="IDocumentSessionOperations" />, so the first argument is an implicit
+    ///         upcast; the second is a cast only because <see cref="IChangeSet" /> and
+    ///         <see cref="IDocumentChangeSet" /> are siblings rather than relatives — Fisher's
+    ///         <c>ChangeSet</c> implements both, and it is the only thing that ever constructs one.
+    ///     </para>
+    ///     <para>
+    ///         <see cref="BeforeSaveChangesAsync" /> is a no-op rather than absent because it has no
+    ///         default: the shared contract is post-commit only, on purpose, and a consumer wanting
+    ///         a pre-commit hook implements Fisher's interface instead. The two synchronous members
+    ///         are left to their defaults.
+    ///     </para>
+    /// </remarks>
+    private sealed class CommitListenerAdapter(IDocumentCommitListener inner) : IDocumentSessionListener
+    {
+        public Task BeforeSaveChangesAsync(IDocumentSession session, CancellationToken token)
+            => Task.CompletedTask;
+
+        public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+            => inner.AfterCommitAsync(session, (IDocumentChangeSet)commit, token);
+    }
+}

--- a/src/Fisher/IDocumentSessionListener.cs
+++ b/src/Fisher/IDocumentSessionListener.cs
@@ -1,4 +1,5 @@
 using Fisher.Services;
+using JasperFx.Events.Documents;
 
 namespace Fisher;
 
@@ -62,7 +63,7 @@ namespace Fisher;
 ///         cannot un-commit anything, on any store.
 ///     </para>
 /// </remarks>
-public interface IDocumentSessionListener
+public interface IDocumentSessionListener : IDocumentCommitListener
 {
     /// <summary>
     ///     Called at the start of <c>SaveChangesAsync</c>, before anything is written.
@@ -79,6 +80,42 @@ public interface IDocumentSessionListener
     ///     Called after the transaction has committed, with a snapshot of what it wrote.
     /// </summary>
     Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token);
+
+    /// <summary>
+    ///     The store-agnostic spelling of the member above (fisher#104 / jasperfx#679), forwarded to
+    ///     it so a listener implements one method rather than two.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>A default implementation, and it has to be one.</b> The contract's member differs
+    ///         from Fisher's by both of its interesting parameter types, so it is a separate
+    ///         signature that Fisher's does not satisfy — deriving without supplying a body would
+    ///         make this interface's contract member unimplemented and every existing listener a
+    ///         CS0535. That is the one mercy of jasperfx#679 over jasperfx#669: the contract declares
+    ///         no default of its own, so the near-miss is a build error rather than a member that
+    ///         silently binds to a throwing default. It still is not evidence of anything — see
+    ///         below.
+    ///     </para>
+    ///     <para>
+    ///         <b>This forward is the outbound half only, and nothing inside Fisher calls it.</b>
+    ///         It exists so that a listener written for Fisher <em>is</em> an
+    ///         <see cref="IDocumentCommitListener" /> — store-agnostic code that collects the shared
+    ///         type picks Fisher's listeners up unchanged. The inbound half, registering a listener
+    ///         that only implements the shared type, is <c>AsSessionListener()</c>; a listener
+    ///         registered that way is invoked through Fisher's own member, not through this one. So
+    ///         a green build proves neither direction, which is what
+    ///         <c>DocumentCommitListenerCompliance</c> is for.
+    ///     </para>
+    ///     <para>
+    ///         The two casts are safe on every path that reaches here from Fisher — the session is
+    ///         always a Fisher session and the change set always Fisher's — and would only fail for
+    ///         a caller synthesising another store's arguments, which is not a case this interface
+    ///         claims to serve.
+    ///     </para>
+    /// </remarks>
+    Task IDocumentCommitListener.AfterCommitAsync(IDocumentSessionOperations session,
+        IDocumentChangeSet commit, CancellationToken token)
+        => AfterCommitAsync((IDocumentSession)session, (IChangeSet)commit, token);
 
     /// <summary>
     ///     Called as each document is materialised from the database.

--- a/src/Fisher/Internal/FisherSession.cs
+++ b/src/Fisher/Internal/FisherSession.cs
@@ -564,7 +564,16 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
         // commit can make, and Fisher is not told when that happens.
         if (Listeners.Count > 0 && EnlistedTransaction is null)
         {
-            var commit = new Services.ChangeSet(queued, streams);
+            // Typed as Fisher's IChangeSet rather than left to var, and that is not style. From
+            // fisher#104 IDocumentSessionListener also carries jasperfx#679's
+            // AfterCommitAsync(IDocumentSessionOperations, IDocumentChangeSet, CancellationToken),
+            // and ChangeSet implements both change-set interfaces while this session implements both
+            // session interfaces — so a `var` local leaves the call below with two applicable
+            // overloads, resolved today only by IDocumentSession being the more derived first
+            // argument. Naming the type makes the shared overload inapplicable instead of
+            // second-best, so the listener Fisher invokes cannot quietly change if either hierarchy
+            // moves.
+            Services.IChangeSet commit = new Services.ChangeSet(queued, streams);
 
             foreach (var listener in Listeners)
             {

--- a/src/Fisher/Services/ChangeSet.DocumentContract.cs
+++ b/src/Fisher/Services/ChangeSet.DocumentContract.cs
@@ -1,0 +1,43 @@
+using JasperFx.Events.Documents;
+
+namespace Fisher.Services;
+
+/// <summary>
+///     The change set's half of the store-agnostic document contract (fisher#104 / jasperfx#679).
+/// </summary>
+/// <remarks>
+///     <para>
+///         Three members, all explicit, because all three collide by name with the
+///         <see cref="IChangeSet" /> members beside them and differ from them by type:
+///         <see cref="IDocumentChangeSet" /> is declared in <see cref="IReadOnlyList{T}" /> where
+///         Fisher's own change set says <see cref="IEnumerable{T}" />. That is not a near-miss to
+///         paper over — it is the contract insisting on a materialised snapshot, because on Marten
+///         the change set <em>is</em> the live unit of work and a lazy sequence handed out of one is
+///         wrong by the time a listener reads it again.
+///     </para>
+///     <para>
+///         <b>Which makes these three the cheapest implementation of the contract of the three
+///         stores, and for a reason that predates it.</b> Fisher already classifies eagerly into
+///         three <see cref="List{T}" /> fields in its constructor, off the operations snapshot
+///         <c>TakePendingOperations</c> produced — the property <see cref="IChangeSet.Clone" />
+///         returns <c>this</c> on. So the snapshot the contract asks for already exists and each
+///         member is a field read: no copy, no <c>ToList</c>, and nothing that could go stale.
+///     </para>
+///     <para>
+///         <b><see cref="Deleted" /> costs nothing either, and that is the derivation doing the
+///         work.</b> <c>_deleted</c> is a <c>List&lt;Fisher.Services.IDocumentDeletion&gt;</c>, and
+///         Fisher's <see cref="IDocumentDeletion" /> derives from the contract's — so the field
+///         converts to <c>IReadOnlyList&lt;JasperFx.Events.Documents.IDocumentDeletion&gt;</c> by
+///         interface variance. Had the two same-named interfaces been left unrelated, this member
+///         could only have been a per-call <c>Cast().ToList()</c>, which allocates on every read and
+///         hands out a different list each time to a consumer told the collections are snapshots.
+///     </para>
+/// </remarks>
+internal sealed partial class ChangeSet : IDocumentChangeSet
+{
+    IReadOnlyList<object> IDocumentChangeSet.Inserted => _inserted;
+
+    IReadOnlyList<object> IDocumentChangeSet.Updated => _updated;
+
+    IReadOnlyList<JasperFx.Events.Documents.IDocumentDeletion> IDocumentChangeSet.Deleted => _deleted;
+}

--- a/src/Fisher/Services/ChangeSet.cs
+++ b/src/Fisher/Services/ChangeSet.cs
@@ -20,7 +20,7 @@ namespace Fisher.Services;
 ///         <c>SQLITE_BUSY</c>, one that had been drained twice.
 ///     </para>
 /// </remarks>
-internal sealed class ChangeSet : IChangeSet
+internal sealed partial class ChangeSet : IChangeSet
 {
     private readonly List<object> _updated = [];
     private readonly List<object> _inserted = [];

--- a/src/Fisher/Services/IChangeSet.cs
+++ b/src/Fisher/Services/IChangeSet.cs
@@ -78,15 +78,25 @@ public interface IChangeSet
 ///     wrong one ever notices — the same lesson <c>StoredDocumentMetadata</c> records. The members are
 ///     unchanged, so a listener body reading <c>DocumentType</c> and <c>Id</c> ports across untouched;
 ///     only a declaration that names the type has to be edited.
+///     <para>
+///         <b>It now derives from <c>JasperFx.Events.Documents.IDocumentDeletion</c></b>, which
+///         jasperfx#679 added with this type's exact members and — deliberately — this type's exact
+///         name, Fisher's spelling having been picked as the shared one precisely because
+///         <c>IDeletion</c> was already taken next to <c>Weasel.Storage</c>. Two structurally
+///         identical interfaces one namespace apart is a clash to resolve rather than a coincidence
+///         to live with, and derivation resolves it in the direction that costs nothing: no member
+///         is re-declared, no implementer changes, and a listener written against the shared
+///         contract sees Fisher's descriptors without an adapter.
+///     </para>
 /// </remarks>
-public interface IDocumentDeletion
+public interface IDocumentDeletion : JasperFx.Events.Documents.IDocumentDeletion
 {
-    /// <summary>The type deleted. For a hierarchy this is the type the caller named.</summary>
-    Type DocumentType { get; }
-
-    /// <summary>
-    ///     The identity deleted, or <c>null</c> for a predicate-based <c>DeleteWhere</c> /
-    ///     <c>HardDeleteWhere</c>, which names rows it never loaded and therefore has no id to report.
-    /// </summary>
-    object? Id { get; }
+    // Both members - Type DocumentType and object? Id - are inherited from the JasperFx contract
+    // rather than declared here, and the derivation is what resolves the name clash jasperfx#679
+    // created. See the remarks above: re-declaring them would hide the base pair behind an identical
+    // pair, which is the exact near-miss shape the contract's own remarks warn about, and it would
+    // cost every implementer an explicit implementation for no gain. Inheriting instead means every
+    // Fisher deletion descriptor IS a contract deletion, so ChangeSet's List<IDocumentDeletion>
+    // satisfies IReadOnlyList<JasperFx.Events.Documents.IDocumentDeletion> by variance with no copy
+    // and no cast.
 }


### PR DESCRIPTION
Adopts JasperFx 2.52.0's `IDocumentCommitListener` / `IDocumentChangeSet` / `IDocumentDeletion` (jasperfx#679). Pins bumped 2.51.0 → 2.52.0 for all four JasperFx ids.

**`DocumentCommitListenerCompliance`: 10/10 pass.** Full suite 1320/1320 on net9.0 and net10.0, no docker.

## The name clash, resolved by derivation

`Fisher.Services.IDocumentDeletion` and the contract's new `IDocumentDeletion` have the same two members and — deliberately — the same name: JasperFx picked Fisher's spelling as the shared one, precisely because `IDeletion` is already taken next to `Weasel.Storage`. Two structurally identical interfaces one namespace apart is a clash to resolve, not a coincidence to live with, so Fisher's now **derives** from the contract's and re-declares nothing.

That is not tidiness. `ChangeSet._deleted` is a `List<Fisher.Services.IDocumentDeletion>`, and derivation is what makes it convert to `IReadOnlyList<JasperFx.Events.Documents.IDocumentDeletion>` by interface variance. Left unrelated, the member could only ever have been a per-call `Cast().ToList()` — allocating on every read, and handing a *different* list each time to a consumer told the collections are snapshots.

## Registration: the DIM, plus an adapter onto the same list

Both directions, and neither adds a collection.

**Outbound** — `IDocumentSessionListener : IDocumentCommitListener` with a default interface implementation forwarding to Fisher's own member. Every existing Fisher listener is now a contract listener with no edit, and `StoreOptions.Listeners` / `SessionOptions.Listeners` are untouched.

**Inbound** — `AsSessionListener()` adapts a listener that implements *only* the shared contract onto Fisher's listener type and adds it to that same `Listeners` collection. This is the half the compliance suite actually exercises, and it is why a parallel `CommitListeners` list was rejected rather than merely not needed: a second list would have doubled the registration surface, doubled the per-session composition `FisherSession.Listeners` caches, and created two firing loops with an undefined order between them. Adapting instead means a contract listener *is* a listener — one list, one cache, one loop, one order, and every rule documented on `IDocumentSessionListener` applies to it because it is one.

`AsSessionListener()` returns the instance unchanged when it is already a Fisher listener, so a listener cannot end up wrapped around itself and firing twice.

## One thing the plan did not anticipate: the firing site became ambiguous

`IDocumentSessionListener` now carries **two** applicable `AfterCommitAsync` overloads, and at the firing site `FisherSession` satisfies both first parameters while `ChangeSet` satisfies both second ones. With `var commit = new Services.ChangeSet(...)` the call still compiles — resolved only by `IDocumentSession` being the more derived first argument, with the second argument a tie. That is a coin balanced on its edge. The local is now typed `Services.IChangeSet`, which makes the shared overload *inapplicable* rather than second-best.

## The traps, as they actually played out

**Covariance did not bite, and it structurally could not.** The contract declares no default implementations, so a near-miss member is CS0535 at build time rather than a member silently binding to a throwing default — the one mercy of jasperfx#679 over jasperfx#669. Deriving `IDocumentSessionListener` *without* a correct DIM would have been a compile error on every existing listener, not a silent unbinding. The real exposure is the wiring, which no compiler sees at any point.

**So the suite was checked for sensitivity rather than trusted.** Removing the fixture's one registration line **fails 8 of the 10 facts**. The 2 that survive are the suite's own negative facts (`the_listener_does_not_fire_for_work_that_was_never_committed`, and `the_listener_fires_if_and_only_if_the_commit_succeeded`, which takes its zero branch) — correctly vacuous when nothing is registered, and not evidence of anything on their own.

## Fisher's divergences: unchanged, and no shipped fact contradicts them

Nothing was bent to make a fact pass. The suite is written with the divergences in mind and asserts neither the empty unit of work nor the enlisted session — and the enlisted case is unreachable from `IDocumentSessionFactory` anyway. Fisher still skips the hook for both, still fires outside the Polly pipeline, and still does not fire for daemon projection batches; the existing `session_listeners` facts covering all three are untouched and green.

**No upstream defect to report.** The one place the suite could have over-assumed — `the_change_set_survives_the_session_moving_on` — Fisher passes for free, because it has classified eagerly off the `TakePendingOperations` snapshot since fisher#12.

## Two seams the shared suite cannot reach, pinned here

`commit_listener_contract` (5 facts):

- **The DIM forward.** Nothing inside Fisher calls it — Fisher's firing site calls Fisher's own member — so a wrong forward would compile, ship, and never be executed by any test in the library.
- **`AsSessionListener()` on an already-Fisher listener.**
- **Both firing divergences through the contract path**, which is the surface a store-agnostic consumer sees and the one that could drift independently of Fisher's own.

## Files

- `Directory.Packages.props` — four ids to 2.52.0
- `src/Fisher/Services/IChangeSet.cs` — `IDocumentDeletion` derives from the contract's
- `src/Fisher/Services/ChangeSet.DocumentContract.cs` (new) — three explicit implementations
- `src/Fisher/IDocumentSessionListener.cs` — derives from `IDocumentCommitListener`, DIM forward
- `src/Fisher/DocumentCommitListenerExtensions.cs` (new) — `AsSessionListener()` + adapter
- `src/Fisher/Internal/FisherSession.cs` — typed change-set local
- `src/Fisher.Tests/Compliance/*` — fixture replays `CommitListeners`; suite enrolled
- `src/Fisher.Tests/Documents/commit_listener_contract.cs` (new)
- `docs/documents/listeners.md` — new "The store-agnostic contract" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mpctjngqnraWVnDaqWtYf