### PR TITLE
TryCreateUsage describes the store's projections (#120)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2893,6 +2893,60 @@ Three SQLite-specific points:
 `ReadStreamMetadata` returns an **empty tag dictionary, not null**: the record declares `Tags`
 non-nullable, and returning null there is what polecat#412 was.
 
+#### What `TryCreateUsage` puts on the wire — fisher#120
+
+`projections list` rendered "No projections in this store." for a store with twenty registered, and
+`projections rebuild` matched none of them. The descriptor is where both of those answers come from,
+and Fisher never populated `EventStoreUsage.Subscriptions`.
+
+**The fix is one line — `Options.Projections.Describe(usage, this)` — and that is the uncomfortable
+part rather than the reassuring one.** Everything it fills was already built: `ProjectionGraph.Describe`
+is the shared implementation, and Fisher's two projection source types of its own
+(`CompositeIProjectionSource`, `FlatTableProjection`) already implemented `Describe`. Nothing about
+the gap was Fisher-specific, which is exactly why it survived — there was no dialect decision to
+prompt anybody to look.
+
+**The general rule this establishes: an unfilled slot on `EventStoreUsage` does not read as "this
+store does not describe that", it reads as *the store has none*.** Every member is a list or a
+nullable that starts empty, so the failure is silent in the one direction that matters — no
+exception, no warning, and a console rendering a confident, wrong answer. That is why the whole
+descriptor was audited alongside the reported member rather than the one line being added:
+
+- **Both event-type collections.** `Events` and `RegisteredEventTypes` are the same registry twice and
+  a consumer may read either. Filling one alone is polecat#411.
+- **`TagTypes` and `DcbTagTypes`**, off `EventGraph.TagTypes`. Fisher has DCB; the console had no way
+  to know.
+- **`ProjectionErrors` and `ProjectionRebuildErrors`** separately, because they differ — a rebuild
+  stops on an error a normal run skips, and a console reading one for the other offers "view related
+  dead letters" to a store that halts.
+- **`EventMetadata`**, whose four event flags are the opt-in `Enable*` options; every *stream* facet
+  is universal in Fisher, so those keep the capability defaults.
+- **`GlobalAggregates` and `DiscoveredDcbAggregates` stay empty, and that is the correct answer** —
+  Fisher registers no aggregate as global and has no `IDcbAggregateRegistry`. Worth saying, because
+  under the rule above an empty list is a claim rather than an omission.
+
+**`MaxEventSequence` is the one entry that means something different here than on either sibling.** It
+is the physical `max(seq_id)`, and the gap between it and the high-water mark is what CritterWatch#150's
+second signal renders. **On Fisher there can never be a gap** — one writer per file plus
+`BEGIN IMMEDIATE` makes committed sequences contiguous, which is the same fact that lets
+`FisherHighWaterDetector` skip gap detection entirely. So the signal cannot fire, and reporting the
+number is what lets a console establish that; leaving it null renders as "n/a" and says nothing.
+
+Two decisions in how it is read:
+
+- **A failed read costs the number, not the description.** The likeliest reason it fails is that the
+  schema does not exist yet, which is precisely when a monitoring tool is most likely to be pointed at
+  the store. `a_store_with_no_schema_still_describes_itself` pins that the method stays useful there.
+- **`Describe` is called last, as Polecat calls it.** It registers each subscription's included event
+  types on the event graph as a side effect, so calling it earlier would let those types into
+  `usage.Events` and make a diagnostics call's output depend on whether anything had asked before.
+
+**The shared suite cannot catch this class of gap for any store**, which is worth knowing before
+assuming compliance covers the descriptor: `EventStoreExplorerCompliance` asserts on `usage.Events`
+alone and returns early when the usage is null. `event_store_usage` is Fisher's own until that grows a
+sibling, and it asserts presence rather than shape for the reason above — all nine of its tests fail
+against the shipped 1.0.2 behaviour.
+
 ### LINQ
 
 Ported from Polecat, which owns `Polecat.Linq.SqlGeneration` itself rather than taking it from

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1377 tests green on net9.0 and net10.0**, with no known intermittent failures — 1322 in
+**1386 tests green on net9.0 and net10.0**, with no known intermittent failures — 1331 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 319 of
 them are shared cross-store compliance tests — 250 event sourcing, which as of 2.53.0 is every event
 suite the shared library has, and 69 document. On JasperFx **2.53.0** / Weasel **9.25.1**.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 37 suites and 319 tests** of `JasperFx.Events.ComplianceTests`, the shared
-> cross-store suite Marten and Polecat also enroll in, alongside its own 1,322.
+> cross-store suite Marten and Polecat also enroll in, alongside its own 1,331.
 >
 > 1.0 means the API is stable and the semantics above are settled — not that Fisher is
 > feature-complete against Marten. The gaps that remain are **decisions**, documented in

--- a/src/Fisher.Tests/Events/event_store_usage.cs
+++ b/src/Fisher.Tests/Events/event_store_usage.cs
@@ -1,0 +1,262 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Projections;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>
+///     What <c>IEventStore.TryCreateUsage</c> puts on the wire, which is the whole of what a monitoring
+///     tool and the shared JasperFx command line know about a Fisher store.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>fisher#120 is the reason this file exists, and the reason it asserts on presence rather
+///         than on shape.</b> Every slot on <see cref="EventStoreUsage" /> is a list or a nullable that
+///         starts empty, so a store that never fills one is indistinguishable from a store that has
+///         none of that thing — there is no exception, no warning, and nothing in the descriptor
+///         saying which of the two it is. That is how a store with twenty registered projections came
+///         to render as "No projections in this store." under <c>projections list</c> and to match
+///         nothing under <c>projections rebuild</c>.
+///     </para>
+///     <para>
+///         The shared <c>EventStoreExplorerCompliance</c> checks exactly one of these lists
+///         (<c>usage.Events</c>) and is explicit that a null usage is allowed, so it cannot catch this
+///         class of gap for any store. Until it grows a sibling, these are Fisher's own.
+///     </para>
+/// </remarks>
+public class event_store_usage : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("usage");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+
+            // Both lifecycles, because the failure mode fisher#120 reported was reachable by
+            // describing only the async half — a daemon-shaped implementation that walked the shards
+            // rather than the registrations would look right and still answer nothing for the store
+            // in the issue, whose twenty projections were all Inline.
+            options.Projections.Snapshot<SurveyTally>(SnapshotLifecycle.Inline);
+            options.Projections.Snapshot<ChartTally>(SnapshotLifecycle.Async);
+
+            options.Events.EnableCorrelationId = true;
+            options.Events.EnableUserName = true;
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using var session = _store.LightweightSession();
+        session.Events.StartStream<SurveyTally>(Guid.NewGuid(), new SurveyBegun("Astrolabe"), new ChartUpdated("Lisbon"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private async Task<EventStoreUsage> TheUsage()
+    {
+        var usage = await ((IEventStore)_store).TryCreateUsage(Token);
+        usage.ShouldNotBeNull();
+        return usage;
+    }
+
+    // ---- fisher#120 ----
+
+    /// <summary>
+    ///     The issue, reduced: an Inline projection has to reach the descriptor. This is the assertion
+    ///     that fails against the shipped 1.0.2 behaviour, where <c>Subscriptions</c> was never
+    ///     populated at all.
+    /// </summary>
+    [Fact]
+    public async Task an_inline_projection_is_described()
+    {
+        var usage = await TheUsage();
+
+        var described = usage.Subscriptions.SingleOrDefault(x => x.Name == nameof(SurveyTally));
+
+        described.ShouldNotBeNull();
+        described.Lifecycle.ShouldBe(ProjectionLifecycle.Inline);
+    }
+
+    /// <summary>
+    ///     The async half, which is what <c>projections rebuild</c> matches a target against — by name
+    ///     and then by shard.
+    /// </summary>
+    [Fact]
+    public async Task an_async_projection_is_described_with_its_shards()
+    {
+        var usage = await TheUsage();
+
+        var described = usage.Subscriptions.SingleOrDefault(x => x.Name == nameof(ChartTally));
+
+        described.ShouldNotBeNull();
+        described.Lifecycle.ShouldBe(ProjectionLifecycle.Async);
+        described.ShardNames.ShouldNotBeEmpty();
+    }
+
+    /// <summary>
+    ///     A rebuild target is resolved off the descriptor's <c>Name</c>, so the names on the wire have
+    ///     to be the names the daemon knows a projection by. Asserted against the store's own
+    ///     registry rather than against string literals, or the test would pin the convention rather
+    ///     than the agreement.
+    /// </summary>
+    [Fact]
+    public async Task the_described_names_are_the_names_the_store_registers()
+    {
+        var usage = await TheUsage();
+
+        var described = usage.Subscriptions.Select(x => x.Name).OrderBy(x => x).ToList();
+        var registered = _store.Options.Projections.All.Select(x => x.Name).OrderBy(x => x).ToList();
+
+        described.ShouldBe(registered);
+    }
+
+    // ---- the rest of the descriptor, gap-audited alongside fisher#120 ----
+
+    /// <summary>
+    ///     <see cref="EventStoreUsage" /> carries the event registry twice and a consumer may read
+    ///     either. Filling one and not the other is polecat#411, where the unfilled list read as "this
+    ///     store has no event types configured".
+    /// </summary>
+    [Fact]
+    public async Task both_event_type_collections_are_filled()
+    {
+        var usage = await TheUsage();
+
+        var alias = _store.Options.EventGraph.EventMappingFor(typeof(SurveyBegun)).EventTypeName;
+
+        usage.Events.Select(x => x.EventTypeName).ShouldContain(alias);
+        usage.RegisteredEventTypes.Select(x => x.Alias).ShouldContain(alias);
+    }
+
+    /// <summary>
+    ///     The two error policies are separate on purpose: a rebuild stops on an error a normal run
+    ///     would skip. A console reading one for the other offers "view related dead letters" for a
+    ///     store that halts instead, which is a button that never returns anything.
+    /// </summary>
+    [Fact]
+    public async Task both_projection_error_policies_are_described_and_are_distinct()
+    {
+        _store.Options.Projections.Errors.SkipApplyErrors = true;
+        _store.Options.Projections.RebuildErrors.SkipApplyErrors = false;
+
+        var usage = await TheUsage();
+
+        usage.ProjectionErrors.ShouldNotBeNull();
+        usage.ProjectionRebuildErrors.ShouldNotBeNull();
+
+        usage.ProjectionErrors.SkipApplyErrors.ShouldBeTrue();
+        usage.ProjectionRebuildErrors.SkipApplyErrors.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     jasperfx#475 — the four event metadata columns are opt-in, so a query facet built over one
+    ///     that is switched off would filter on a column the table does not have.
+    /// </summary>
+    [Fact]
+    public async Task the_opt_in_metadata_columns_are_reported_as_configured()
+    {
+        var usage = await TheUsage();
+
+        usage.EventMetadata.ShouldNotBeNull();
+        usage.EventMetadata.StoreType.ShouldBe("Fisher");
+
+        usage.EventMetadata.CorrelationId.ShouldBeTrue();
+        usage.EventMetadata.UserName.ShouldBeTrue();
+        usage.EventMetadata.CausationId.ShouldBeFalse();
+        usage.EventMetadata.Headers.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     Every stream facet is universal in Fisher — <c>fi_streams</c> always carries the aggregate
+    ///     type, the version, the timestamp, the tenant and the archived flag — so the capability
+    ///     defaults are correct rather than merely unset. Pinned because "left at the default" and
+    ///     "checked and true" are indistinguishable from the outside, and a later schema change that
+    ///     made one of them optional would need to say so here.
+    /// </summary>
+    [Fact]
+    public async Task every_stream_facet_is_reported_as_captured()
+    {
+        var usage = await TheUsage();
+
+        usage.EventMetadata.ShouldNotBeNull();
+        usage.EventMetadata.StreamAggregateType.ShouldBeTrue();
+        usage.EventMetadata.StreamVersion.ShouldBeTrue();
+        usage.EventMetadata.StreamTimestamps.ShouldBeTrue();
+        usage.EventMetadata.TenantId.ShouldBeTrue();
+        usage.EventMetadata.Archived.ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     <b>The Fisher-specific fact in this file.</b> The gap between the physical maximum and the
+    ///     high-water mark is what CritterWatch#150's second signal renders, and on Fisher there can
+    ///     never be one: one writer per file plus <c>BEGIN IMMEDIATE</c> means committed sequences are
+    ///     contiguous. Reporting the number is what lets a console see that; leaving it null renders
+    ///     as "n/a" and says nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task the_max_event_sequence_is_the_high_water_mark()
+    {
+        var usage = await TheUsage();
+
+        var highWater = await _store.Database.FetchHighestEventSequenceNumber(Token);
+
+        usage.MaxEventSequence.ShouldNotBeNull();
+        usage.MaxEventSequence.Value.ShouldBe(highWater);
+    }
+
+    /// <summary>
+    ///     A store pointed at before its schema exists is exactly when a monitoring tool is most likely
+    ///     to ask, so an unreadable sequence has to cost the optional number rather than the whole
+    ///     description.
+    /// </summary>
+    [Fact]
+    public async Task a_store_with_no_schema_still_describes_itself()
+    {
+        using var empty = TemporaryDatabase.Create("usage-noschema");
+        await using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = empty.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.None;
+            options.Projections.Snapshot<SurveyTally>(SnapshotLifecycle.Inline);
+        });
+
+        var usage = await ((IEventStore)store).TryCreateUsage(Token);
+
+        usage.ShouldNotBeNull();
+        usage.Subscriptions.ShouldNotBeEmpty();
+    }
+}
+
+public record SurveyBegun(string Ship);
+
+public record ChartUpdated(string Port);
+
+public class SurveyTally
+{
+    public Guid Id { get; set; }
+    public string Ship { get; set; } = string.Empty;
+    public int Ports { get; set; }
+
+    public void Apply(SurveyBegun begun) => Ship = begun.Ship;
+
+    public void Apply(ChartUpdated called) => Ports++;
+}
+
+public class ChartTally
+{
+    public Guid Id { get; set; }
+    public int Calls { get; set; }
+
+    public void Apply(ChartUpdated called) => Calls++;
+}

--- a/src/Fisher/DocumentStore.EventStore.cs
+++ b/src/Fisher/DocumentStore.EventStore.cs
@@ -180,11 +180,23 @@ public partial class DocumentStore : IEventStore
     ///     Describe this store's configuration for monitoring tools.
     /// </summary>
     /// <remarks>
-    ///     Built by hand rather than through <see cref="EventStoreUsage" />'s reflective constructor,
-    ///     which walks the subject's properties and would dump the store's runtime handles into the
-    ///     descriptor as if they were configuration.
+    ///     <para>
+    ///         Built by hand rather than through <see cref="EventStoreUsage" />'s reflective constructor,
+    ///         which walks the subject's properties and would dump the store's runtime handles into the
+    ///         descriptor as if they were configuration.
+    ///     </para>
+    ///     <para>
+    ///         <b>Building it by hand is why fisher#120 happened, and the shape of that bug is the reason
+    ///         to be exhaustive here rather than tidy.</b> An unfilled slot on this object is not read as
+    ///         "this store does not describe that" — it is read as <em>the store has none</em>. The
+    ///         missing <see cref="EventStoreUsage.Subscriptions" /> list made
+    ///         <c>projections list</c> answer "No projections in this store" for a store with twenty of
+    ///         them, and <c>projections rebuild</c> match none of them, with nothing anywhere reporting a
+    ///         gap. Every list below is populated for that reason, not because a consumer was known to
+    ///         want it.
+    ///     </para>
     /// </remarks>
-    Task<EventStoreUsage?> IEventStore.TryCreateUsage(CancellationToken token)
+    async Task<EventStoreUsage?> IEventStore.TryCreateUsage(CancellationToken token)
     {
         var usage = new EventStoreUsage
         {
@@ -207,12 +219,103 @@ public partial class DocumentStore : IEventStore
         // wire rather than guessing.
         usage.MaxConcurrentRebuildsPerDatabase = ResolveMaxConcurrentRebuilds();
 
+        // Both event-type collections, because EventStoreUsage carries the registry twice and a
+        // consumer is entitled to read either. Filling one alone is what polecat#411 was.
         foreach (var eventType in EventGraph.AllKnownEventTypes())
         {
             usage.Events.Add(new EventDescriptor(eventType.EventTypeName, TypeDescriptor.For(eventType.EventType)));
+
+            usage.RegisteredEventTypes.Add(new EventTypeDescriptor(
+                EventType: TypeDescriptor.For(eventType.EventType),
+                Alias: eventType.EventTypeName,
+                Description: null!));
         }
 
-        return Task.FromResult<EventStoreUsage?>(usage);
+        foreach (var registration in EventGraph.TagTypes)
+        {
+            usage.TagTypes.Add(new TagTypeDescriptor
+            {
+                TagType = registration.TagType.FullName ?? registration.TagType.Name,
+                SimpleType = registration.SimpleType.FullName ?? registration.SimpleType.Name,
+                TableSuffix = registration.TableSuffix,
+                AggregateType = registration.AggregateType?.FullName
+            });
+
+            usage.DcbTagTypes.Add(new DcbTagDescriptor(
+                Name: registration.TagType.Name,
+                SimpleType: registration.SimpleType.FullName ?? registration.SimpleType.Name,
+                TagType: TypeDescriptor.For(registration.TagType),
+                Description: null!));
+        }
+
+        // JasperFx/ProductSupport#3 — the two policies are separate because they differ: a rebuild
+        // stops on an error a normal run would skip, and a console showing "view related dead
+        // letters" for a store that halts instead offers a button that never returns anything.
+        usage.ProjectionErrors = ErrorPolicyFor(Options.Projections.Errors);
+        usage.ProjectionRebuildErrors = ErrorPolicyFor(Options.Projections.RebuildErrors);
+
+        // jasperfx#475 — the four event columns are opt-in and read straight off the options. Every
+        // stream facet is universal in Fisher, so those keep EventMetadataCapabilities' defaults.
+        usage.EventMetadata = new EventMetadataCapabilities
+        {
+            StoreType = "Fisher",
+            CorrelationId = Options.Events.EnableCorrelationId,
+            CausationId = Options.Events.EnableCausationId,
+            Headers = Options.Events.EnableHeaders,
+            UserName = Options.Events.EnableUserName
+        };
+
+        usage.MaxEventSequence = await TryReadMaxEventSequenceAsync(token).ConfigureAwait(false);
+
+        // fisher#120 — the line whose absence was the issue. Everything it fills is already built:
+        // ProjectionGraph.Describe walks the registered projections and subscriptions, and Fisher's
+        // two source types of its own (CompositeIProjectionSource, FlatTableProjection) implement
+        // Describe. Nothing here is Fisher-specific, which is exactly why it was easy to leave out.
+        Options.Projections.Describe(usage, this);
+
+        return usage;
+    }
+
+    private static ProjectionErrorHandlingDescriptor ErrorPolicyFor(ErrorHandlingOptions options)
+        => new()
+        {
+            SkipApplyErrors = options.SkipApplyErrors,
+            SkipUnknownEvents = options.SkipUnknownEvents,
+            SkipSerializationErrors = options.SkipSerializationErrors
+        };
+
+    /// <summary>
+    ///     The highest sequence physically present in <c>fi_events</c>, or null when it cannot be read.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>On Fisher this is always equal to the high-water mark, and that is worth stating
+    ///         rather than leaving a consumer to infer it.</b> The gap between the two is what
+    ///         CritterWatch#150's second signal renders — a sequence issued but not yet safe to read —
+    ///         and on Marten and Polecat it is real, because a server-side sequence or IDENTITY hands
+    ///         out numbers outside the transaction. SQLite allows one writer per file and
+    ///         <c>BEGIN IMMEDIATE</c> commits a transaction's sequences before the next writer
+    ///         allocates any, so committed sequences are contiguous and the signal cannot fire here.
+    ///         Reporting the number anyway is what lets a console see that, where leaving it null
+    ///         renders as "n/a" and says nothing.
+    ///     </para>
+    ///     <para>
+    ///         A failure is swallowed rather than propagated: this is a diagnostics call, and the most
+    ///         likely reason the read fails is that the schema has not been created yet — which is
+    ///         precisely when a monitoring tool is most likely to be pointed at the store. Failing the
+    ///         whole description over one optional number would answer nothing at all.
+    ///     </para>
+    /// </remarks>
+    private async Task<long?> TryReadMaxEventSequenceAsync(CancellationToken token)
+    {
+        try
+        {
+            return await Database.FetchHighestEventSequenceNumber(token).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #120.

## The bug

`usage.Subscriptions` is what `ConsoleView.ListShards` renders and what `projections rebuild` matches a target against. Fisher never populated it, so the shared JasperFx command line was blind to every registered projection — `projections list` answered "No projections in this store." for a store with twenty, and `rebuild` matched none of them. Anything else consuming `EventStoreUsage`, CritterWatch included, saw the same.

The reporter's diagnosis was exact, including that the building blocks were already there.

## The fix, and why it is not reassuring that it is one line

`Options.Projections.Describe(usage, this)`. `ProjectionGraph.Describe` is the shared implementation and Fisher's two projection source types of its own — `CompositeIProjectionSource`, `FlatTableProjection` — already implemented `Describe`. `SubscriptionDescriptor` guards its only async-specific block, so Inline registrations describe correctly with no special casing.

Nothing about the gap was dialect-specific, which is exactly why it survived: there was no SQLite decision anywhere to prompt somebody to look at the method.

## Why the whole descriptor is audited here

**Every member of `EventStoreUsage` is a list or a nullable that starts empty**, so an unfilled slot does not read as "this store does not describe that" — it reads as *the store has none*. No exception, no warning, and a console renders a confident wrong answer. Fisher was filling 6 of ~16 slots while holding real data for most of the rest, so fixing only the reported one would have left the same failure mode in place for everything else.

Now populated:

| Slot | Source |
|---|---|
| `Subscriptions` | the reported gap |
| `RegisteredEventTypes` | same registry as `Events`; filling one alone is polecat#411 |
| `TagTypes` / `DcbTagTypes` | `EventGraph.TagTypes` — Fisher has DCB and the console had no way to know |
| `ProjectionErrors` / `ProjectionRebuildErrors` | separately, because they differ |
| `EventMetadata` | the opt-in `Enable*` flags; stream facets keep the defaults, all universal here |
| `MaxEventSequence` | `max(seq_id)` |

`GlobalAggregates` and `DiscoveredDcbAggregates` stay empty — Fisher registers no global aggregate and has no `IDcbAggregateRegistry`. Under the rule above that is a claim rather than an omission, so it is stated in CLAUDE.md rather than left looking like more of the same bug.

## The one entry that means something different on Fisher

`MaxEventSequence` exists so a consumer can render the gap between it and the high-water mark — CritterWatch#150's second signal, "HWM is behind the actual max event sequence". **On Fisher there can never be a gap**: one writer per file plus `BEGIN IMMEDIATE` makes committed sequences contiguous, which is the same fact that lets `FisherHighWaterDetector` skip gap detection entirely. Reporting the number is what lets a console establish that; leaving it null renders as "n/a" and says nothing.

Two decisions in how it is read:

- **A failed read costs the number, not the description.** The likeliest cause is a schema that does not exist yet, which is precisely when a monitoring tool is most likely to be pointed at the store.
- **`Describe` is called last**, matching Polecat. It registers each subscription's included event types on the graph as a side effect, so calling it earlier would let those into `usage.Events` and make a diagnostics call's output depend on whether anything had asked before.

## Tests

Nine in `event_store_usage`, **all nine of which fail against the shipped behaviour** (verified by stashing the production change). They assert presence rather than shape, for the reason above.

The shared suite cannot catch this class of gap for any store — `EventStoreExplorerCompliance.usage_describes_the_registered_event_types` asserts on `usage.Events` alone and returns early when the usage is null. Worth a sibling upstream.

## Not addressed here

The issue's side observation — two projections publishing the same document type, where rebuilding either wipes the other's rows — is real and reproduces in `TeardownExistingProjectionStateAsync`, which deletes the whole published table. It is a separate concern from the descriptor and is getting its own issue rather than being folded in.

## Verification

Full suite green on both TFMs: 1331 + 36 + 19 = **1386**. `check_scoreboard.py` reproduced locally against real TRX output and reports agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)