### PR TITLE
Pin DCB boundary serialization under concurrency (gh-133)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1398 tests green on net9.0 and net10.0**, with no known intermittent failures — 1343 in
+**1401 tests green on net9.0 and net10.0**, with no known intermittent failures — 1346 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 320 of
 them are shared cross-store compliance tests — 251 event sourcing, which as of 2.56.0 is every event
 suite the shared library has, and 69 document. On JasperFx **2.56.0** / Weasel **9.27.0**.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 37 suites and 320 tests** of `JasperFx.Events.ComplianceTests`, the shared
-> cross-store suite Marten and Polecat also enroll in, alongside its own 1,343.
+> cross-store suite Marten and Polecat also enroll in, alongside its own 1,346.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/src/Fisher.Tests/Events/concurrent_boundary_appends.cs
+++ b/src/Fisher.Tests/Events/concurrent_boundary_appends.cs
@@ -1,0 +1,221 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+
+namespace Fisher.Tests.Events;
+
+public record EnrolleeId(Guid Value);
+
+public record ProgramId(Guid Value);
+
+public record Enrolled(string Name);
+
+public record ProgressRecorded(string Milestone);
+
+public class ProgramEnrollment
+{
+    // Fisher resolves an aggregate's identity from a Guid `Id` (or an [Identity] member) even when the
+    // aggregate is only ever reached through a tag boundary — there is no boundary-aggregate marker here
+    // the way Polecat has one. The value is unused by these tests, which only read Enrollee.
+    public Guid Id { get; set; }
+
+    public string Enrollee { get; set; } = "";
+
+    public List<string> Milestones { get; set; } = [];
+
+    public void Apply(Enrolled e) => Enrollee = e.Name;
+
+    public void Apply(ProgressRecorded e) => Milestones.Add(e.Milestone);
+}
+
+/// <summary>
+///     Concurrent appends guarded by the same DCB tag boundary must serialize: when several writers race
+///     the same boundary, exactly one may commit. Ported from the coverage that caught this in the other
+///     two stores — marten#5300 (staggered racers) and marten#4591 (barrier-synced racers), which found
+///     polecat#515 as well.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Fisher is expected to pass this from the outset, and the point of the fixture is to keep it
+///         that way. Marten and Polecat both checked their boundaries with a non-locking predicate read,
+///         which at READ COMMITTED lets every concurrent saver run the check before any of them commits —
+///         so all of them win. Fisher re-runs the tag query inside <c>BEGIN IMMEDIATE</c>, and SQLite
+///         admits one writer per file, so the check-then-act is genuinely serial.
+///     </para>
+///     <para>
+///         That argument rests on two properties that a later change could quietly remove: the check runs
+///         inside the write transaction, and <c>seq_id</c> is globally monotonic. Move the check outside
+///         the lock, or shard the sequence, and this fixture is what notices. See
+///         <c>FisherSession.AssertBoundariesAreStillConsistentAsync</c>.
+///     </para>
+///     <para>
+///         Racers each carry their OWN EnrolleeId as well as the shared ProgramId, so the boundary routes
+///         them to distinct streams and the (stream, version) constraint cannot serialize them. The DCB
+///         boundary has to be what catches the race.
+///     </para>
+/// </remarks>
+public class concurrent_boundary_appends : IAsyncLifetime
+{
+    private const int Racers = 16;
+    private const int Rounds = 50;
+
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("dcb-concurrency");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.RegisterTagType<EnrolleeId>("enrollee").ForAggregate<ProgramEnrollment>();
+            options.Events.RegisterTagType<ProgramId>("program").ForAggregate<ProgramEnrollment>();
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    [Fact]
+    public async Task staggered_racers_on_one_boundary_serialize_to_one_winner()
+    {
+        long worst = 0;
+
+        for (var round = 0; round < Rounds; round++)
+        {
+            var programId = new ProgramId(Guid.NewGuid());
+            await Task.WhenAll(Enumerable.Range(0, Racers).Select(_ => TryEnrollAsync(programId)));
+
+            worst = Math.Max(worst, await EnrollmentCountAsync(programId));
+        }
+
+        worst.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     Same race, but the boundary already has an unrelated event under it, so the racers append at an
+    ///     established position rather than creating the boundary from nothing. A check that only guarded
+    ///     the first-ever append would pass the test above and fail here.
+    /// </summary>
+    [Fact]
+    public async Task staggered_racers_at_an_established_boundary_serialize_to_one_winner()
+    {
+        long worst = 0;
+
+        for (var round = 0; round < Rounds; round++)
+        {
+            var programId = new ProgramId(Guid.NewGuid());
+            await SeedUnrelatedActivityAsync(programId);
+            await Task.WhenAll(Enumerable.Range(0, Racers).Select(_ => TryEnrollAsync(programId)));
+
+            worst = Math.Max(worst, await EnrollmentCountAsync(programId));
+        }
+
+        worst.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     Every racer completes its fetch, then all of them are released into SaveChangesAsync at once —
+    ///     a different interleaving from the staggered tests, and the one that caught marten#4591.
+    /// </summary>
+    [Fact]
+    public async Task barrier_synced_racers_on_one_boundary_serialize_to_one_winner()
+    {
+        var programId = new ProgramId(Guid.NewGuid());
+        var query = new EventTagQuery().Or<ProgramId>(programId);
+
+        var fetched = new TaskCompletionSource[Racers];
+        for (var i = 0; i < Racers; i++) fetched[i] = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+
+        var racers = Enumerable.Range(0, Racers).Select(i => Task.Run(async () =>
+        {
+            await using var session = _store.LightweightSession();
+            var boundary = await session.Events.FetchForWritingByTags<ProgramEnrollment>(query);
+
+            fetched[i].SetResult();
+            await release.Task;
+
+            var enrolled = session.Events.BuildEvent(new Enrolled($"Student-{i}"));
+            enrolled.WithTag(new EnrolleeId(Guid.NewGuid()), programId);
+            boundary.AppendOne(enrolled);
+
+            try
+            {
+                await session.SaveChangesAsync();
+                return true;
+            }
+            catch (DcbConcurrencyException)
+            {
+                return false;
+            }
+        })).ToArray();
+
+        await Task.WhenAll(fetched.Select(x => x.Task));
+        release.SetResult();
+
+        var results = await Task.WhenAll(racers);
+
+        results.Count(x => x).ShouldBe(1);
+
+        // And the losers lose the documented way. Every racer here appended, so none of them can have
+        // returned false for any reason other than a DcbConcurrencyException — worth pinning, because
+        // SQLite serializes writers and the plausible alternative failure is a busy/locked error leaking
+        // out of the resilience pipeline, which is not the contract callers write retry loops against.
+        results.Count(x => !x).ShouldBe(Racers - 1);
+    }
+
+    // Invariant: at most one enrollment per program. A racer whose fetch already shows one backs off, so
+    // every commit past the first is one the boundary check should have refused.
+    //
+    // Only DcbConcurrencyException is caught, deliberately. If contention on SQLite's single writer
+    // surfaces as something else — a busy/locked error escaping the resilience pipeline, say — that is
+    // worth failing over rather than swallowing: the contract callers write their retry loops against is
+    // the exception type.
+    private async Task TryEnrollAsync(ProgramId programId)
+    {
+        await using var session = _store.LightweightSession();
+        var boundary = await session.Events.FetchForWritingByTags<ProgramEnrollment>(
+            new EventTagQuery().Or<ProgramId>(programId));
+
+        if (boundary.Aggregate is { Enrollee.Length: > 0 })
+        {
+            return;
+        }
+
+        var enrolled = session.Events.BuildEvent(new Enrolled("Student"));
+        enrolled.WithTag(new EnrolleeId(Guid.NewGuid()), programId);
+        boundary.AppendOne(enrolled);
+
+        try
+        {
+            await session.SaveChangesAsync();
+        }
+        catch (DcbConcurrencyException)
+        {
+        }
+    }
+
+    private async Task SeedUnrelatedActivityAsync(ProgramId programId)
+    {
+        await using var session = _store.LightweightSession();
+        var progress = session.Events.BuildEvent(new ProgressRecorded("kickoff"));
+        progress.WithTag(new EnrolleeId(Guid.NewGuid()), programId);
+        session.Events.Append(Guid.NewGuid(), progress);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<long> EnrollmentCountAsync(ProgramId programId)
+    {
+        await using var session = _store.LightweightSession();
+        var enrollments = await session.Events.QueryByTagsAsync(
+            new EventTagQuery().Or<Enrolled, ProgramId>(programId), TestContext.Current.CancellationToken);
+
+        return enrollments.Count;
+    }
+}


### PR DESCRIPTION
Closes #133. Test-only — **no production change**, because none turned out to be needed.

## Result: Fisher was already correct

This is the third store in the sweep that started with [marten#5300](https://github.com/JasperFx/marten/pull/5301). The other two both checked their DCB boundaries with a non-locking predicate read, which at READ COMMITTED lets every concurrent saver run the check before any of them commits:

| store | racers committing where one is allowed |
|---|---|
| Marten (pre-#4591) | 5–7 of 8 |
| Polecat (through 5.20.0) | **16 of 16** — see [polecat#516](https://github.com/JasperFx/polecat/pull/516) |
| **Fisher** | **1 of 16 — correct** |

Fisher passes all three ported tests from the outset. `AssertBoundariesAreStillConsistentAsync` re-runs the tag query inside `BEGIN IMMEDIATE`, and SQLite admits one writer per file, so the check-then-act is genuinely serial rather than merely looking it. The marten#5300 ordering defect doesn't map here either — there is no separately-captured version to pair with a stale aggregate, because the boundary is re-checked under the lock instead of compared against a value read earlier.

## Why merge a test that was always going to pass

The correctness argument rests on two properties a later change could quietly remove:

1. the boundary check runs **inside** the write transaction, and
2. `seq_id` stays **globally monotonic**.

Neither is the sort of thing whose removal looks like it touched DCB. Moving the check onto its own connection, or sharding the sequence per tenant, would both silently reintroduce exactly the bug the other two stores had — and nothing in the existing suite would notice, because the sequential DCB tests pass fine against a broken check. That is precisely how Polecat shipped this for as long as it did.

## One contract worth pinning

The barrier-synced test asserts the exception **type**, not just the count: all 16 racers append, exactly one commits, and the other 15 must fail with `DcbConcurrencyException`. With writers serialized by the file lock, the plausible alternative failure was a busy/locked error leaking out of the resilience pipeline — which is not what callers write their `catch` blocks against. It doesn't, and now that's held in place.

## Coverage

Three tests, mirroring the other two stores:

- **staggered racers** on a fresh boundary — unsynchronized fetch/save interleaving, the shape that caught marten#5300
- **staggered racers at an established boundary** — the boundary already has an unrelated event, so racers append at an established position; a check that only guarded the first-ever append would pass the first test and fail this one
- **barrier-synced racers** — every racer fetches, then all are released into `SaveChangesAsync` at once; the shape that caught marten#4591

16 racers × 50 rounds, and the whole class runs in under a second. Verified 5 consecutive clean runs; full Fisher suite 1346/1346.

## One thing noticed in passing

Fisher has no `[BoundaryAggregate]` marker equivalent to Polecat's: an aggregate reached only through a tag boundary still has to carry a `Guid Id` (or an `[Identity]` member) or `AggregatorFor<T>()` throws "has no identity member" the first time a boundary fetch actually finds events. The test works around it with an unused `Id` property and a comment. Not in scope here, but possibly worth its own issue.

Multi-process concurrency is not covered — the harness has no way to express it, and `BEGIN IMMEDIATE` is OS-level file locking so the same argument holds across processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)