### PR TITLE
1.0.0, and the docs site ships with the release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,17 @@
 name: Deploy docs
 
+# A release publishes the packages and the site it points at, together. `publish.yml` fires on the
+# same tag, so `gh release create v1.0.0` is the whole release: three nupkgs and the documentation
+# that documents them, cut from one commit. Without this the site drifted — it was
+# workflow_dispatch-only and had never run, so fisher.jasperfx.net was two waves behind the packages
+# while `PackageProjectUrl` on every one of them pointed at it.
+#
+# Lowercase `v*` matches the pattern `publish.yml` uses, and matters for the same reason: a tag cut
+# as `V1.0.0` matches neither workflow and the release silently does nothing.
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 concurrency:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.9.2</Version>
+        <Version>1.0.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ SQLite-backed Event Store and Document Database inside the Critter Stack.
     <img src="./logo.png" alt="Fisher logo" width="40%">
 </div>
 
-_Sorry, we don't have the documentation published **yet**, but we'll get there soon!_
-
 **Documentation: [fisher.jasperfx.net](https://fisher.jasperfx.net/)**
 
 Fisher is [Marten](https://martendb.io) and [Polecat](https://polecat.jasperfx.net) for SQLite —
@@ -19,7 +17,7 @@ event sourcing and document storage with the same API, in a database that is a *
 process**. There is no server to install, nothing to provision, and nothing to keep running. Backup is
 `cp`. Tests need no fixture.
 
-> **Status: early, but no longer a skeleton.** The event store, document storage over all four
+> **Status: 1.0.** The event store, document storage over all four
 > identity types plus strong-typed wrappers, hierarchies, numeric revisions, soft delete, duplicated
 > fields, user-declared indexes, document metadata mapping, LINQ — including joins, grouping and both
 > paging styles — patching, bulk insert, DCB tags, natural keys, all five projection shapes across all
@@ -28,8 +26,12 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 32 suites and 275 tests** of `JasperFx.Events.ComplianceTests`, the shared
-> cross-store suite Marten and Polecat also enroll in.
+> Fisher passes **all 37 suites and 319 tests** of `JasperFx.Events.ComplianceTests`, the shared
+> cross-store suite Marten and Polecat also enroll in, alongside its own 1,320.
+>
+> 1.0 means the API is stable and the semantics above are settled — not that Fisher is
+> feature-complete against Marten. The gaps that remain are **decisions**, documented in
+> [HANDOFF.md](HANDOFF.md) rather than filed as issues.
 >
 > The one thing that is *not* there is deliberate and permanent: **no message bus.** The projection
 > side-effect seam exists and the default outbox drops every message, because delivery is a bus


### PR DESCRIPTION
Bumps to 1.0.0, and closes the gap that made the version number the least interesting part of this PR.

## The docs site was never wired to anything

`docs.yml` was `workflow_dispatch`-only and **had never once run** — so
[fisher.jasperfx.net](https://fisher.jasperfx.net/) has been serving pre-0.9.0 content while
`PackageProjectUrl` on all three packages points at it. Confirmed directly: `CacheAggregatesForWriting`
and `PendingStreams`, both 0.9.0, return zero hits on the live pages that document them.

It now carries the same `push: tags: v*` trigger `publish.yml` already has, so a release deploys the
packages and the documentation for them from one commit. `npm run docs-build` verified clean first,
since the tag now depends on it.

The lowercase `v*` is load-bearing, and there is precedent: **`V0.9.2` matched neither workflow**, and
0.9.2 had to be rescued with a manual `workflow_dispatch`. A tag cut with a capital V silently does
nothing.

## README ships inside the package

It announced `Status: early, but no longer a skeleton` and _"Sorry, we don't have the documentation
published yet"_ — the latter contradicted by the link directly beneath it. Both go.

The compliance scoreboard was two waves stale at 32 suites / 275 tests. Counted off an actual run
(`--filter-namespace Fisher.Tests.Compliance --list-tests`), it is **37 suites / 319 tests**.

1.0 is framed as API stability, explicitly *not* parity with Marten — the deliberate gaps stay
decisions in HANDOFF.md rather than becoming issues. The permanent "no message bus" note is untouched.

## Verification

Full suite, Release, both TFMs, before the tag:

| Project | net9.0 | net10.0 |
|---|---|---|
| Fisher.Tests | 1320 | 1320 |
| Fisher.AspNetCore.Tests | 36 | 36 |
| Fisher.EntityFrameworkCore.Tests | 13 | 13 |

Zero failures, zero skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)