### PR TITLE
Point event_store_usage.cs at jasperfx#712

### DIFF
--- a/src/Fisher.Tests/Events/event_store_usage.cs
+++ b/src/Fisher.Tests/Events/event_store_usage.cs
@@ -20,9 +20,25 @@ namespace Fisher.Tests.Events;
 ///         nothing under <c>projections rebuild</c>.
 ///     </para>
 ///     <para>
-///         The shared <c>EventStoreExplorerCompliance</c> checks exactly one of these lists
-///         (<c>usage.Events</c>) and is explicit that a null usage is allowed, so it cannot catch this
-///         class of gap for any store. Until it grows a sibling, these are Fisher's own.
+///         The shared <c>EventStoreExplorerCompliance</c> now checks two of these lists —
+///         <c>usage.Events</c>, and <c>usage.Subscriptions</c> since jasperfx#700 closed the slot
+///         fisher#120 reported — and is explicit that a null usage is allowed. Every other slot is
+///         still unguarded for every store, so these remain Fisher's own.
+///     </para>
+///     <para>
+///         <b>Seven of them are in the wrong repository and there is an issue to move them</b>
+///         (jasperfx#712). Nothing about the event-type collections, the two error policies, the async
+///         shard names, the descriptor's names or the opt-in metadata flags is dialect-specific, and
+///         six of the seven need no new seam member — so they are guarding a shared contract from one
+///         store's test project. Whatever is promoted gets deleted here rather than duplicated.
+///     </para>
+///     <para>
+///         <b>Two stay whatever happens</b>, and they are the reason this reads as an audit rather
+///         than a backlog. <c>the_max_event_sequence_is_the_high_water_mark</c> asserts equality,
+///         which is true because one writer per file plus <c>BEGIN IMMEDIATE</c> makes committed
+///         sequences contiguous — a claim about SQLite, not about the contract.
+///         <c>every_stream_facet_is_reported_as_captured</c> is a claim about <c>fi_streams</c>'
+///         shape; it may well hold for the siblings too, but that is theirs to confirm.
 ///     </para>
 /// </remarks>
 public class event_store_usage : IAsyncLifetime


### PR DESCRIPTION
Follow-up to #125. Comment-only; no test change.

Seven of `event_store_usage.cs`'s nine tests assert nothing dialect-specific, so they are guarding a shared contract from one store's test project. [JasperFx/jasperfx#712](https://github.com/JasperFx/jasperfx/issues/712) proposes moving them into `EventStoreExplorerCompliance`, and **six of the seven need no new seam member** — `ComplianceStoreConfig` already carries `Snapshot<T>(SnapshotLifecycle.Async)`, `EnableCorrelationTracking`, `EnableHeaders` and `MaxConcurrentRebuildsPerDatabase`, and both `ContinuousErrors` and `RebuildErrors` are already on `IEventStore<,>`.

The strongest of them is the event-type collections: `EventStoreUsage` carries the registry twice and the shared suite asserts on `Events` only, so **polecat#411 — filling one and not the other — is currently invisible to the suite**, having already happened once.

Two corrections to the file's own remarks while here:

- It said the shared suite checks one list. It checks two now — jasperfx#700 closed the `Subscriptions` slot #120 reported.
- It now names the two tests that **stay whatever happens**, so the file reads as an audit rather than a backlog. `the_max_event_sequence_is_the_high_water_mark` asserts equality, which holds because one writer per file plus `BEGIN IMMEDIATE` makes committed sequences contiguous — a claim about SQLite, not about the contract. `every_stream_facet_is_reported_as_captured` is a claim about `fi_streams`' shape; it may hold for the siblings, but that is theirs to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)