### PR TITLE
JasperFx 2.56.0 and Weasel 9.27.0 (#125)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3290,13 +3290,24 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**Fisher is enrolled, in full — all 36 suites, 309 tests, as of 2.51.0.**
+**Fisher is enrolled, in full — all 37 suites, 320 tests, as of 2.56.0.**
 `JasperFx.Events.ComplianceTests` is referenced unconditionally — the old `$(EnableComplianceTests)`
 gate is gone. The most recently enrolled are `BinaryEventSerializationCompliance` (6, the event half's
 twenty-ninth) and `DocumentSessionEventsCompliance` (5) from 2.50.0, and 2.51.0's two:
 `PendingStreamActionsCompliance` (9, fisher#96) and `AggregateWriteCacheCompliance` (14, fisher#97).
 All four are **opt-in** — their contract members carry throwing defaults, so enrolling is a deliberate
 line rather than something a bump does to you.
+
+**2.52.0 added the 37th suite and 2.56.0 the 320th test, and nothing between them moved.**
+`DocumentCommitListenerCompliance` (10) is the document half's seventh; 2.52.1, 2.53.0, 2.54.0 and
+2.55.0 changed no suite file at all. 2.56.0 added one test —
+`EventStoreExplorerCompliance.usage_describes_the_registered_projections`, jasperfx#700 — which is
+**fisher#120's regression guard, and shared rather than Fisher-local on purpose**: `TryCreateUsage`
+had one shared test asserting on `usage.Events` alone, so a store could fill that slot, leave the
+rest of `EventStoreUsage` empty and still pass the suite. Nothing about the omission was
+dialect-specific, so no store-level decision existed to prompt anybody to look. Fisher passed it
+unchanged on the bump — see "What `TryCreateUsage` puts on the wire" for the one-line fix it holds
+in place.
 
 2.51.0's third change is fisher#98 and is fixture-side: `DocumentComplianceConfig.StreamIdentity`
 (jasperfx#672) replaced an inference `FisherDocumentComplianceFixture` was making — string identity

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,20 +7,20 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.53.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.53.0" />
+        <PackageVersion Include="JasperFx" Version="2.56.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.56.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.53.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.53.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.56.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.56.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage
              runtime extracted from Marten, which Fisher plugs a SQLite dialect into rather than
              hand-writing storage. -->
-        <PackageVersion Include="Weasel.Sqlite" Version="9.25.1" />
-        <PackageVersion Include="Weasel.Storage" Version="9.25.1" />
+        <PackageVersion Include="Weasel.Sqlite" Version="9.27.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.27.0" />
 
         <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
         <!-- Override the transitive SQLitePCLRaw 2.1.11 (vulnerable native lib,

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,10 +12,10 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1386 tests green on net9.0 and net10.0**, with no known intermittent failures — 1331 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 319 of
-them are shared cross-store compliance tests — 250 event sourcing, which as of 2.53.0 is every event
-suite the shared library has, and 69 document. On JasperFx **2.53.0** / Weasel **9.25.1**.
+**1387 tests green on net9.0 and net10.0**, with no known intermittent failures — 1332 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 320 of
+them are shared cross-store compliance tests — 251 event sourcing, which as of 2.56.0 is every event
+suite the shared library has, and 69 document. On JasperFx **2.56.0** / Weasel **9.27.0**.
 
 ## Closed since the comparison
 
@@ -452,17 +452,32 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.53.0 ships **37 suites, 319 tests**. Fisher passes **all 319, all
-37 suites**. Every suite compiles; every one is also subclassed and running. 2.53.0 changed no suite
-file and added no test — verified against a run rather than by diffing the file list, which is the
-lesson 2.49.0 taught.
+`JasperFx.Events.ComplianceTests` 2.56.0 ships **37 suites, 320 tests**. Fisher passes **all 320, all
+37 suites**. Every suite compiles; every one is also subclassed and running.
+
+**The bump crossed three releases and the whole compliance delta is one test.** 2.54.0 and 2.55.0
+changed no suite file; 2.56.0 added `usage_describes_the_registered_projections` to
+`EventStoreExplorerCompliance`, taking it from 6 to 7 and the event half from 250 to 251. No suite
+was added, no seam member was needed — `ComplianceStoreConfig` and `IComplianceStoreRegistrar` are
+byte-identical across the three, and the suite registers its `VoyageSnapshot` through the
+`config.Snapshot<T>(SnapshotLifecycle.Inline)` that was already there.
+
+**That one test is fisher#120's regression guard, and it is worth knowing why it is shared rather
+than Fisher's** (jasperfx#700). `TryCreateUsage` had exactly one shared test and it asserted on
+`usage.Events` alone, so a store could fill that list, leave every other slot on `EventStoreUsage`
+empty, and pass the whole suite — which is what Fisher did for several releases, describing none of
+its twenty registered projections to `projections list`, `projections rebuild` or CritterWatch.
+Nothing about the omission was dialect-specific, so there was no store-level decision anywhere to
+prompt somebody to look. It is registered **Inline** on purpose: an implementation describing the
+daemon's shards rather than the registrations would look correct and still answer nothing for an
+inline-only store, which is exactly the shape that went unreported.
 
 **2.49.0 added no suite file and still required production work**, which is the first bump of that
 shape: `DocumentLoadAndStoreCompliance` gained three tests for `LoadAsync<T>(object)` (jasperfx#665 /
 fisher#89) and `DocumentComplianceConfig` gained `ValueTypes`. Diffing the suite *list* would have
 reported a clean bump — diff the contents.
 
-The library is now two halves. The **event sourcing** half is 30 suites and 250 tests, and its
+The library is now two halves. The **event sourcing** half is 30 suites and 251 tests, and its
 upstream backlog has been empty since 2.45.0 — that is the whole of it rather than a snapshot. The
 **document** half arrived in 2.47.0 (jasperfx#647) and is now seven suites, 69 tests, over the
 store-agnostic document contract Fisher implements for fisher#68. Every suite added since 2.49.0 has
@@ -502,9 +517,9 @@ and `Query<T>` were already `notnull`. See "The store-agnostic document contract
 **Green on all thirty-seven is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 37 suites, 319 tests
+### Green — 37 suites, 320 tests
 
-Event sourcing — 30 suites, 250 tests:
+Event sourcing — 30 suites, 251 tests:
 
 | Suite | Tests |
 |---|---|
@@ -524,10 +539,10 @@ Event sourcing — 30 suites, 250 tests:
 | `ConjoinedEventTenancyCompliance` | 8 |
 | `FetchLatestCompliance` | 7 |
 | `LiveAggregationCompliance` | 7 |
+| `EventStoreExplorerCompliance` | 7 |
 | `StringIdentitySingleStreamCompliance` | 6 |
 | `StreamArchivingCompliance` | 6 |
 | `SnapshotLifecycleCompliance` | 6 |
-| `EventStoreExplorerCompliance` | 6 |
 | `AssignTagWhereCompliance` | 6 |
 | `BinaryEventSerializationCompliance` | 6 |
 | `DeadLetterCompliance` | 6 |

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 37 suites and 319 tests** of `JasperFx.Events.ComplianceTests`, the shared
-> cross-store suite Marten and Polecat also enroll in, alongside its own 1,331.
+> Fisher passes **all 37 suites and 320 tests** of `JasperFx.Events.ComplianceTests`, the shared
+> cross-store suite Marten and Polecat also enroll in, alongside its own 1,332.
 >
 > 1.0 means the API is stable and the semantics above are settled — not that Fisher is
 > feature-complete against Marten. The gaps that remain are **decisions**, documented in

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -9,7 +9,7 @@ namespace Fisher.Tests.Compliance;
  * these tests cannot drift between the products.
  *
  * Suites were added one at a time as Fisher grew into them. All thirty-seven that ship in
- * JasperFx.Events.ComplianceTests 2.53.0 are enrolled; there is no suite Fisher declines.
+ * JasperFx.Events.ComplianceTests 2.56.0 are enrolled; there is no suite Fisher declines.
  *
  * Nothing in the fixture throws any more, but the discipline stands for the next seam member that
  * arrives ahead of the feature: a member Fisher cannot honour throws a NotSupportedException naming


### PR DESCRIPTION
Closes #125.

The bump crosses three JasperFx releases and **the entire compliance delta is one test.** 2.54.0 and 2.55.0 changed no suite file; 2.56.0 adds `EventStoreExplorerCompliance.usage_describes_the_registered_projections` (JasperFx/jasperfx#700), taking that suite from 6 to 7, the event half from 250 to 251 and the library from 319 to 320.

Fisher passes it unchanged, which is the point of the bump rather than an aside: that test is #120's regression guard. `TryCreateUsage` had exactly one shared test and it asserted on `usage.Events` alone, so a store could fill that slot, leave the rest of `EventStoreUsage` empty and still pass the whole suite — which Fisher did for several releases, describing none of its twenty registered projections. It is registered **Inline** on purpose: an implementation describing the daemon's shards rather than the registrations would look correct and still answer nothing for an inline-only store.

**No seam member was needed.** `ComplianceStoreConfig` and `IComplianceStoreRegistrar` are byte-identical across all three releases, and the suite registers its `VoyageSnapshot` through the `config.Snapshot<T>(SnapshotLifecycle.Inline)` that was already there. On the core side the public surface delta is confined to `JasperFx.Events.EventModeling`, which Fisher references nowhere, and additive `TestSupport.ProjectionScenario` members.

**Weasel moves with it**, as the pin comment says it must: 9.25.1 → 9.27.0. Weasel.Storage 9.27.0 floors JasperFx.Events at 2.46.0, satisfied here.

### The two Fisher-local tests the issue flagged are kept

The issue asked whether `event_store_usage.cs` and `event_store_explorer.cs` are now redundant. They are not:

- `an_inline_projection_is_described` also asserts the **lifecycle**, which the shared test does not.
- `usage_reports_the_event_types_the_store_knows` resolves its expected names through Fisher's own `EventGraph` aliases.

Both assert something the shared suite does not, so deleting either would trade real coverage for tidiness.

### Docs

`CLAUDE.md`'s compliance section had stopped at 2.51.0 and understated the library by a suite and eleven tests. It now reconciles with `HANDOFF.md` — 2.52.0 added the 37th suite (`DocumentCommitListenerCompliance`, 10 tests) and nothing between then and 2.56.0 moved.

---

**1387 green on net9.0 and net10.0**, `scripts/check_scoreboard.py` agreeing on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)