### PR TITLE
EF Core projection storage is not thread-safe, and says so (closes #108)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3586,6 +3586,24 @@ factory)`, over `Projections.StorageProviders` in the core.
 - Registering a bare `IProjection` now wraps it in JasperFx's `ProjectionWrapper`, which Fisher had no
   path for before: `Projections.Add(ProjectionBase, ...)` assumed every projection base was also an
   `IProjectionSource`. Polecat wraps in the same place.
+- **`EfCoreProjectionStorage.IsThreadSafe` is `false`, and the `SemaphoreSlim` beside it is not an
+  alternative to that** (fisher#108, over jasperfx#683). `AggregationRunner` posts a range's slices
+  into a fixed ten-wide `Block` — ten real reader tasks — against one storage instance, and a
+  `DbContext` is not thread-safe. The lock serializes each individual *call*; what it cannot close is
+  the window *between* two, where one thread's aggregation mutates entities that another thread's
+  `Entry()` is running `DetectChanges` over. Nothing reachable from inside the storage can stop the
+  fan-out, which is why the seam had to be upstream. `FisherProjectionStorage` keeps the default of
+  `true`: it queues onto the session, whose queue fisher#13 made thread-safe for this exact shape.
+  - **Fisher was measurably harder to break than Marten, and that is the semaphore's doing rather than
+    luck.** Marten reported real corruption (marten#5266 — `Dictionary.TryInsert`,
+    `ChangeDetector.DetectChanges`); forcing Fisher back to ten-wide over 15,000 slice applications
+    produced no exception at all. So the lock stays: it is what makes the residual window narrow, and
+    the declaration is what closes it.
+  - **The test asserts the fan-out stopped, not that a crash stopped**, which is the only assertion
+    worth making about a data race — a test waiting for corruption is probabilistic in the direction
+    that fails you, so green would prove nothing. `slices_are_applied_one_at_a_time` counts concurrent
+    `Apply` calls: one with the declaration, **8 measured without it**. The counters live in the test's
+    projection rather than in the storage, so production carries no instrumentation.
 
 ## Conventions
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.52.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.52.0" />
+        <PackageVersion Include="JasperFx" Version="2.53.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.53.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.52.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.52.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.53.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.53.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,10 +12,10 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1369 tests green on net9.0 and net10.0**, with no known intermittent failures — 1320 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 13 in `Fisher.EntityFrameworkCore.Tests`. 319 of
-them are shared cross-store compliance tests — 250 event sourcing, which as of 2.52.0 is every event
-suite the shared library has, and 69 document. On JasperFx **2.52.0** / Weasel **9.24.0**.
+**1374 tests green on net9.0 and net10.0**, with no known intermittent failures — 1320 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 18 in `Fisher.EntityFrameworkCore.Tests`. 319 of
+them are shared cross-store compliance tests — 250 event sourcing, which as of 2.53.0 is every event
+suite the shared library has, and 69 document. On JasperFx **2.53.0** / Weasel **9.24.0**.
 
 ## Closed since the comparison
 
@@ -452,8 +452,10 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.52.0 ships **37 suites, 319 tests**. Fisher passes **all 319, all
-37 suites**. Every suite compiles; every one is also subclassed and running.
+`JasperFx.Events.ComplianceTests` 2.53.0 ships **37 suites, 319 tests**. Fisher passes **all 319, all
+37 suites**. Every suite compiles; every one is also subclassed and running. 2.53.0 changed no suite
+file and added no test — verified against a run rather than by diffing the file list, which is the
+lesson 2.49.0 taught.
 
 **2.49.0 added no suite file and still required production work**, which is the first bump of that
 shape: `DocumentLoadAndStoreCompliance` gained three tests for `LoadAsync<T>(object)` (jasperfx#665 /

--- a/src/Fisher.EntityFrameworkCore.Tests/ef_core_projection_concurrency.cs
+++ b/src/Fisher.EntityFrameworkCore.Tests/ef_core_projection_concurrency.cs
@@ -1,0 +1,334 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Fisher.EntityFrameworkCore.Tests;
+
+/// <summary>
+///     fisher#108, over jasperfx#683 — an EF Core projection storage declares itself not thread-safe,
+///     so the daemon applies a range's slices one at a time instead of ten-wide.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>AggregationRunner</c> posts every slice of a range into a fixed ten-wide <c>Block</c> —
+///         ten real reader tasks — against one storage instance. That is fine for Fisher's own document
+///         storage, which queues onto a session whose operation queue fisher#13 made thread-safe for
+///         this exact fan-out; it is not fine for a <c>DbContext</c>, which is explicitly not
+///         thread-safe. Reported on Marten as <c>InvalidOperationException</c> out of
+///         <c>Dictionary.TryInsert</c> and <c>NullReferenceException</c> out of
+///         <c>ChangeDetector.DetectChanges</c> (marten#5266).
+///     </para>
+///     <para>
+///         <b>What is asserted here is that the fan-out stopped, not that a crash stopped.</b> That is
+///         deliberate, and it is the stronger of the two: the corruption is a data race, so a test
+///         waiting for it to throw is probabilistic in the direction that fails you — green would prove
+///         nothing. Concurrency itself is directly observable, so <see cref="SquadTallyProjection" />
+///         records the most <c>Apply</c> calls ever in flight at once, which is ten-wide before the
+///         declaration and exactly one after it. Measured rather than assumed: with <c>IsThreadSafe</c>
+///         forced back to <c>true</c> this suite observes 9 concurrent applies and
+///         <see cref="slices_are_applied_one_at_a_time" /> fails on the number.
+///     </para>
+///     <para>
+///         <b>Fisher was harder to break than Marten, and why is worth keeping.</b> The storage's own
+///         <c>SemaphoreSlim</c> serializes each individual call, so the simultaneous-call corruption
+///         Marten hit is already closed here — 15,000 slice applications over a forced ten-wide run
+///         produced no exception at all. What a lock cannot close is the window <em>between</em> two
+///         calls, where one thread's aggregation mutates entities that another thread's <c>Entry()</c>
+///         is running <c>DetectChanges</c> over; that window is why the fix has to be the fan-out
+///         rather than the lock. It is also why this was never reported against Fisher in the wild
+///         while it was against Marten — and why it still had to be fixed.
+///     </para>
+///     <para>
+///         <c>Identities</c> rather than a single-stream projection, because one event naming every
+///         squad guarantees a range far wider than the block; a single-stream projection reaches the
+///         same place only when a range happens to span several streams.
+///     </para>
+///     <para>
+///         One thing to expect in this suite's schema and not to read as a defect in it: registering
+///         through <c>Projections.Add</c> rather than <c>Snapshot&lt;T&gt;</c> leaves a stray, empty
+///         <c>fi_doc_squadtally</c> table, because only <c>Snapshot&lt;T&gt;</c> guards its mapping
+///         with <c>HasProviderFor</c>. The registered EF storage is still what resolves —
+///         <see cref="an_ef_backed_storage_declares_itself_not_thread_safe" /> is what proves it — so
+///         nothing here is measuring the wrong table. Tracked as fisher#111.
+///     </para>
+/// </remarks>
+public class ef_core_projection_concurrency : IAsyncLifetime
+{
+    // Wider than AggregationRunner's ten-slice block, so a range always holds more slices than the
+    // block can take at once and the concurrent path is genuinely exercised rather than incidentally
+    // serial.
+    private const int SquadCount = 60;
+    private const int AuditCount = 10;
+
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("ef-projection-concurrency");
+    private DocumentStore _store = null!;
+    private IProjectionDaemon? _daemon;
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private static string[] Squads =>
+        Enumerable.Range(0, SquadCount).Select(i => $"squad-{i:D3}").ToArray();
+
+    public async ValueTask InitializeAsync()
+    {
+        SquadTallyProjection.ResetConcurrencyProbe();
+
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+
+            options.ProjectToEfCore<SquadTally, string, SquadContext>("SquadTallies", ContextForReads);
+            options.Projections.Add(new SquadTallyProjection(), ProjectionLifecycle.Async);
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "create table if not exists SquadTallies (Id text primary key, Audits integer not null)";
+        await command.ExecuteNonQueryAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_daemon is not null)
+        {
+            await _daemon.StopAllAsync();
+            _daemon.Dispose();
+        }
+
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private SquadContext ContextForReads()
+        => new(new DbContextOptionsBuilder<SquadContext>().UseSqlite(_database.ConnectionString).Options);
+
+    private async Task AppendAuditsAsync()
+    {
+        await using var session = _store.LightweightSession();
+
+        for (var i = 0; i < AuditCount; i++)
+        {
+            session.Events.StartStream(Guid.NewGuid(), new SquadsAudited(Squads));
+        }
+
+        await session.SaveChangesAsync(Token);
+    }
+
+    private async Task RunDaemonAsync()
+    {
+        _daemon ??= await _store.BuildProjectionDaemonAsync();
+        await _daemon.StartAllAsync();
+        await _store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(60));
+    }
+
+    private async Task<List<SquadTally>> TalliesAsync()
+    {
+        await using var context = ContextForReads();
+
+        return await context.SquadTallies.OrderBy(x => x.Id).ToListAsync(Token);
+    }
+
+    /// <summary>
+    ///     The declaration, read back through the seam the daemon resolves storage through.
+    /// </summary>
+    /// <remarks>
+    ///     Asserted against the resolved storage rather than by constructing the internal type, so what
+    ///     is pinned is what <c>AggregationRunner</c> will actually ask — a registration that stopped
+    ///     routing to the EF storage would fail here rather than silently going back to ten-wide.
+    /// </remarks>
+    [Fact]
+    public async Task an_ef_backed_storage_declares_itself_not_thread_safe()
+    {
+        await using var session = _store.LightweightSession();
+
+        var storage = await ((IStorageOperations)session)
+            .FetchProjectionStorageAsync<SquadTally, string>(StorageConstants.DefaultTenantId, Token);
+
+        storage.IsThreadSafe.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     And the contrast, because "not thread-safe" has to be the EF storage's answer rather than
+    ///     Fisher's.
+    /// </summary>
+    /// <remarks>
+    ///     <c>FisherProjectionStorage</c> keeps JasperFx's default of <c>true</c>: it queues operations
+    ///     onto the session, whose queue is guarded precisely so the daemon can fan out onto it
+    ///     (fisher#13). Serializing every projection would cost throughput for every store that does
+    ///     not use EF and nothing would report it, so both answers are pinned rather than one.
+    /// </remarks>
+    [Fact]
+    public async Task fishers_own_projection_storage_is_still_thread_safe()
+    {
+        await using var session = _store.LightweightSession();
+
+        var storage = await ((IStorageOperations)session)
+            .FetchProjectionStorageAsync<PlainTally, Guid>(StorageConstants.DefaultTenantId, Token);
+
+        storage.IsThreadSafe.ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     The regression: the daemon never has two of this projection's slices in flight at once.
+    /// </summary>
+    /// <remarks>
+    ///     This is the test that fails without the declaration, and it fails on a number rather than on
+    ///     a crash — see the class remarks for why that is the stronger assertion. The projection's
+    ///     <c>Apply</c> yields, which is what makes overlap observable at all: ten threads each applying
+    ///     one increment can finish without ever coinciding, where anything with an await point in it
+    ///     coincides immediately if the runner is fanning out.
+    /// </remarks>
+    [Fact]
+    public async Task slices_are_applied_one_at_a_time()
+    {
+        await AppendAuditsAsync();
+        await RunDaemonAsync();
+
+        // Guards a vacuous pass: with nothing applied there is no concurrency to observe, and a max of
+        // zero or one would "prove" serialization without the projection having run at all.
+        SquadTallyProjection.AppliedCount.ShouldBe(SquadCount * AuditCount);
+        SquadTallyProjection.MaxConcurrentApplies.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     And every slice's write still lands, which is the half a lock alone would not save.
+    /// </summary>
+    /// <remarks>
+    ///     A torn change tracker can lose a slice's write as easily as it can throw — fisher#13's shape
+    ///     one layer over — so asserting each squad reached its full audit count is what separates "did
+    ///     not crash" from "wrote everything".
+    /// </remarks>
+    [Fact]
+    public async Task a_wide_fan_out_applies_every_slice()
+    {
+        await AppendAuditsAsync();
+        await RunDaemonAsync();
+
+        var tallies = await TalliesAsync();
+
+        tallies.Count.ShouldBe(SquadCount);
+        tallies.ShouldAllBe(x => x.Audits == AuditCount);
+    }
+
+    /// <summary>
+    ///     And the same under a rebuild, which is the shape the failures were reported against.
+    /// </summary>
+    /// <remarks>
+    ///     A rebuild replays every event through the same runner with no throttling from the append
+    ///     side, so slices arrive as fast as the loader can page them — the densest fan-out the daemon
+    ///     ever produces.
+    /// </remarks>
+    [Fact]
+    public async Task a_wide_fan_out_survives_a_rebuild()
+    {
+        await AppendAuditsAsync();
+        await RunDaemonAsync();
+
+        SquadTallyProjection.ResetConcurrencyProbe();
+
+        await _daemon!.RebuildProjectionAsync("SquadTally", TimeSpan.FromSeconds(60), Token);
+
+        var tallies = await TalliesAsync();
+
+        tallies.Count.ShouldBe(SquadCount);
+        tallies.ShouldAllBe(x => x.Audits == AuditCount);
+        SquadTallyProjection.MaxConcurrentApplies.ShouldBe(1);
+    }
+}
+
+/// <remarks>
+///     <para>
+///         <c>Identities</c> is what produces the fan-out: one event names every squad, so a single
+///         event becomes <c>SquadCount</c> slices and a range of them many times the block's width.
+///     </para>
+///     <para>
+///         The counters are this suite's instrument, and they live here rather than in the storage so
+///         that nothing is added to production code for a test's benefit. <c>Apply</c> runs inside the
+///         slice execution, so two applies in flight at once <em>is</em> two slices in flight at once —
+///         the thing under test, observed without reaching past the public projection surface.
+///     </para>
+/// </remarks>
+public partial class SquadTallyProjection : Projections.MultiStreamProjection<SquadTally, string>
+{
+    private static int _current;
+    private static int _max;
+    private static int _applied;
+
+    public SquadTallyProjection()
+    {
+        Name = "SquadTally";
+        Identities<SquadsAudited>(x => x.Squads);
+    }
+
+    public static int MaxConcurrentApplies => Volatile.Read(ref _max);
+
+    public static int AppliedCount => Volatile.Read(ref _applied);
+
+    public static void ResetConcurrencyProbe()
+    {
+        Volatile.Write(ref _current, 0);
+        Volatile.Write(ref _max, 0);
+        Volatile.Write(ref _applied, 0);
+    }
+
+    public async Task Apply(SquadsAudited _, SquadTally tally)
+    {
+        var inFlight = Interlocked.Increment(ref _current);
+
+        int seen;
+        while (inFlight > (seen = Volatile.Read(ref _max)))
+        {
+            Interlocked.CompareExchange(ref _max, inFlight, seen);
+        }
+
+        try
+        {
+            // An await point, so overlap is observable at all rather than depending on ten increments
+            // happening to coincide.
+            await Task.Yield();
+
+            tally.Audits++;
+            Interlocked.Increment(ref _applied);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _current);
+        }
+    }
+}
+
+public class SquadContext : DbContext
+{
+    public SquadContext(DbContextOptions<SquadContext> options) : base(options)
+    {
+    }
+
+    public DbSet<SquadTally> SquadTallies => Set<SquadTally>();
+}
+
+public class SquadTally
+{
+    public string Id { get; set; } = string.Empty;
+    public int Audits { get; set; }
+}
+
+/// <remarks>
+///     A Fisher-stored document, so the contrast test has a non-EF projection storage to resolve. It is
+///     never projected into — resolving its storage is the whole of its job.
+/// </remarks>
+public class PlainTally
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+public record SquadsAudited(string[] Squads);

--- a/src/Fisher.EntityFrameworkCore/EfCoreProjectionStorage.cs
+++ b/src/Fisher.EntityFrameworkCore/EfCoreProjectionStorage.cs
@@ -25,10 +25,30 @@ namespace Fisher.EntityFrameworkCore;
 ///         which blocks from inside the transaction it is waiting on.
 ///     </para>
 ///     <para>
-///         The <see cref="SemaphoreSlim" /> is fisher#13's lesson applied one layer over. A
-///         <c>DbContext</c> is explicitly not thread-safe, and JasperFx's <c>ExecutionStage</c> fans
-///         its slices out with <c>Task.WhenAll</c> onto the same storage — the shape that silently lost
-///         a slice's write when the session's operation queue was an unguarded <c>List&lt;T&gt;</c>.
+///         <b>This storage declares itself not thread-safe, and that — not the
+///         <see cref="SemaphoreSlim" /> — is what makes it correct</b> (fisher#108, over
+///         jasperfx#683). <c>AggregationRunner</c> applies a range's slices through a fixed ten-wide
+///         block against one storage instance, and a <c>DbContext</c> is explicitly not thread-safe;
+///         for a multi-stream projection whose grouping fans one event into many slices, up to ten of
+///         them concurrently call <c>Entry()</c> / <c>Find</c> and mutate one change tracker. Reported
+///         on Marten as <c>InvalidOperationException</c> out of <c>Dictionary.TryInsert</c> and
+///         <c>NullReferenceException</c> out of <c>ChangeDetector.DetectChanges</c> (marten#5266).
+///     </para>
+///     <para>
+///         <b>A lock inside the storage does not close it</b>, which is the part worth keeping: it
+///         serializes each individual call, but between two calls the aggregation running on one
+///         thread mutates entities that another thread's <c>Entry()</c> is running
+///         <c>DetectChanges</c> over — precisely the second exception above. The fan-out itself has to
+///         stop and nothing reachable from inside the storage can stop it, which is why the seam is
+///         upstream rather than here.
+///     </para>
+///     <para>
+///         The <see cref="SemaphoreSlim" /> stays regardless. With <see cref="IsThreadSafe" /> false
+///         the runner applies slices one at a time, but that is the runner's promise rather than
+///         something this class can observe; the gate costs an uncontended lock per call and keeps the
+///         invariant local to the thing that depends on it. fisher#13 is why that caution is cheap at
+///         the price — the same fan-out silently lost a slice's write when the session's operation
+///         queue was an unguarded <c>List&lt;T&gt;</c>.
 ///     </para>
 /// </remarks>
 internal sealed class EfCoreProjectionStorage<TDoc, TId, TContext> : IProjectionStorage<TDoc, TId>
@@ -51,6 +71,18 @@ internal sealed class EfCoreProjectionStorage<TDoc, TId, TContext> : IProjection
     internal TContext Context => _context;
 
     public string TenantId { get; }
+
+    /// <summary>
+    ///     False, because this storage wraps one <see cref="DbContext" /> and a <c>DbContext</c> is not
+    ///     thread-safe. The daemon then applies a range's slices one at a time instead of ten-wide.
+    /// </summary>
+    /// <remarks>
+    ///     See the remarks on the class for why the <see cref="SemaphoreSlim" /> below is not an
+    ///     alternative to this. <c>FisherProjectionStorage</c> leaves the default of <c>true</c>: it
+    ///     queues operations onto the session, whose queue was made thread-safe by fisher#13 for
+    ///     exactly this fan-out.
+    /// </remarks>
+    public bool IsThreadSafe => false;
 
     public void SetIdentity(TDoc document, TId identity) => Locked(() => SetIdentityUnsafe(document, identity));
 

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -8,8 +8,7 @@ namespace Fisher.Tests.Compliance;
  * Fisher's session pair through FisherComplianceFixture. Marten and Polecat enroll the same way, so
  * these tests cannot drift between the products.
  *
- * Suites were added one at a time as Fisher grew into them. All thirty-seven that ship in
- * JasperFx.Events.ComplianceTests 2.52.0 are enrolled; there is no suite Fisher declines.
+ * Suites were added one at a time as Fisher grew into them.  * JasperFx.Events.ComplianceTests 2.53.0 are enrolled; there is no suite Fisher declines.
  *
  * Nothing in the fixture throws any more, but the discipline stands for the next seam member that
  * arrives ahead of the feature: a member Fisher cannot honour throws a NotSupportedException naming


### PR DESCRIPTION
Closes #108. Unblocked by jasperfx#683, which shipped in **JasperFx 2.53.0**.

`EfCoreProjectionStorage.IsThreadSafe` returns `false`, so `AggregationRunner` applies a range's slices one at a time instead of through its fixed ten-wide `Block`. `FisherProjectionStorage` keeps the default of `true` — it queues onto the session, whose operation queue fisher#13 made thread-safe for this exact fan-out.

## The comment had to be corrected, not just extended

The class remark credited the `SemaphoreSlim` with closing this:

> The `SemaphoreSlim` is fisher#13's lesson applied one layer over.

jasperfx#683 is explicit that a lock does **not** close it — it serializes each individual call, but between two calls one thread's aggregation mutates entities that another thread's `Entry()` is running `DetectChanges` over. The comment was asserting a guarantee the code did not have.

## Two things measured rather than assumed

Both changed the shape of the work:

- **Fisher is genuinely exposed.** Instrumenting the storage showed **up to 9 concurrent calls**, so the ten-wide premise holds here and is not Marten-specific. (`Block(10, …)` starts ten real reader tasks — I checked.)
- **Fisher is much harder to break than Marten, and the semaphore is why.** Forcing the storage back to ten-wide over **15,000 slice applications produced no exception at all**, where Marten reported real corruption (marten#5266). So the lock stays — it is what makes the residual window narrow — and the declaration is what closes it. That also explains why this was never reported against Fisher in the wild while it was against Marten, which the issue noted without an explanation.

## The test asserts the fan-out stopped, not that a crash stopped

The issue anticipated a probabilistic test with `[Trait("Retry", …)]` or an assert-over-N-runs. I went the other way, because a test waiting for a data race to throw is probabilistic **in the direction that fails you** — green proves nothing, so it would be a test that cannot regress. My first attempt was exactly that shape and it passed 8/8 with the fix reverted, which is what sent me looking for the measurements above.

Concurrency itself is directly observable, so `slices_are_applied_one_at_a_time` counts concurrent `Apply` calls: **1 with the declaration, 8 without**. The counters live in the test's own projection rather than in the storage, so production carries no instrumentation for a test's benefit, and a vacuity guard asserts the projection actually ran.

Five tests: the declaration through the real resolution seam, the `FisherProjectionStorage` contrast (so "not thread-safe" is the EF storage's answer and not a blanket), the serialization assertion, and correct results under both a live run and a rebuild.

**Verified load-bearing by reverting**, as the repo does everywhere: with `IsThreadSafe` forced back to `true`, three of the five fail on 3 of 3 runs. Restored, 5 green on 6 of 6.

## Filed while here

**#111** — `ProjectToEfCore` + `Projections.Add` still maps the document type and leaves a stray `fi_doc_*` table, because only `Snapshot<T>` guards its mapping with `HasProviderFor`. Runtime behaviour is correct (the registered EF storage is what resolves, which the first test here proves); the schema is not. `Add` is the only door for a multi-stream projection, so it is every EF-backed one. Noted in the test file so the stray table is not read as a defect in this suite.

## Scope notes

- **The bump is small**: `v2.52..2.53.0` is four commits and touches no compliance-test file. `Fisher.Tests` stays at exactly 1320, confirming no suite was added — verified against a run rather than by diffing the file list, which is the lesson 2.49.0 taught.
- **Weasel stays at 9.24.0.** `Weasel.Storage` floors at `JasperFx.Events` 2.46.0, so nothing forces it along. 9.25.0 is available if you want it, but it is not this issue's business.

## Verification

`dotnet build fisher.slnx` clean. **1374 tests green on net9.0 and net10.0**, 0 failed.