### PR TITLE
Stamp IEvent.Timestamp before inline projections fold it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3409,6 +3409,47 @@ the same method compare that value against itself and pass unconditionally. Keep
 assignment and metadata application apart is what keeps the guard real; the cost is that a new
 metadata field in JasperFx will not reach Fisher's events until this method learns about it.
 
+#### `Timestamp`, and that cost coming due — fisher#119
+
+**The cost named above is not hypothetical, and `Timestamp` is the field it came due on.**
+`PrepareEvents` stamps it (as `EventSlice` does for a projection's raised events) and
+`ApplySessionMetadata` did not — so an event reached an inline projection carrying
+`DateTimeOffset.MinValue`, and every read model recording `e.Timestamp` baked in a year-0001 date.
+Worse than merely wrong: **the same projection produced different documents inline and rebuilt**,
+because replay reads the column, so the divergence was invisible until somebody looked at a date.
+
+- **One reading per stream, not per event** — the events of one append share a moment the way they
+  share a transaction — and **round-tripped through `SqliteTimestamp` before it is assigned**. The
+  column keeps milliseconds, so stamping raw ticks would leave the inline view sub-millisecond ahead
+  of every later read of the same event: the same divergence, one digit further down.
+- **`FisherQuickAppendEventsOperation` persists the stamped value instead of `NowExpression`**
+  whenever it is set. That is the half that makes the two views agree; stamping alone would have
+  fixed the year-0001 symptom and left inline and replay a clock apart.
+- **Guarded on `== default`**, so a caller's own value survives — and so does the first attempt's
+  when the resilience pipeline re-executes the write delegate. A retried commit therefore persists
+  the moment the append was made rather than the moment it finally won the write lock, which is
+  exactly what the inline projection already folded on attempt one.
+- **Raised events are stamped by JasperFx before they ever reach here**, so the guard leaves them
+  alone and the operation now persists their value too. They previously took the column default; the
+  two paths are consistent for free.
+
+**The trade, which is real and is not closable.** With inline projections registered the reading is
+taken in `AssignVersionsAheadOfProjectionsAsync` — *outside* the write lock, because running before
+it is that pass's whole purpose — so `fi_events.timestamp` is no longer strictly monotonic with
+`seq_id`. Two writers on different streams can stamp in one order and commit in the other, skewed by
+at most the write-lock wait. **Same-stream ordering is untouched**: the loser of a concurrent append
+to one stream fails the optimistic guard rather than interleaving, so `FetchStreamAsync`'s timestamp
+bound and the rewrite operations' assumption both still hold where they are actually read. The one
+consumer reading that order *across* streams is `FindEventStoreFloorAtTimeAsync`, whose
+`max(seq_id) where timestamp <= ?` can floor a rebuild-from-timestamp one skew window off.
+
+It cannot be had both ways — an inline projection cannot see the final timestamp before the write
+lock is taken *and* have it assigned under that lock. Marten resolves it identically, and
+`EventAppendMode.Quick`'s own doc comment says timestamps come from `TimeProvider`, so this is the
+family's behaviour rather than a Fisher concession, and ported projection code now behaves the same
+here as it does there. **Without inline projections nothing moves at all**: the stamp is taken in
+`PlanAsync`, which runs inside the write transaction.
+
 #### Closed upstream gap — jasperfx#663
 
 Historical, and the second completed cycle of the "workaround, filed upstream, removed when the fix

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1375 tests green on net9.0 and net10.0**, with no known intermittent failures — 1320 in
+**1377 tests green on net9.0 and net10.0**, with no known intermittent failures — 1322 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 319 of
 them are shared cross-store compliance tests — 250 event sourcing, which as of 2.53.0 is every event
 suite the shared library has, and 69 document. On JasperFx **2.53.0** / Weasel **9.25.1**.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 37 suites and 319 tests** of `JasperFx.Events.ComplianceTests`, the shared
-> cross-store suite Marten and Polecat also enroll in, alongside its own 1,320.
+> cross-store suite Marten and Polecat also enroll in, alongside its own 1,322.
 >
 > 1.0 means the API is stable and the semantics above are settled — not that Fisher is
 > feature-complete against Marten. The gaps that remain are **decisions**, documented in

--- a/src/Fisher.Tests/Projections/event_envelope_metadata_in_projections.cs
+++ b/src/Fisher.Tests/Projections/event_envelope_metadata_in_projections.cs
@@ -128,9 +128,58 @@ public class event_envelope_metadata_in_projections : IAsyncLifetime
         entry.ShouldNotBeNull();
         entry.StreamId.ShouldBe(streamId);
     }
+
+    [Fact]
+    public async Task an_appended_event_carries_its_timestamp_into_an_inline_projection()
+    {
+        var before = DateTimeOffset.UtcNow.AddMinutes(-1);
+
+        await using (var session = _stringStore.LightweightSession())
+        {
+            session.Events.StartStream("TimestampedService", new EnvelopeRecorded("stamped"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _stringStore.LightweightSession();
+
+        var entry = await query.LoadAsync<EnvelopeSnapshot>("stamped", TestContext.Current.CancellationToken);
+
+        entry.ShouldNotBeNull();
+
+        // The broken behaviour was not a wrong value but the *default* one: the envelope's
+        // Timestamp was only ever hydrated on read paths, so an inline projection folded
+        // events whose Timestamp was DateTimeOffset.MinValue and baked year-0001 dates
+        // into every read model that recorded e.Timestamp.
+        entry.Timestamp.ShouldBeGreaterThan(before);
+        entry.Timestamp.ShouldBeLessThan(DateTimeOffset.UtcNow.AddMinutes(1));
+    }
+
+    [Fact]
+    public async Task the_inline_timestamp_and_the_persisted_timestamp_agree()
+    {
+        await using (var session = _stringStore.LightweightSession())
+        {
+            session.Events.StartStream("AgreeingService", new EnvelopeRecorded("agreeing"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _stringStore.LightweightSession();
+
+        var entry = await query.LoadAsync<EnvelopeSnapshot>("agreeing", TestContext.Current.CancellationToken);
+        var replayed = await query.Events.FetchStreamAsync("AgreeingService",
+            token: TestContext.Current.CancellationToken);
+
+        entry.ShouldNotBeNull();
+        replayed.Count.ShouldBe(1);
+
+        // What the inline projection saw must be what a rebuild will see, or the same
+        // projection produces different documents inline vs rebuilt.
+        replayed[0].Timestamp.ShouldBe(entry.Timestamp);
+    }
 }
 
 public record EnvelopeRecorded(string Name);
+
 
 // partial, because JasperFx's source generator emits the conventional-method dispatcher into it.
 public partial class EnvelopeProjection : EventProjection
@@ -141,7 +190,8 @@ public partial class EnvelopeProjection : EventProjection
         StreamId = e.StreamId,
         StreamKey = e.StreamKey ?? string.Empty,
         TenantId = e.TenantId ?? string.Empty,
-        Version = e.Version
+        Version = e.Version,
+        Timestamp = e.Timestamp
     };
 }
 
@@ -152,4 +202,5 @@ public class EnvelopeSnapshot
     public string StreamKey { get; set; } = string.Empty;
     public string TenantId { get; set; } = string.Empty;
     public long Version { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/src/Fisher.Tests/Projections/event_envelope_metadata_in_projections.cs
+++ b/src/Fisher.Tests/Projections/event_envelope_metadata_in_projections.cs
@@ -180,7 +180,6 @@ public class event_envelope_metadata_in_projections : IAsyncLifetime
 
 public record EnvelopeRecorded(string Name);
 
-
 // partial, because JasperFx's source generator emits the conventional-method dispatcher into it.
 public partial class EnvelopeProjection : EventProjection
 {

--- a/src/Fisher/Events/AppendPlanner.cs
+++ b/src/Fisher/Events/AppendPlanner.cs
@@ -184,8 +184,8 @@ internal sealed class AppendPlanner
         // Round-tripped through the storage format up front: the column keeps milliseconds,
         // so stamping raw ticks here would leave the inline view sub-millisecond ahead of
         // every later read of the same event.
-        var timestamp = Fisher.Storage.SqliteTimestamp.FromDatabaseValue(
-            Fisher.Storage.SqliteTimestamp.ToDatabaseValue(_graph.TimeProvider.GetUtcNow()));
+        var timestamp = SqliteTimestamp.FromDatabaseValue(
+            SqliteTimestamp.ToDatabaseValue(_graph.TimeProvider.GetUtcNow()));
 
         foreach (var @event in stream.Events)
         {

--- a/src/Fisher/Events/AppendPlanner.cs
+++ b/src/Fisher/Events/AppendPlanner.cs
@@ -176,8 +176,24 @@ internal sealed class AppendPlanner
     /// </remarks>
     private void ApplySessionMetadata(StreamAction stream)
     {
+        // One reading per stream, not per event: the events of one append share a moment the
+        // same way they share a transaction. Guarded so a caller that stamped its own value
+        // (or a retry re-entering this method) is left alone — and mirrored by the append
+        // operation, which persists this value instead of the column default whenever it is
+        // set, so what an inline projection folded is what a rebuild will read back.
+        // Round-tripped through the storage format up front: the column keeps milliseconds,
+        // so stamping raw ticks here would leave the inline view sub-millisecond ahead of
+        // every later read of the same event.
+        var timestamp = Fisher.Storage.SqliteTimestamp.FromDatabaseValue(
+            Fisher.Storage.SqliteTimestamp.ToDatabaseValue(_graph.TimeProvider.GetUtcNow()));
+
         foreach (var @event in stream.Events)
         {
+            if (@event.Timestamp == default)
+            {
+                @event.Timestamp = timestamp;
+            }
+
             if (_session.CorrelationIdEnabled)
             {
                 @event.CorrelationId ??= _session.CorrelationId;

--- a/src/Fisher/Events/Storage/FisherQuickAppendEventsOperation.cs
+++ b/src/Fisher/Events/Storage/FisherQuickAppendEventsOperation.cs
@@ -153,7 +153,17 @@ internal sealed class FisherQuickAppendEventsOperation
             Bind(builder, @event.EventTypeName, StorageColumnType.String);
 
             builder.Append(", ");
-            builder.Append(SqliteTimestamp.NowExpression);
+            if (@event.Timestamp != default)
+            {
+                // The value AppendPlanner.ApplySessionMetadata stamped before inline projections
+                // ran. Persisting it (rather than the server-side now) is what keeps the inline
+                // and replay views of e.Timestamp identical.
+                Bind(builder, SqliteTimestamp.ToDatabaseValue(@event.Timestamp), StorageColumnType.String);
+            }
+            else
+            {
+                builder.Append(SqliteTimestamp.NowExpression);
+            }
 
             builder.Append(", ");
             Bind(builder, @event.TenantId ?? Stream.TenantId, StorageColumnType.String);


### PR DESCRIPTION
## The problem

An inline projection reading `e.Timestamp` receives `DateTimeOffset.MinValue`. The envelope's `Timestamp` is only hydrated on read paths (`FisherEventsRowReader`, projection replay) — on the write path, the `fi_events.timestamp` column is filled by the SQL `now()` expression that `FisherQuickAppendEventsOperation` hardcodes, a value the in-memory event never carries.

Consequences:

- Every read model that records `e.Timestamp` inline bakes in year-0001 dates.
- The same projection produces **different documents inline vs rebuilt** (replay reads the correct column value), so the divergence is silent until someone looks at a date.
- Projection code ported from Marten breaks without changing: Marten stamps the envelope at append time, so `e.Timestamp` in `Evolve`/`Create` is an ordinary, documented pattern there.

We hit this in production-shaped testing during a Marten→Fisher migration — every date in the UI rendered as "Jan 1, 0001" (with the time-of-day showing the viewer's *ancient LMT* offset, which is how we knew the values were exactly `MinValue`).

## The fix

Two coordinated changes, mirroring how `Version` is already handled by `AssignVersionsAheadOfProjectionsAsync` ("so inline projections fold events that already know their versions" — `Timestamp` was the missing sibling):

1. **`AppendPlanner.ApplySessionMetadata`** stamps `Timestamp` from `EventGraph.TimeProvider` — one reading per stream (the events of one append share a moment the way they share a transaction), guarded with `== default` so caller-supplied values and retry re-entry are left alone. The value is round-tripped through `SqliteTimestamp`'s storage format up front, so the inline view is not sub-millisecond ahead of every later read of the same event.
2. **`FisherQuickAppendEventsOperation`** persists the stamped value instead of the column-default `now()` whenever it is set — which is what keeps the inline and replay views of `e.Timestamp` identical, tick for tick.

## Tests

Two new tests in `event_envelope_metadata_in_projections`, which already pins exactly this envelope-metadata contract (fisher#72) for `StreamKey`/`TenantId`/`Version`:

- `an_appended_event_carries_its_timestamp_into_an_inline_projection` — the inline-folded value is a real time, not the default
- `the_inline_timestamp_and_the_persisted_timestamp_agree` — what the inline projection saw is exactly what a rebuild will read back

Both fail against `main`; all 1322 Fisher.Tests (net9 + net10) plus the AspNetCore (36) and EntityFrameworkCore (19) suites pass with the fix.

Happy to adjust the approach if you'd rather hydrate elsewhere in the pipeline — the constraint we cared about is just: whatever an inline projection folds must match what replay reads.