### PR TITLE
Both registration doors skip a type stored somewhere else (closes #111)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3569,10 +3569,17 @@ factory)`, over `Projections.StorageProviders` in the core.
   is created per batch and cannot dispose itself — it has to outlive the apply that created it *and*
   survive a retried commit. Disposing at the batch boundary covers the failed batch too, which is the
   case that would otherwise leak a context per attempt behind a persistently failing shard.
-- **A registered type is deliberately not mapped**, so `Snapshot<T>` skips its mapping and the type
-  gets no `fi_doc_*` table. That is what makes registration-before-projection load-bearing, and it is
-  checked rather than documented — the same "this line has to come first" shape fisher#39 gave
-  `SeedInitialDataOnStartup`.
+- **A registered type is deliberately not mapped**, so registering the projection skips its mapping
+  and the type gets no `fi_doc_*` table. That is what makes registration-before-projection
+  load-bearing, and it is checked rather than documented — the same "this line has to come first"
+  shape fisher#39 gave `SeedInitialDataOnStartup`.
+  - **Both registration doors skip it, which was fisher#111**: only `Snapshot<T>` carried the
+    `HasProviderFor` guard, so `Projections.Add(projection, lifecycle)` mapped the type anyway and
+    left a stray, empty table in the migration. `Add` is the only door for a multi-stream projection,
+    so that was *every* EF-backed one. Silent in both directions — the projection works, because
+    storage resolution checks the registry first, and the table sits in the schema forever. The guard
+    is per published type rather than per projection, since a projection may publish several and only
+    some of them be registered.
 - **Rebuild teardown reads the table name off the registry**, because the sweep that finds a
   projection's tables looks at *mapped* types. **This is the flat-table lesson one layer over** — the
   same gap `IPublishesTables` closes, reached from the other direction, and without it a rebuild

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,8 +12,8 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1374 tests green on net9.0 and net10.0**, with no known intermittent failures — 1320 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 18 in `Fisher.EntityFrameworkCore.Tests`. 319 of
+**1375 tests green on net9.0 and net10.0**, with no known intermittent failures — 1320 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 319 of
 them are shared cross-store compliance tests — 250 event sourcing, which as of 2.53.0 is every event
 suite the shared library has, and 69 document. On JasperFx **2.53.0** / Weasel **9.24.0**.
 

--- a/src/Fisher.EntityFrameworkCore.Tests/ef_core_projection_concurrency.cs
+++ b/src/Fisher.EntityFrameworkCore.Tests/ef_core_projection_concurrency.cs
@@ -47,12 +47,11 @@ namespace Fisher.EntityFrameworkCore.Tests;
 ///         same place only when a range happens to span several streams.
 ///     </para>
 ///     <para>
-///         One thing to expect in this suite's schema and not to read as a defect in it: registering
-///         through <c>Projections.Add</c> rather than <c>Snapshot&lt;T&gt;</c> leaves a stray, empty
-///         <c>fi_doc_squadtally</c> table, because only <c>Snapshot&lt;T&gt;</c> guards its mapping
-///         with <c>HasProviderFor</c>. The registered EF storage is still what resolves —
-///         <see cref="an_ef_backed_storage_declares_itself_not_thread_safe" /> is what proves it — so
-///         nothing here is measuring the wrong table. Tracked as fisher#111.
+///         This suite registers through <c>Projections.Add</c> rather than <c>Snapshot&lt;T&gt;</c>,
+///         which is forced — <c>Add</c> is the only door for a multi-stream projection — and is also
+///         why <see cref="an_ef_backed_type_registered_through_add_gets_no_fisher_document_table" />
+///         lives here: fisher#111 was that only <c>Snapshot&lt;T&gt;</c> guarded its mapping, so this
+///         registration left a stray, empty <c>fi_doc_squadtally</c> table behind.
 ///     </para>
 /// </remarks>
 public class ef_core_projection_concurrency : IAsyncLifetime
@@ -175,6 +174,32 @@ public class ef_core_projection_concurrency : IAsyncLifetime
             .FetchProjectionStorageAsync<PlainTally, Guid>(StorageConstants.DefaultTenantId, Token);
 
         storage.IsThreadSafe.ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     fisher#111 — the other registration door leaves no stray Fisher table either.
+    /// </summary>
+    /// <remarks>
+    ///     <c>an_ef_backed_type_gets_no_fisher_document_table</c> covers the same property for
+    ///     <c>Snapshot&lt;T&gt;</c>, which was the only door that had the guard. Asserted on the name
+    ///     rather than on "no <c>fi_doc</c> tables at all", because
+    ///     <see cref="fishers_own_projection_storage_is_still_thread_safe" /> resolves storage for a
+    ///     genuine Fisher document and creates <c>fi_doc_plaintally</c> on demand — a blanket assertion
+    ///     would pass or fail on test ordering.
+    /// </remarks>
+    [Fact]
+    public async Task an_ef_backed_type_registered_through_add_gets_no_fisher_document_table()
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "select count(*) from sqlite_master where type = 'table' and name = 'fi_doc_squadtally'";
+
+        var count = Convert.ToInt64(await command.ExecuteScalarAsync(Token));
+
+        count.ShouldBe(0);
     }
 
     /// <summary>

--- a/src/Fisher/Projections/FisherProjectionOptions.cs
+++ b/src/Fisher/Projections/FisherProjectionOptions.cs
@@ -156,6 +156,17 @@ public class FisherProjectionOptions : ProjectionGraph<IProjection, IDocumentSes
     ///         rather than a shortcoming: what such a projection writes, and where, is its own business,
     ///         and Fisher only creates tables for types it was told about.
     ///     </para>
+    ///     <para>
+    ///         <b>A published type with a registered storage provider is skipped</b>, the same check
+    ///         <see cref="Snapshot{T}" /> makes and for the same reason: its rows are not in a Fisher
+    ///         document table, so mapping it would put a second, empty table in the migration and leave
+    ///         a reader wondering which one the projection uses. <b>This was fisher#111</b>, and only
+    ///         <c>Snapshot&lt;T&gt;</c> had the guard — so an EF Core-backed
+    ///         <c>SingleStreamProjection</c> registered here, and <em>every</em> EF-backed
+    ///         <c>MultiStreamProjection</c>, since this overload is the only door for one. Silent in
+    ///         both directions: the projection works, because storage resolution checks the registry
+    ///         first, and the stray table sits in the schema forever.
+    ///     </para>
     /// </remarks>
     public void Add(ProjectionBase projection, ProjectionLifecycle lifecycle)
     {
@@ -179,6 +190,14 @@ public class FisherProjectionOptions : ProjectionGraph<IProjection, IDocumentSes
 
         foreach (var published in source.PublishedTypes())
         {
+            // Unless it already has somewhere else to live, exactly as Snapshot<T> checks — see the
+            // remarks. Asked per published type rather than per projection, because a projection may
+            // publish several and only some of them be registered.
+            if (StorageProviders.HasProviderFor(published))
+            {
+                continue;
+            }
+
             _events.Options.Schema.MappingFor(published);
         }
 


### PR DESCRIPTION
Closes #111. Found while building #108's regression suite.

## The bug

Only `Snapshot<T>` carried the `HasProviderFor` guard, so a type registered with `ProjectToEfCore` and then projected through `Projections.Add(projection, lifecycle)` was mapped anyway — putting a stray, empty `fi_doc_*` table in the migration beside the EF table the projection actually writes to.

**`Add` is the only door for a multi-stream projection**, so this was every EF-backed one, plus any single-stream projection registered by instance rather than through `Snapshot<T>`.

It is silent in both directions, which is why it survived: the projection works, because storage resolution checks the registry before resolving Fisher document storage, and the stray table is simply empty forever. CLAUDE.md stated the property as a decision — *"A registered type is deliberately not mapped"* — and the code only honoured it on one of the two paths.

## The fix

The same guard, in `Add`'s `PublishedTypes()` sweep. **Asked per published type rather than per projection**, since a projection may publish several and only some of them be registered.

Two neighbours checked and deliberately untouched:

- **`Add<TProjection>()` needs nothing** — it routes through the instance overload, which is fisher#76's whole point, so it inherits the guard.
- **`CompositeProjectionFor` maps no published types at all**, so it has nothing to guard.

## Coverage

The existing `an_ef_backed_type_gets_no_fisher_document_table` only exercised `Snapshot<T>` — the door that already had the guard. That is exactly why this was missed, so the new assertion goes on the other door.

It lives in #108's `ef_core_projection_concurrency` suite because that suite registers through `Add` (a multi-stream projection has no other door), and it asserts on the **table name** rather than on "no `fi_doc` tables at all": the same suite resolves storage for a genuine Fisher document in the `IsThreadSafe` contrast test, which creates `fi_doc_plaintally` on demand, so a blanket assertion would pass or fail on test ordering.

**Verified load-bearing by disabling the guard**: the new test fails and nothing else does.

## Verification

`dotnet build fisher.slnx` clean. **1375 tests green on net9.0 and net10.0**, 0 failed.

Docs: CLAUDE.md's bullet now says both doors skip it, and why, rather than naming `Snapshot<T>` alone.