### PR TITLE
1.0.2, on Weasel 9.25.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.1</Version>
+        <Version>1.0.2</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,8 +19,8 @@
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage
              runtime extracted from Marten, which Fisher plugs a SQLite dialect into rather than
              hand-writing storage. -->
-        <PackageVersion Include="Weasel.Sqlite" Version="9.25.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.25.0" />
+        <PackageVersion Include="Weasel.Sqlite" Version="9.25.1" />
+        <PackageVersion Include="Weasel.Storage" Version="9.25.1" />
 
         <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
         <!-- Override the transitive SQLitePCLRaw 2.1.11 (vulnerable native lib,

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -15,7 +15,7 @@ scoreboard and the things that are true right now but not obvious from either.
 **1375 tests green on net9.0 and net10.0**, with no known intermittent failures — 1320 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 319 of
 them are shared cross-store compliance tests — 250 event sourcing, which as of 2.53.0 is every event
-suite the shared library has, and 69 document. On JasperFx **2.53.0** / Weasel **9.25.0**.
+suite the shared library has, and 69 document. On JasperFx **2.53.0** / Weasel **9.25.1**.
 
 ## Closed since the comparison
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,23 @@ Status: **one open issue, and it is blocked upstream** —
 next-release item. It is filed so the Fisher half is not rediscovered later rather than because it is
 actionable now.
 
+**1.0.2** is Weasel **9.25.1**, and it exists because of what the 9.25.0 bump removed rather than
+what 9.25.1 adds. Fisher carried a `DocumentTable.ConfigureQueryCommand` override for
+[weasel#426](https://github.com/JasperFx/weasel/issues/426), which had shipped in 9.24.0 — so the
+override was a release stale, and 9.25.0 then added a fifth statement (triggers) to the metadata query
+it copies. The override and the reader that consumes it are one contract, so a consumer on 1.0.1 who
+took Weasel 9.25.0 transitively got `ArgumentOutOfRangeException` from `readForeignKeysAsync` on any
+document type with a foreign key. Removed on `main`, released here.
+
+9.25.1 rather than 9.25.0 because upstream's own upgrade page now leads with a warning to skip
+9.25.0: a length rule on local identifiers refused conventional schemas whose primary key constraint
+names were merely long (weasel#485, weasel#486), and the quiet half aborted a projection's schema
+application so the daemon then failed against storage that had never been created. **Fisher itself is
+not exposed to that** — verified rather than assumed, by applying a schema with a ~140-character index
+name on both 9.25.0 and 9.25.1: Fisher emits an inline `PRIMARY KEY` with no named constraint, so the
+rule has nothing of Fisher's to reject. Taking 9.25.1 is still right, because a Fisher application's
+*own* Weasel-managed schema is not Fisher's to vouch for.
+
 **1.0.1** is the JasperFx **2.53.0** bump and two fixes it turned up.
 [#108](https://github.com/JasperFx/fisher/issues/108) is the reason for the bump:
 [jasperfx#683](https://github.com/JasperFx/jasperfx/issues/683) adds


### PR DESCRIPTION
Releases what `main` has carried since #116, on Weasel **9.25.1**.

## Why this needs releasing rather than waiting

#116 removed `DocumentTable.ConfigureQueryCommand`. That matters to a consumer, not only to this repo: **Fisher 1.0.1 ships the override and pins Weasel 9.24.0 — but a pin is a floor.** Anyone who takes Weasel 9.25.0 transitively meets a four-statement override against a five-statement reader:

```
ArgumentOutOfRangeException ... at Weasel.Sqlite.Tables.Table.readForeignKeysAsync
```

on any document type with a foreign key. They did not choose the upgrade and the message names nothing of Fisher's.

## Why 9.25.1 and not 9.25.0

Upstream's upgrade page now leads with a warning to skip 9.25.0. A length rule on local identifiers refused conventional schemas whose primary key constraint names were merely long (weasel#485, weasel#486); the quiet half aborted a projection's schema application, so the daemon then failed against storage that had never been created.

**Fisher itself is not exposed to that — verified rather than assumed.** A schema with a ~140-character index name applies cleanly on 9.25.0 *and* 9.25.1: Fisher emits an inline `PRIMARY KEY` with no named constraint, so the rule has nothing of Fisher's to reject. Taking 9.25.1 is still correct, because a Fisher application's *own* Weasel-managed schema is not Fisher's to vouch for.

## One thing worth recording about the wait

The flat-container index served 9.25.1 from one CDN node while another still served 9.25.0, and a clean `dotnet restore --no-cache` resolved to 9.25.0 for a further two minutes after `V9.25.1` was tagged. **The index is not the authority; a restore is** — which is what the release playbook already says, now confirmed twice in one session.

## Verification

- **1375 tests green on net9.0 and net10.0**, 0 failed.
- Scoreboard check green — and it earned its keep again here, catching a stale test binary that still contained a scratch test I had deleted (1321 vs 1320) before that number could reach HANDOFF.
- `npm run docs-build` completes.

After merge: tag `v1.0.2`, lowercase.