### PR TITLE
Warn when a rebuild will clear a table another projection publishes into (#122)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1393 tests green on net9.0 and net10.0**, with no known intermittent failures — 1338 in
+**1398 tests green on net9.0 and net10.0**, with no known intermittent failures — 1343 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 320 of
 them are shared cross-store compliance tests — 251 event sourcing, which as of 2.56.0 is every event
 suite the shared library has, and 69 document. On JasperFx **2.56.0** / Weasel **9.27.0**.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 37 suites and 320 tests** of `JasperFx.Events.ComplianceTests`, the shared
-> cross-store suite Marten and Polecat also enroll in, alongside its own 1,338.
+> cross-store suite Marten and Polecat also enroll in, alongside its own 1,343.
 >
 > 1.0 means the API is stable and the semantics above are settled — not that Fisher is
 > feature-complete against Marten. The gaps that remain are **decisions**, documented in

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -143,6 +143,38 @@ Test a rebuild with a row the replay **cannot** recreate. A replay rewrites ever
 produce, so a broken teardown is invisible against live data.
 :::
 
+### Two projections publishing one document type
+
+Teardown clears **the whole of** every table the named projection publishes into. Two projections
+that publish the same document type share one `fi_doc_*` table, so rebuilding either one deletes
+**both** projections' rows — and the rebuild then replays only the projection it was asked for. The
+rebuild succeeds, the rebuilt projection is correct, and the other read model is left empty.
+
+Marten behaves the same way. Fisher warns about it at rebuild time, naming the table and the other
+projections that write into it:
+
+```
+warn: Rebuilding projection LandedTally will clear 1 table(s) that another registered projection
+      also publishes into: fi_doc_tally is also published by ReleasedTally. ...
+```
+
+::: danger
+**Rebuilding the other projection afterwards does not fix it.** There is no operation that rebuilds
+two projections together — every `RebuildProjectionAsync` overload names one — so a second rebuild
+clears the shared table *again* and discards what the first one wrote. Only the projection rebuilt
+last keeps its rows.
+
+Rewind instead. `RewindSubscriptionAsync` replays a projection onto the rows that are already there
+rather than clearing first:
+
+```cs
+await daemon.RewindSubscriptionAsync("ReleasedTally", token, sequenceFloor: 0);
+```
+:::
+
+Sharing a published type between two projections is legal and costs nothing until somebody rebuilds,
+so Fisher warns rather than refusing.
+
 ## Catching up and waiting
 
 ```cs

--- a/src/Fisher.Tests/Events/shared_published_table_rebuild.cs
+++ b/src/Fisher.Tests/Events/shared_published_table_rebuild.cs
@@ -1,0 +1,319 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>
+///     Two projections publishing one document type, and what a rebuild of either does to the other —
+///     fisher#122, reported during a Marten to Fisher migration.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>The behaviour is by design and is not changed here.</b> Teardown deletes the whole of
+///         every table the named projection publishes into and the rebuild then replays only that
+///         projection, so a shared <c>fi_doc_*</c> table loses the other projection's rows.
+///         <b>Marten behaves identically.</b> What was missing is that nothing said so: the rebuild
+///         succeeds, the rebuilt projection is correct, and the damage is to a read model nobody is
+///         looking at.
+///     </para>
+///     <para>
+///         So the first test below <em>documents the loss</em> rather than asserting against it, and
+///         the rest are about the warning. Changing the semantics would break a configuration that
+///         works fine as long as both projections are rebuilt together, which is a real way to run
+///         this — see <c>DocumentStore.WarnAboutTablesSharedWithAnotherProjection</c>.
+///     </para>
+///     <para>
+///         <b>Same family as the teardown gaps #63 and the flat-table <c>IPublishesTables</c> work, and
+///         the opposite direction.</b> Those were the sweep clearing too little; this is it clearing
+///         too much. Both are "what gets cleared does not match what gets rewritten".
+///     </para>
+/// </remarks>
+public class shared_published_table_rebuild : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("shared-teardown");
+    private DocumentStore _store = null!;
+    private readonly RecordingLogger _logger = new();
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(o =>
+        {
+            o.ConnectionString = _database.ConnectionString;
+            o.AutoCreateSchemaObjects = AutoCreate.All;
+
+            o.Schema.For<Tally>();
+
+            // Both publish Tally, so both write into fi_doc_tally.
+            o.Projections.Add(new LandedTally(), ProjectionLifecycle.Async);
+            o.Projections.Add(new ReleasedTally(), ProjectionLifecycle.Async);
+
+            // Publishes a type of its own, so the warning has a negative case to be silent about.
+            o.Projections.Add(new BoatLog(), ProjectionLifecycle.Async);
+            o.Schema.For<Boat>();
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private async Task<(Guid Landed, Guid Released)> SeedAsync()
+    {
+        var landed = Guid.NewGuid();
+        var released = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream(landed, new Landed("Trout"));
+            session.Events.StartStream(released, new Released("Pike"));
+            await session.SaveChangesAsync(Token);
+        }
+
+        using var daemon = await _store.BuildProjectionDaemonAsync(logger: _logger);
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(TimeSpan.FromSeconds(20));
+
+        return (landed, released);
+    }
+
+    private async Task RebuildAsync(string projectionName)
+    {
+        using var daemon = await _store.BuildProjectionDaemonAsync(logger: _logger);
+        await daemon.RebuildProjectionAsync(projectionName, TimeSpan.FromSeconds(30), Token);
+    }
+
+    /// <summary>
+    ///     The reported behaviour, reproduced. Rebuilding one projection leaves the other's row gone —
+    ///     and the rebuild reports success.
+    /// </summary>
+    [Fact]
+    public async Task rebuilding_one_projection_clears_the_rows_of_another_sharing_its_table()
+    {
+        var (landed, released) = await SeedAsync();
+
+        await using (var before = _store.LightweightSession())
+        {
+            (await before.LoadAsync<Tally>(landed, Token)).ShouldNotBeNull();
+            (await before.LoadAsync<Tally>(released, Token)).ShouldNotBeNull();
+        }
+
+        await RebuildAsync(nameof(LandedTally));
+
+        await using var after = _store.LightweightSession();
+
+        // The rebuilt projection is correct.
+        (await after.LoadAsync<Tally>(landed, Token)).ShouldNotBeNull().Count.ShouldBe(1);
+
+        // The other one's row is gone. Documented, not asserted against -- changing this would break
+        // a configuration that works when both are rebuilt together.
+        (await after.LoadAsync<Tally>(released, Token)).ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     The point of fisher#122: the operator is told, at the moment they are present and the
+    ///     information is actionable.
+    /// </summary>
+    [Fact]
+    public async Task the_rebuild_warns_and_names_the_other_projection()
+    {
+        await SeedAsync();
+        _logger.Warnings.Clear();
+
+        await RebuildAsync(nameof(LandedTally));
+
+        var warning = _logger.Warnings.ShouldHaveSingleItem();
+
+        warning.ShouldContain("fi_doc_tally");
+        warning.ShouldContain(nameof(ReleasedTally));
+        warning.ShouldContain(nameof(LandedTally));
+
+        // The projection that shares nothing must not be dragged in.
+        warning.ShouldNotContain(nameof(BoatLog));
+    }
+
+    /// <summary>
+    ///     <b>Rebuilding each in turn does not restore both, and that is the sharp edge.</b>
+    /// </summary>
+    /// <remarks>
+    ///     The obvious remedy — and the one fisher#122 and its reporter both assumed — is to rebuild
+    ///     the sharing projections together. There is no such operation: every
+    ///     <c>RebuildProjectionAsync</c> overload names one projection or one type, so "together"
+    ///     means "one after the other", and the second rebuild's teardown clears the whole shared
+    ///     table again, discarding what the first rebuild just wrote. The end state has only the
+    ///     projection rebuilt last.
+    /// </remarks>
+    [Fact]
+    public async Task rebuilding_each_in_turn_still_leaves_one_of_them_empty()
+    {
+        var (landed, released) = await SeedAsync();
+
+        await RebuildAsync(nameof(LandedTally));
+        await RebuildAsync(nameof(ReleasedTally));
+
+        await using var after = _store.LightweightSession();
+
+        (await after.LoadAsync<Tally>(released, Token)).ShouldNotBeNull().Count.ShouldBe(1);
+        (await after.LoadAsync<Tally>(landed, Token)).ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     <b>A rewind is the remedy, because it replays without a teardown.</b>
+    /// </summary>
+    /// <remarks>
+    ///     <c>RewindSubscriptionAsync</c> moves a projection's progression back and lets it replay onto
+    ///     the rows that are there, where a rebuild clears first. That is exactly what the projection
+    ///     collaterally emptied above needs, and it is what the warning should send an operator to —
+    ///     "rebuild them together" is advice that cannot be followed.
+    /// </remarks>
+    [Fact]
+    public async Task rewinding_the_collaterally_emptied_projection_restores_it()
+    {
+        var (landed, released) = await SeedAsync();
+
+        await RebuildAsync(nameof(LandedTally));
+
+        using (var daemon = await _store.BuildProjectionDaemonAsync(logger: _logger))
+        {
+            await daemon.StartAllAsync();
+            await daemon.RewindSubscriptionAsync(nameof(ReleasedTally), Token, sequenceFloor: 0);
+            await daemon.WaitForNonStaleData(TimeSpan.FromSeconds(20));
+        }
+
+        await using var after = _store.LightweightSession();
+
+        (await after.LoadAsync<Tally>(landed, Token)).ShouldNotBeNull().Count.ShouldBe(1);
+        (await after.LoadAsync<Tally>(released, Token)).ShouldNotBeNull().Count.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     A projection whose table nothing else publishes into says nothing. Without this the warning
+    ///     could be unconditional and every test above would still pass.
+    /// </summary>
+    [Fact]
+    public async Task a_projection_that_shares_no_table_does_not_warn()
+    {
+        await SeedAsync();
+        _logger.Warnings.Clear();
+
+        await RebuildAsync(nameof(BoatLog));
+
+        _logger.Warnings.ShouldBeEmpty();
+    }
+
+    // ---- fixtures ----
+
+    public record Landed(string Species);
+
+    public record Released(string Species);
+
+    public class Tally
+    {
+        public Guid Id { get; set; }
+        public int Count { get; set; }
+    }
+
+    public class Boat
+    {
+        public Guid Id { get; set; }
+        public int Trips { get; set; }
+    }
+
+    /// <summary>
+    ///     Bare <c>IProjection</c>s over <c>ProjectionBase</c> rather than conventional
+    ///     <c>EventProjection</c>s, so the dispatcher source generator is not involved and the
+    ///     published type is declared outright — which is what <c>PublishedTableNamesFor</c> reads.
+    /// </summary>
+    public class LandedTally : ProjectionBase, Fisher.Projections.IProjection
+    {
+        public LandedTally()
+        {
+            Name = nameof(LandedTally);
+            Options.DeleteViewTypeOnTeardown<Tally>();
+        }
+
+        public Task ApplyAsync(IDocumentSession operations, IReadOnlyList<IEvent> events,
+            CancellationToken cancellation)
+        {
+            foreach (var e in events.Where(x => x.Data is Landed))
+            {
+                operations.Store(new Tally { Id = e.StreamId, Count = 1 });
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public class ReleasedTally : ProjectionBase, Fisher.Projections.IProjection
+    {
+        public ReleasedTally()
+        {
+            Name = nameof(ReleasedTally);
+            Options.DeleteViewTypeOnTeardown<Tally>();
+        }
+
+        public Task ApplyAsync(IDocumentSession operations, IReadOnlyList<IEvent> events,
+            CancellationToken cancellation)
+        {
+            foreach (var e in events.Where(x => x.Data is Released))
+            {
+                operations.Store(new Tally { Id = e.StreamId, Count = 1 });
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>Publishes a type of its own, so the warning has a negative case.</summary>
+    public class BoatLog : ProjectionBase, Fisher.Projections.IProjection
+    {
+        public BoatLog()
+        {
+            Name = nameof(BoatLog);
+            Options.DeleteViewTypeOnTeardown<Boat>();
+        }
+
+        public Task ApplyAsync(IDocumentSession operations, IReadOnlyList<IEvent> events,
+            CancellationToken cancellation)
+        {
+            foreach (var e in events.Where(x => x.Data is Landed))
+            {
+                operations.Store(new Boat { Id = e.StreamId, Trips = 1 });
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    ///     Captures warnings only. A real <c>ILoggerFactory</c> would work; this keeps the assertion
+    ///     about the message rather than about logging infrastructure.
+    /// </summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<string> Warnings { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                lock (Warnings)
+                {
+                    Warnings.Add(formatter(state, exception));
+                }
+            }
+        }
+    }
+}

--- a/src/Fisher/DocumentStore.Daemon.cs
+++ b/src/Fisher/DocumentStore.Daemon.cs
@@ -209,6 +209,10 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         var tables = PublishedTableNamesFor(subscriptionName);
         var target = DatabaseFrom(database);
 
+        // Outside the resilience pipeline below, so a retried SQLITE_BUSY does not warn twice about
+        // one rebuild -- the same reason every other once-per-unit-of-work step sits outside it.
+        WarnAboutTablesSharedWithAnotherProjection(subscriptionName, tables);
+
         await Options.ResiliencePipeline.ExecuteAsync(async ct =>
         {
             await using var connection = await target.OpenConnectionAsync(ct).ConfigureAwait(false);
@@ -246,6 +250,98 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
     }
 
     /// <summary>
+    ///     Warn when a rebuild is about to clear a table another registered projection also writes to
+    ///     (fisher#122).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Teardown deletes <em>the whole of</em> every table the named projection publishes into,
+    ///         and then the rebuild replays only that projection. So when two projections publish the
+    ///         same document type they share one <c>fi_doc_*</c> table, and rebuilding either wipes
+    ///         both — the rebuilt one is correct and the other's rows are simply gone until it too is
+    ///         rebuilt. Nothing errors, the rebuild reports success, and the damage is to a read model
+    ///         nobody is looking at.
+    ///     </para>
+    ///     <para>
+    ///         <b>This is a warning and not a refusal, deliberately.</b> Sharing a published type is
+    ///         legal and sometimes intended — it is only rebuilding that costs anything, and a store
+    ///         that never rebuilds runs this configuration perfectly well. Refusing would break it;
+    ///         saying nothing is what cost the reporter a debugging session.
+    ///     </para>
+    ///     <para>
+    ///         <b>The message sends the operator to a rewind, not to a second rebuild, and that
+    ///         correction came out of writing the test.</b> fisher#122 and its reporter both assumed
+    ///         "rebuild them together" was the remedy. There is no such operation — every
+    ///         <c>RebuildProjectionAsync</c> overload names one projection — so "together" means one
+    ///         after the other, and the second teardown clears the shared table again and discards what
+    ///         the first rebuild wrote. Only the projection rebuilt last keeps its rows.
+    ///         <c>RewindSubscriptionAsync</c> is what actually works, because it replays onto the rows
+    ///         that are there instead of clearing first.
+    ///         <c>shared_published_table_rebuild.rebuilding_each_in_turn_still_leaves_one_of_them_empty</c>
+    ///         pins the wrong advice as wrong.
+    ///     </para>
+    ///     <para>
+    ///         <b>And it is at rebuild time rather than at registration.</b> A registration-time warning
+    ///         fires on every boot about something that only matters when somebody rebuilds. Here the
+    ///         operator is present, the information is actionable, and the other projections can be
+    ///         named.
+    ///     </para>
+    ///     <para>
+    ///         <b>Marten behaves identically</b>, so this is not a Fisher divergence and the semantics
+    ///         are unchanged. What is added is that the store now says so.
+    ///     </para>
+    /// </remarks>
+    private void WarnAboutTablesSharedWithAnotherProjection(string subscriptionName, IReadOnlyList<string> tables)
+    {
+        if (tables.Count == 0)
+        {
+            return;
+        }
+
+        var mine = new HashSet<string>(tables, StringComparer.OrdinalIgnoreCase);
+
+        // Grouped by table rather than by projection, because the table is the thing being cleared and
+        // one projection may share more than one of them.
+        var shared = new SortedDictionary<string, SortedSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var other in Options.Projections.All)
+        {
+            if (other.Name == subscriptionName)
+            {
+                continue;
+            }
+
+            foreach (var table in PublishedTableNamesFor(other).Where(mine.Contains))
+            {
+                if (!shared.TryGetValue(table, out var names))
+                {
+                    shared[table] = names = new SortedSet<string>(StringComparer.Ordinal);
+                }
+
+                names.Add(other.Name);
+            }
+        }
+
+        if (shared.Count == 0)
+        {
+            return;
+        }
+
+        var detail = string.Join("; ",
+            shared.Select(pair => $"{pair.Key} is also published by {string.Join(", ", pair.Value)}"));
+
+        _daemonLogger.LogWarning(
+            "Rebuilding projection {Projection} will clear {TableCount} table(s) that another registered "
+            + "projection also publishes into: {Detail}. Teardown deletes the whole table and the rebuild "
+            + "replays only {Projection}, so the other projection(s) will be left with no rows. Rebuilding "
+            + "them afterwards does NOT fix it -- each rebuild clears the shared table again, so only the "
+            + "one rebuilt last keeps its rows. Rewind them instead: "
+            + "daemon.RewindSubscriptionAsync(name, token, sequenceFloor: 0) replays a projection onto the "
+            + "rows that are there rather than clearing first.",
+            subscriptionName, shared.Count, detail, subscriptionName);
+    }
+
+    /// <summary>
     ///     The unquoted tables a projection publishes into.
     /// </summary>
     /// <remarks>
@@ -255,12 +351,13 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
     ///     the rows the previous run left behind.
     /// </remarks>
     private IReadOnlyList<string> PublishedTableNamesFor(string subscriptionName)
-    {
-        if (!Options.Projections.TryFindProjection(subscriptionName, out var source))
-        {
-            return [];
-        }
+        => Options.Projections.TryFindProjection(subscriptionName, out var source)
+            ? PublishedTableNamesFor(source!)
+            : [];
 
+    private IReadOnlyList<string> PublishedTableNamesFor(
+        IProjectionSource<IDocumentSession, IQuerySession> source)
+    {
         var tables = source.PublishedTypes()
             .Where(Options.Schema.HasMappingFor)
             .Select(x => Options.Schema.MappingFor(x).TableName.Name)
@@ -412,8 +509,31 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         return daemons;
     }
 
+    /// <summary>
+    ///     The logger the most recently built daemon was given, so a rebuild has somewhere to warn.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Stashed rather than passed, because the seam has no parameter for it.</b>
+    ///         <c>TeardownExistingProjectionStateAsync</c> is on <see cref="IEventStore{T,TQ}" />, which
+    ///         is JasperFx's interface and takes an <see cref="IEventDatabase" /> and a name. A rebuild
+    ///         only ever reaches teardown through a daemon, and a daemon is only ever built through
+    ///         <see cref="BuildDaemonForAsync" />, so this is set on every path that can reach the
+    ///         warning.
+    ///     </para>
+    ///     <para>
+    ///         Under database-per-tenant several daemons are built and the last logger wins. That is
+    ///         harmless here: <c>AddAsyncDaemon</c> hands every one of them the same logger, and a
+    ///         consumer building daemons by hand with different ones still gets the warning — on one of
+    ///         its own loggers rather than on none.
+    ///     </para>
+    /// </remarks>
+    private volatile ILogger _daemonLogger = NullLogger.Instance;
+
     private async ValueTask<IProjectionDaemon> BuildDaemonForAsync(FisherDatabase database, ILogger logger)
     {
+        _daemonLogger = logger;
+
         // Per database, because the journal mode is a property of the file. A store with one tenant
         // configured without WAL is exactly the case the warning exists for, and warning once for the
         // store would miss it.


### PR DESCRIPTION
Closes #122. Reported by @kebin during a Marten → Fisher migration.

Teardown deletes **the whole of** every table the named projection publishes into, then the rebuild replays only that projection. Two projections publishing the same document type share one `fi_doc_*` table, so rebuilding either wipes both and only the rebuilt one comes back. Nothing reports it: the rebuild succeeds, the rebuilt projection is correct, and the damage is to a read model nobody is looking at.

**Semantics are unchanged and Marten behaves identically.** What is added is that the store now says so — at rebuild time, where the operator is present and the other projections can be named, rather than at registration, which would warn on every boot about something that only matters when somebody rebuilds. A warning and not a refusal: the configuration is legal and costs nothing until a rebuild.

### The issue's suggested remedy is wrong, and the test is what found it

Both the issue and its reporter assumed "rebuild them together" was the answer. **There is no such operation** — every `RebuildProjectionAsync` overload names one projection or one type — so "together" means one after the other, and the second teardown clears the shared table *again* and discards what the first rebuild wrote. Only the projection rebuilt last keeps its rows. `rebuilding_each_in_turn_still_leaves_one_of_them_empty` pins that.

**`RewindSubscriptionAsync` is what actually works**, because it replays onto the rows that are there instead of clearing first, and `rewinding_the_collaterally_emptied_projection_restores_it` pins it. The warning message and the docs both send the operator there rather than to a second rebuild.

### The logger

Stashed at `BuildDaemonForAsync`. `TeardownExistingProjectionStateAsync` is on JasperFx's `IEventStore<,>` and has no logger parameter, and a rebuild only ever reaches teardown through a daemon, which is only ever built there. Under database-per-tenant the last logger wins, which is harmless — `AddAsyncDaemon` hands every daemon the same one.

The warning is computed **outside** the resilience pipeline, so a retried `SQLITE_BUSY` does not warn twice for one rebuild — #12's property again.

### Verification

Removing the call fails `the_rebuild_warns_and_names_the_other_projection` and leaves the other four passing, so the reproduction and the remedy are pinned independently of the warning. `a_projection_that_shares_no_table_does_not_warn` is what stops the warning being unconditional.

---

**1398 green on net9.0 and net10.0.** Docs site builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)