### PR TITLE
1.0.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.3</Version>
+        <Version>1.0.4</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,14 +3,53 @@
 Where Fisher is, what comes next, and why in this order. See [CLAUDE.md](CLAUDE.md) for
 architecture and the SQLite-specific decisions.
 
-Status: **two open issues, neither of them next-release work.**
+Status: **one open issue, and it is not next-release work.**
 [#109](https://github.com/JasperFx/fisher/issues/109) is the downstream half of
 [jasperfx#684](https://github.com/JasperFx/jasperfx/issues/684), an epic rather than a next-release
 item; it is filed so the Fisher half is not rediscovered later rather than because it is actionable
-now. [#122](https://github.com/JasperFx/fisher/issues/122) is a rebuild that clears the rows of a
-*second* projection publishing the same document type — by design given per-projection teardown, and
-Marten behaves identically, so what is wanted is a warning and a docs note rather than a change to
-what teardown means.
+now. One upstream issue is outstanding and is Fisher's to write:
+[jasperfx#712](https://github.com/JasperFx/jasperfx/issues/712), promoting seven of
+`event_store_usage.cs`'s nine tests into the shared suite.
+
+**1.0.4** is the JasperFx **2.56.0** / Weasel **9.27.0** bump plus the three issues that Marten→Fisher
+migration left open. No new public API; nothing in it changes what any existing call does.
+
+The bump crosses three JasperFx releases and **the entire compliance delta is one test**, which is the
+one worth having: [jasperfx#700](https://github.com/JasperFx/jasperfx/issues/700) adds
+`usage_describes_the_registered_projections` to `EventStoreExplorerCompliance`, so 1.0.3's #120 fix is
+now held by a cross-store guard rather than by Fisher's own tests. Fisher passed it unchanged. No seam
+member was needed — `ComplianceStoreConfig` and `IComplianceStoreRegistrar` are byte-identical across
+2.54.0, 2.55.0 and 2.56.0, and the core's public surface moved only in `EventModeling`, which Fisher
+references nowhere. Weasel moves in lockstep as its pin comment requires.
+
+[#122](https://github.com/JasperFx/fisher/issues/122) is the shared-published-type teardown hazard
+#120 turned up: teardown clears *the whole of* every table a projection publishes into, so two
+projections publishing one document type share a `fi_doc_*` table and rebuilding either wipes both.
+Marten behaves identically and the semantics are unchanged — what is added is that the store now says
+so, at rebuild time, naming the table and the other projections. **Writing the test corrected the
+remedy.** The issue and its reporter both assumed "rebuild them together" was the answer; there is no
+such operation, since every `RebuildProjectionAsync` overload names one projection, so "together" is
+one after the other and the second teardown discards what the first rebuild wrote. `RewindSubscriptionAsync`
+is what actually works, because it replays onto the rows that are there instead of clearing first, and
+that is where the warning and the docs now point.
+
+[#126](https://github.com/JasperFx/fisher/issues/126) is regression guards for two Marten patching
+bugs ([marten#5290](https://github.com/JasperFx/marten/issues/5290),
+[marten#5295](https://github.com/JasperFx/marten/issues/5295)), **neither of which exists here** —
+`PatchExpression.PathOf` resolves through the same member machinery the LINQ provider uses, and a
+duplicated field is a `VIRTUAL` generated column that cannot drift from `data`. Half the request was
+already covered; what was genuinely missing is `[JsonPropertyName]`. The experiment is the reason the
+file earns its place: replacing `PathOf` with marten#5290 exactly — the CLR name under a camelCase
+transform — leaves **all 23 existing patching tests passing** and fails three of the new ones.
+
+[#124](https://github.com/JasperFx/fisher/issues/124) removes an endorsement the rest of the
+documentation argued against: **Fisher is not a test double for Marten or Polecat.** The divergence
+list two sections above it is headed "the ones that compile and then behave differently", which is
+precisely a stand-in's failure mode, and several of those divergences — the exclusive methods, the
+revision guard, `QueryForNonStaleData`, ordinal string comparison, inner-side join predicates — are
+what integration tests exist to cover. Both pages said it, not just the one the issue named. The
+compliance claim in README and HANDOFF now says what it means: the shared suite pins **API
+portability, not behavioural equivalence.**
 
 **1.0.3** is two bugs found by one Marten→Fisher migration, both of which answered a question
 wrongly rather than failing.
@@ -43,9 +82,10 @@ it and the high-water mark is what CritterWatch#150's second signal renders, and
 never be one, because one writer per file plus `BEGIN IMMEDIATE` makes committed sequences
 contiguous.
 
-Neither was catchable by the shared compliance suite, which asserts on `usage.Events` alone and has
-no coverage of envelope metadata inside an inline projection —
-[jasperfx#700](https://github.com/JasperFx/jasperfx/issues/700) is filed for the first half of that.
+Neither was catchable by the shared compliance suite, which asserted on `usage.Events` alone and has
+no coverage of envelope metadata inside an inline projection.
+[jasperfx#700](https://github.com/JasperFx/jasperfx/issues/700) closed the first half of that and
+shipped in 2.56.0, which 1.0.4 takes.
 
 **1.0.2** is Weasel **9.25.1**, and it exists because of what the 9.25.0 bump removed rather than
 what 9.25.1 adds. Fisher carried a `DocumentTable.ConfigureQueryCommand` override for


### PR DESCRIPTION
The JasperFx **2.56.0** / Weasel **9.27.0** bump plus the three issues that one Marten→Fisher migration left open. **No new public API**, so a patch.

| Issue | PR | What |
|---|---|---|
| #125 | #127 | JasperFx 2.53.0 → 2.56.0, Weasel 9.25.1 → 9.27.0 |
| #126 | #128 | Patch-path regression guards |
| #122 | #129 | Shared-table rebuild warning |
| #124 | #130 | Docs positioning |
| — | #131 | Cross-reference to jasperfx#712 |

**#125** crosses three JasperFx releases and the entire compliance delta is one test — [jasperfx#700](https://github.com/JasperFx/jasperfx/issues/700)'s `usage_describes_the_registered_projections`, which makes 1.0.3's #120 fix a cross-store guard rather than a Fisher-local one. Fisher passed it unchanged and no seam member was needed.

**#122** warns when a rebuild will clear a table another registered projection publishes into. Semantics unchanged and Marten behaves identically — what is added is that the store says so. **Writing the test corrected the remedy:** there is no operation that rebuilds two projections together, so a second rebuild discards what the first wrote; `RewindSubscriptionAsync` is what actually works.

**#126** is regression guards for [marten#5290](https://github.com/JasperFx/marten/issues/5290) and [marten#5295](https://github.com/JasperFx/marten/issues/5295), neither of which exists here. Half the request already existed; `[JsonPropertyName]` was the real gap.

**#124** removes an endorsement the rest of the documentation argued against — Fisher is not a test double for Marten or Polecat — and says what the compliance claim means: **API portability, not behavioural equivalence.**

### Release prep

`ROADMAP.md`'s Status line moves to one open issue (#109, still blocked upstream on jasperfx#684), and the 1.0.3 entry's "jasperfx#700 is filed" becomes "shipped in 2.56.0, which 1.0.4 takes". Nothing but this file checks that line, which is why it is release prep.

---

**1398 green on net9.0 and net10.0**, scoreboard agreeing on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)