### PR TITLE
Fisher is not a test double for Marten or Polecat (#124)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -455,6 +455,15 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 `JasperFx.Events.ComplianceTests` 2.56.0 ships **37 suites, 320 tests**. Fisher passes **all 320, all
 37 suites**. Every suite compiles; every one is also subclassed and running.
 
+**What that does and does not claim, because the difference is load-bearing** (fisher#124). The suite
+pins **API portability, not behavioural equivalence**: code written against one store compiles and
+runs against another. It does not pin that the three *behave* the same, and the migration guide's
+"Behaviour that differs" list is exactly what it does not pin — the exclusive methods failing rather
+than waiting, Marten's strictly-greater revision guard rather than Polecat's equality one, a stricter
+`QueryForNonStaleData`, ordinal string comparison, applied inner-side join predicates. Read as
+equivalence, "passes all 37 suites" invites using Fisher as a test double for a Marten or Polecat
+application, which the divergence list argues against.
+
 **The bump crossed three releases and the whole compliance delta is one test.** 2.54.0 and 2.55.0
 changed no suite file; 2.56.0 added `usage_describes_the_registered_projections` to
 `EventStoreExplorerCompliance`, taking it from 6 to 7 and the event half from 250 to 251. No suite

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > Fisher passes **all 37 suites and 320 tests** of `JasperFx.Events.ComplianceTests`, the shared
 > cross-store suite Marten and Polecat also enroll in, alongside its own 1,343.
 >
+> That suite pins **API portability, not behavioural equivalence** — code written against one store
+> compiles and runs against another. It does not pin that the three behave identically, and they do
+> not: concurrency under contention, string collation, timestamp precision and staleness semantics all
+> differ. The [migration guide](https://fisher.jasperfx.net/migration-guide#behaviour-that-differs)
+> lists them, which is also why Fisher is not a drop-in test double for a Marten or Polecat
+> application.
+>
 > 1.0 means the API is stable and the semantics above are settled — not that Fisher is
 > feature-complete against Marten. The gaps that remain are **decisions**, documented in
 > [HANDOFF.md](HANDOFF.md) rather than filed as issues.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -148,6 +148,28 @@ Worth revisiting when you port, because the workaround you carried may no longer
 
 ## Testing against Fisher, deploying elsewhere
 
-A common and reasonable setup — an integration suite with no server at all, against production code
-that runs on PostgreSQL or SQL Server. Just test the SQLite-specific behaviours above against the store
-you actually deploy on. See [Integration Testing](/testing/integration).
+An integration suite with no server at all is an appealing idea, and it is a **narrow** one. Read the
+scope before adopting it.
+
+::: danger
+**Fisher is not a test double for Marten or Polecat.** The section above is a list of behaviours that
+compile and then differ — which is the exact failure mode of a stand-in: the suite compiles, goes
+green, and production behaves another way.
+
+Several of those divergences fall squarely in the territory integration tests exist to cover.
+Concurrency under contention differs (the exclusive methods fail where the siblings wait), the
+numeric-revision guard differs from Polecat's, `QueryForNonStaleData` is stricter here — so a real
+staleness race in the deployed store can stay hidden — and both ordinal string comparison and
+inner-side join predicates change which rows come back.
+:::
+
+What a suite on Fisher **can** honestly cover for an application deployed elsewhere: wiring,
+registration, projection shape, and that your handlers and endpoints hold together. What it **cannot**
+cover: concurrency, ordering, collation, and staleness semantics. Those have to be tested against the
+store you deploy on, and the hard part is that knowing in advance which of your tests are sensitive to
+them is not obvious.
+
+Fisher's own positioning is **SQLite in production** — edge, embedded, desktop, single-node. That is
+where it is a first-class answer rather than a compromise.
+
+See [Integration Testing](/testing/integration).

--- a/docs/testing/integration.md
+++ b/docs/testing/integration.md
@@ -179,12 +179,29 @@ Filter by a tag the test's own store sets.
 
 ## Testing against Fisher, deploying on Marten or Polecat
 
-The API is shared, so this is a common and reasonable setup — an integration suite that needs no server
-at all, against production code that runs on PostgreSQL or SQL Server.
+The API is shared, so an integration suite that needs no server at all is an appealing idea. It is
+also a **narrow** one, and worth scoping deliberately.
 
-::: warning
-What does **not** carry across is the behaviour this documentation calls out as SQLite-specific: the
+::: danger
+**Fisher is not a test double for Marten or Polecat.** The
+[migration guide](/migration-guide#behaviour-that-differs) lists the behaviours that compile and then
+differ, which is precisely the failure mode of a stand-in: the suite compiles, goes green, and
+production behaves another way.
+
+Several of them are what integration tests are for. The
 [exclusive append methods fail rather than wait](/events/appending#the-exclusive-methods-fail-where-the-siblings-wait),
-[string comparisons are ordinal](/documents/querying/linq/strings), sub-millisecond timestamp equality
-is normalised away, and there is one writer per file. Test those against the store you deploy on.
+so a suite here exercises the failing path and production the waiting one.
+[Numeric revisions](/documents/concurrency#numeric-revisions) follow Marten's strictly-greater guard
+rather than Polecat's equality one. `QueryForNonStaleData` waits for the whole store, which is
+*stricter* — so a real staleness race in the deployed store can stay hidden.
+[String comparisons are ordinal](/documents/querying/linq/strings) and inner-side join predicates are
+applied, both of which change which rows come back. And there is one writer per file.
 :::
+
+Scoped honestly, a suite on Fisher for an application deployed elsewhere covers **wiring,
+registration, projection shape**, and that handlers and endpoints hold together. It does **not** cover
+concurrency, ordering, collation, or staleness — and the hard part is that knowing which of your tests
+are sensitive to those is not obvious in advance.
+
+None of this applies when you deploy on Fisher, which is what it is built for: edge, embedded,
+desktop, single-node. Then the suite and production are the same store.


### PR DESCRIPTION
Closes #124.

The migration guide endorsed running an integration suite on Fisher for an application deployed on PostgreSQL or SQL Server — two sections below a list headed *"the ones that compile and then behave differently"*, which is the exact failure mode of a stand-in: the suite compiles, goes green, and production behaves another way.

Several of the listed divergences are squarely what integration tests exist to cover:

- **The exclusive append methods fail where the siblings wait**, so the suite exercises the failing path and production the waiting one.
- **Numeric revisions** follow Marten's strictly-greater guard rather than Polecat's equality one.
- **`QueryForNonStaleData` is stricter here**, so a real staleness race in the deployed store can stay hidden.
- **Ordinal string comparison** and **applied inner-side join predicates** both change which rows come back.

The old caveat asked the reader to know in advance which of their tests were sensitive to these, which is the hard part.

### Both sections said it, not just the one the issue named

`docs/migration-guide.md` **and** `docs/testing/integration.md`, so fixing only the first would have left the endorsement standing. Each is now a scoped caveat: a suite on Fisher covers **wiring, registration and projection shape**, and does not cover **concurrency, ordering, collation or staleness**.

Neither section is dropped — the idea is reasonable within that scope — and both close by pointing at what Fisher is actually for: SQLite in production, edge, embedded, desktop, single-node.

### The compliance claim

Also the inference the issue flagged next to it, in `README.md` and `HANDOFF.md`: the shared suite pins **API portability, not behavioural equivalence.** Code written against one store compiles and runs against another; the divergence list is precisely what it does not pin. Left unsaid, "passes all 37 suites and 320 tests" reads as equivalence and invites the very use the rest of the guide argues against.

### Context

Raised while planning Critter Stack AI skills for Fisher, which position it as a production store — so this keeps the product docs and that guidance aligned rather than diverging silently.

---

Docs site builds clean; scoreboard agrees on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)