### PR TITLE
Honour [BoundaryAggregate] on a DCB boundary aggregate (gh-135)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3269,6 +3269,37 @@ than from the hydration context the single-stream reads use.
 
 Guid tag values bind as lowercase canonical text, same trap as `SqliteGuidIdentification`.
 
+**A boundary aggregate needs no single-stream identity** (fisher#135). `AggregateIdentity.ResolveIdType`
+treats `JasperFx.Events.Aggregation.BoundaryAggregateAttribute` as an explicit opt-out and answers
+`typeof(string)` — the vestigial `TId` the source generator already keys a marked identity-less type's
+evolver on, so it is the only answer that finds the dispatcher.
+
+**Fisher is the first store to actually honour it, which is not what fisher#135 assumed.** The issue
+filed this as a Fisher-only divergence on the strength of Polecat's DCB page, which documents the
+marker as the answer across the stack. Polecat's *source* has no mention of it: its
+`IAggregationSourceFactory.Build<TDoc>()` resolves identity through `DocumentMapping`, whose
+constructor throws for a type with no `Id`. Verified by running it rather than by reading — a
+`[BoundaryAggregate]` aggregate with no identity fails there with *"must have a public property named
+'Id'"*, from `DocumentMapping..ctor`. So the divergence being closed here is between Fisher and the
+attribute's documented contract, and Polecat's docs are wrong (polecat#521). **The shared suite catches
+neither, because every DCB aggregate in it happens to carry an identity** — jasperfx#718 is the request
+to add an identity-less one, which has to fold *with events present* or it passes on a broken store.
+
+- **The marker is the whole exemption, and the message names it.** An unmarked identity-less aggregate
+  is still refused, because it is far more often a forgotten `Id` than a deliberate boundary aggregate
+  — the same reason the generator emits nothing for one. What changed beside the exemption is that the
+  refusal now mentions `[BoundaryAggregate]`, since the old text ("single stream aggregates need an
+  `Id`") was accurate for the aggregate it was written about and misleading for this one.
+- **Not inherited.** The generator reads the attribute off the declaring type in its own compilation,
+  so a subclass inheriting the marker here would resolve to `string` and then fail to find a dispatcher
+  of its own.
+- **The empty boundary is why this bites late, and why the coverage has to have events.**
+  `FetchForWritingByTags` folds only when the query finds something, so a boundary over an empty result
+  — the ordinary "this must not exist yet" assertion — succeeded before this was honoured. A suite
+  exercising only that path is green over a model that throws on first real use.
+  `boundary_aggregates.fetch_for_writing_by_tags_folds_an_identity_less_aggregate` is the discriminating
+  test; `concurrent_boundary_appends` dropped the unused `Id` it carried as the workaround.
+
 **`AssignTagWhere` is a client of the LINQ `WhereClauseParser`**, as Marten builds it. The only piece
 it needed was `EventMemberFactory`, an `IMemberResolver` resolving `IEvent` members to `fi_events`
 columns instead of `json_extract` paths — which is why `IMemberResolver` is an interface rather than

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1401 tests green on net9.0 and net10.0**, with no known intermittent failures — 1346 in
+**1408 tests green on net9.0 and net10.0**, with no known intermittent failures — 1353 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 320 of
 them are shared cross-store compliance tests — 251 event sourcing, which as of 2.56.0 is every event
 suite the shared library has, and 69 document. On JasperFx **2.56.0** / Weasel **9.27.0**.
@@ -1154,6 +1154,27 @@ against our own appends, and checking outside the transaction would prove nothin
 A boundary over an *empty* result still enforces consistency — `LastSeenSequence` is 0, and any
 matching event appearing later has a sequence above it. That is what makes a boundary usable as a
 "this must not exist yet" assertion.
+
+### A boundary aggregate needs no identity
+
+An aggregate reached only through a tag boundary is keyed to no stream, so `[BoundaryAggregate]`
+(`JasperFx.Events.Aggregation`) is an explicit opt-out of single-stream identity and
+`AggregateIdentity.ResolveIdType` answers `typeof(string)` for one — the vestigial `TId` the source
+generator already keys a marked type's evolver on. Before #135 Fisher required the `Id` anyway.
+
+**Fisher is the first Critter Stack store to honour it.** #135 filed this as a Fisher-only divergence
+because Polecat's DCB page documents the marker as the cross-stack answer — but Polecat's source never
+mentions it, and an identity-less boundary aggregate throws there too, out of `DocumentMapping`'s
+constructor. Confirmed by running it against the Polecat tree, and filed as polecat#521. What Fisher is
+now aligned with is the attribute's documented contract, not with a sibling's behaviour.
+
+**That gap is invisible from the empty-boundary path**, which is what made it late-breaking rather
+than obvious: `FetchForWritingByTags` folds only when the query finds events, so the "this must not
+exist yet" assertion above worked either way and the throw arrived on first real use. The shared suite
+does not catch it either — every DCB aggregate in it happens to carry an identity, which is filed as
+jasperfx#718. An unmarked
+identity-less aggregate is still refused, and the message now names the boundary case rather than
+sending its author after an `Id` their model has no use for.
 
 ### Batched queries exist for parity, not for speed
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 37 suites and 320 tests** of `JasperFx.Events.ComplianceTests`, the shared
-> cross-store suite Marten and Polecat also enroll in, alongside its own 1,346.
+> cross-store suite Marten and Polecat also enroll in, alongside its own 1,353.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -67,6 +67,60 @@ A boundary over an **empty result still enforces consistency**: the last-seen se
 later matching event exceeds it.
 :::
 
+## Identity-less boundary aggregates
+
+An aggregate reached only through a tag boundary is keyed to no stream, so requiring it to carry a
+`Guid Id` would be asking for a member the model has no use for. Mark it `[BoundaryAggregate]` (from
+`JasperFx.Events.Aggregation`) and leave the identity off:
+
+<!-- snippet: sample_dcb_boundary_aggregate -->
+<a id='snippet-sample_dcb_boundary_aggregate'></a>
+```cs
+[BoundaryAggregate]
+public partial class ShowSeating
+{
+    public HashSet<string> Reserved { get; } = [];
+
+    public void Apply(SeatReserved e) => Reserved.Add(e.Seat);
+
+    public void Apply(SeatReleased e) => Reserved.Remove(e.Seat);
+}
+```
+<sup><a href='https://github.com/JasperFx/fisher/blob/main/src/Fisher.Tests/Documentation/dcb_samples.cs#L17-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_dcb_boundary_aggregate' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Keep the type `partial`: the marker is what makes JasperFx's source generator emit a dispatcher for
+it, and the generator attaches that to the type. The attribute must sit on the aggregate **in its own
+defining assembly** — that is the compilation the evolver is emitted into, and the assembly the
+runtime scans when resolving it.
+
+::: warning
+The marker is the whole opt-in, and an identity-less aggregate **without** it is still refused. A bare
+no-`Id` aggregate is far more often a forgotten identity than a deliberate boundary aggregate, so the
+generator emits nothing for one and Fisher declines to resolve it — deliberately, rather than
+inventing an identity that would leave the dispatcher unmatched later.
+:::
+
+::: tip
+An aggregate that already has an `Id` needs no marker and is unaffected. `[BoundaryAggregate]` is only
+for the identity-less case, and the `string` identity it implies is vestigial — nothing on the DCB
+path reads it.
+:::
+
+::: tip
+This bites late without the marker. `FetchForWritingByTags` only folds an aggregate when the query
+**finds events**, so a boundary over an empty result — the ordinary "this must not exist yet"
+assertion — works either way, and the failure arrives the first time the boundary actually matches
+something.
+:::
+
+::: warning
+`[BoundaryAggregate]` is a JasperFx marker rather than a Fisher one, so a model carrying it is
+portable in *source*. It is not yet portable in behaviour: as of Polecat 5.20.0 an identity-less
+boundary aggregate still fails there, from its own document-identity resolution, despite Polecat's
+DCB page documenting the marker. See [polecat#521](https://github.com/JasperFx/polecat/issues/521).
+:::
+
 ## How tag rows are stored
 
 One `fi_event_tag_<suffix>` table per tag type, with a composite primary key **leading with `value`**.

--- a/src/Fisher.Tests/Documentation/dcb_samples.cs
+++ b/src/Fisher.Tests/Documentation/dcb_samples.cs
@@ -1,0 +1,27 @@
+using JasperFx.Events.Aggregation;
+
+namespace Fisher.Tests.Documentation;
+
+/*
+ * The compiled source behind docs/events/dcb.md.
+ *
+ * See "Documentation samples" in CLAUDE.md: every sample a reader would copy lives in a
+ * #region here and is pulled into the markdown by mdsnippets, so a sample that stops compiling
+ * fails the build rather than going stale in a page nobody rebuilds.
+ */
+
+public record SeatReserved(string Seat);
+
+public record SeatReleased(string Seat);
+
+#region sample_dcb_boundary_aggregate
+[BoundaryAggregate]
+public partial class ShowSeating
+{
+    public HashSet<string> Reserved { get; } = [];
+
+    public void Apply(SeatReserved e) => Reserved.Add(e.Seat);
+
+    public void Apply(SeatReleased e) => Reserved.Remove(e.Seat);
+}
+#endregion

--- a/src/Fisher.Tests/Events/boundary_aggregates.cs
+++ b/src/Fisher.Tests/Events/boundary_aggregates.cs
@@ -1,0 +1,199 @@
+using Fisher.Storage;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Tags;
+
+namespace Fisher.Tests.Events;
+
+public record WardId(Guid Value);
+
+public record PatientId(Guid Value);
+
+public record Admitted(string Patient);
+
+public record Discharged(string Patient);
+
+/// <summary>
+///     A pure boundary aggregate: it spans streams by tag and is keyed to none of them, so it carries no
+///     <c>Id</c> and no <c>[Identity]</c> member. <c>[BoundaryAggregate]</c> is what tells JasperFx's
+///     source generator to emit an evolver for it anyway — keyed on a vestigial <c>string</c> TId, which
+///     is why <see cref="AggregateIdentity.ResolveIdType" /> has to answer <c>string</c> for it.
+/// </summary>
+[BoundaryAggregate]
+public partial class WardOccupancy
+{
+    public List<string> Patients { get; } = [];
+
+    public void Apply(Admitted e) => Patients.Add(e.Patient);
+
+    public void Apply(Discharged e) => Patients.Remove(e.Patient);
+}
+
+/// <summary>
+///     The same shape without the marker. Nothing here should work — this type exists to pin that the
+///     exemption is the attribute rather than "no identity member is fine now".
+/// </summary>
+public class UnmarkedWardOccupancy
+{
+    public List<string> Patients { get; } = [];
+
+    public void Apply(Admitted e) => Patients.Add(e.Patient);
+}
+
+/// <summary>
+///     An aggregate reached only through a DCB tag boundary must not need a single-stream identity
+///     (gh-135). <c>[BoundaryAggregate]</c> is JasperFx's marker for exactly that case, and honouring it
+///     is what keeps the same model compiling and running against Fisher and Polecat alike.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The coverage that matters is <b>with events present</b>. <c>FetchForWritingByTags</c> only
+///         resolves the aggregator when the query finds something, so a boundary over an empty result —
+///         the ordinary "this must not exist yet" assertion — succeeded even before this was honoured.
+///         A suite that only exercised the empty path would be green over a model that throws the first
+///         time the boundary actually matches.
+///     </para>
+/// </remarks>
+public class boundary_aggregates : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("boundary-aggregate");
+    private readonly WardId _ward = new(Guid.NewGuid());
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.RegisterTagType<WardId>("ward").ForAggregate<WardOccupancy>();
+            options.Events.RegisterTagType<PatientId>("patient").ForAggregate<WardOccupancy>();
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private EventTagQuery WardQuery => new EventTagQuery().Or<WardId>(_ward);
+
+    private async Task AdmitAsync(params string[] patients)
+    {
+        await using var session = _store.LightweightSession();
+
+        foreach (var patient in patients)
+        {
+            var admitted = session.Events.BuildEvent(new Admitted(patient));
+            admitted.WithTag(new PatientId(Guid.NewGuid()), _ward);
+            session.Events.StartStream(Guid.NewGuid(), admitted);
+        }
+
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_by_tags_folds_an_identity_less_aggregate()
+    {
+        await AdmitAsync("Frodo", "Sam");
+
+        await using var session = _store.LightweightSession();
+        var boundary = await session.Events.FetchForWritingByTags<WardOccupancy>(
+            WardQuery, TestContext.Current.CancellationToken);
+
+        boundary.Aggregate.ShouldNotBeNull();
+        boundary.Aggregate.Patients.ShouldBe(["Frodo", "Sam"]);
+    }
+
+    [Fact]
+    public async Task aggregate_by_tags_folds_an_identity_less_aggregate()
+    {
+        await AdmitAsync("Frodo", "Sam");
+
+        await using var session = _store.LightweightSession();
+        var occupancy = await session.Events.AggregateByTagsAsync<WardOccupancy>(
+            WardQuery, TestContext.Current.CancellationToken);
+
+        occupancy.ShouldNotBeNull();
+        occupancy.Patients.ShouldBe(["Frodo", "Sam"]);
+    }
+
+    /// <summary>
+    ///     The boundary is still a boundary: an append through it commits, and the events it wrote are
+    ///     what the next fetch folds. Pinned separately from the read above because resolving the
+    ///     aggregator is only half of what the DCB path does with the type.
+    /// </summary>
+    [Fact]
+    public async Task an_identity_less_boundary_still_appends_and_guards()
+    {
+        await AdmitAsync("Frodo");
+
+        await using (var session = _store.LightweightSession())
+        {
+            var boundary = await session.Events.FetchForWritingByTags<WardOccupancy>(
+                WardQuery, TestContext.Current.CancellationToken);
+
+            boundary.Aggregate!.Patients.ShouldBe(["Frodo"]);
+
+            var discharged = session.Events.BuildEvent(new Discharged("Frodo"));
+            discharged.WithTag(new PatientId(Guid.NewGuid()), _ward);
+            boundary.AppendOne(discharged);
+
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var reader = _store.LightweightSession();
+        var occupancy = await reader.Events.AggregateByTagsAsync<WardOccupancy>(
+            WardQuery, TestContext.Current.CancellationToken);
+
+        occupancy!.Patients.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     The empty-boundary path, which never reached the aggregator and so passed before gh-135 was
+    ///     fixed. Kept as the counterpart to the tests above rather than as the coverage: what it pins is
+    ///     that honouring the marker did not change the "nothing matched" answer from null.
+    /// </summary>
+    [Fact]
+    public async Task an_empty_boundary_over_an_identity_less_aggregate_is_null()
+    {
+        await using var session = _store.LightweightSession();
+        var boundary = await session.Events.FetchForWritingByTags<WardOccupancy>(
+            WardQuery, TestContext.Current.CancellationToken);
+
+        boundary.Aggregate.ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     The marker is the whole exemption. An identity-less aggregate without it is still refused —
+    ///     it is far more often a forgotten <c>Id</c> than a deliberate boundary aggregate, which is the
+    ///     same reason the source generator emits nothing for one.
+    /// </summary>
+    [Fact]
+    public void an_unmarked_identity_less_aggregate_is_still_refused()
+    {
+        var ex = Should.Throw<InvalidOperationException>(
+            () => AggregateIdentity.ResolveIdType(typeof(UnmarkedWardOccupancy), StreamIdentity.AsGuid));
+
+        ex.Message.ShouldContain(nameof(UnmarkedWardOccupancy));
+
+        // And the message names the boundary case, so somebody who arrived here down a DCB path is not
+        // sent looking for a missing Id their model has no use for.
+        ex.Message.ShouldContain("BoundaryAggregate");
+    }
+
+    /// <summary>
+    ///     The identity type the marker resolves to is <c>string</c>, not the store's stream identity
+    ///     primitive — that is the type the generated evolver is keyed on, and a Guid-identity store
+    ///     must not talk itself into <c>Guid</c> here.
+    /// </summary>
+    [Theory]
+    [InlineData(StreamIdentity.AsGuid)]
+    [InlineData(StreamIdentity.AsString)]
+    public void a_boundary_aggregate_resolves_to_the_vestigial_string_identity(StreamIdentity identity)
+        => AggregateIdentity.ResolveIdType(typeof(WardOccupancy), identity).ShouldBe(typeof(string));
+}

--- a/src/Fisher.Tests/Events/concurrent_boundary_appends.cs
+++ b/src/Fisher.Tests/Events/concurrent_boundary_appends.cs
@@ -1,5 +1,6 @@
 using JasperFx;
 using JasperFx.Events;
+using JasperFx.Events.Aggregation;
 using JasperFx.Events.Tags;
 
 namespace Fisher.Tests.Events;
@@ -12,13 +13,12 @@ public record Enrolled(string Name);
 
 public record ProgressRecorded(string Milestone);
 
-public class ProgramEnrollment
+// gh-135: reached only through a tag boundary, so it is keyed to no stream and carries no identity.
+// It used to need an unused `Id` to satisfy single-stream identity resolution; [BoundaryAggregate] is
+// the marker that says the omission is deliberate. See boundary_aggregates.
+[BoundaryAggregate]
+public partial class ProgramEnrollment
 {
-    // Fisher resolves an aggregate's identity from a Guid `Id` (or an [Identity] member) even when the
-    // aggregate is only ever reached through a tag boundary — there is no boundary-aggregate marker here
-    // the way Polecat has one. The value is unused by these tests, which only read Enrollee.
-    public Guid Id { get; set; }
-
     public string Enrollee { get; set; } = "";
 
     public List<string> Milestones { get; set; } = [];

--- a/src/Fisher/Storage/AggregateIdentity.cs
+++ b/src/Fisher/Storage/AggregateIdentity.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx;
 using JasperFx.Events;
+using JasperFx.Events.Aggregation;
 
 namespace Fisher.Storage;
 
@@ -48,6 +49,7 @@ internal static class AggregateIdentity
     ///     for <paramref name="aggregateType" />.
     /// </summary>
     /// <remarks>
+    ///     <para>
     ///     An identity member is required even though live aggregation never reads one — it takes
     ///     <c>TId</c> from the stream. What needs it is JasperFx's source generator, which keys the
     ///     dispatcher it emits on <c>(TDoc, TId)</c> and skips a type it cannot resolve an identity for.
@@ -55,16 +57,36 @@ internal static class AggregateIdentity
     ///     defaulting to the stream identity primitive here would only push the failure to
     ///     <c>AssembleAndAssertValidity</c> with a message about a missing generated dispatcher rather
     ///     than about the missing <c>Id</c> that actually caused it.
+    ///     </para>
+    ///     <para>
+    ///     <see cref="BoundaryAggregateAttribute" /> is the one exemption, and it exists because a DCB
+    ///     boundary aggregate is <em>defined</em> by spanning streams by tag rather than being keyed to
+    ///     one — so "single stream aggregates need an Id" is telling its author to add a member their
+    ///     model has no use for. The marker is the generator's own opt-in: it emits an
+    ///     <c>IGeneratedSyncEvolver&lt;TDoc, string&gt;</c> for a marked identity-less type, so
+    ///     <c>string</c> is the only answer that finds that dispatcher. It is vestigial — nothing on the
+    ///     DCB path reads it — but it has to agree.
+    ///     </para>
     /// </remarks>
     internal static Type ResolveIdType(Type aggregateType, StreamIdentity streamIdentity)
     {
         var streamIdType = streamIdentity == StreamIdentity.AsGuid ? typeof(Guid) : typeof(string);
 
-        var member = FindIdMember(aggregateType)
-            ?? throw new InvalidOperationException(
+        var member = FindIdMember(aggregateType);
+
+        if (member is null)
+        {
+            // A boundary aggregate has opted out of single-stream identity, so there is nothing to
+            // resolve and typeof(string) is the answer the generator already committed to.
+            if (IsBoundaryAggregate(aggregateType)) return typeof(string);
+
+            throw new InvalidOperationException(
                 $"Aggregate type '{aggregateType.FullName}' has no identity member. Single stream " +
                 $"aggregates need a public {streamIdType.Name} member named 'Id', or one marked with " +
-                "[Identity].");
+                "[Identity]. An aggregate reached only through a DCB tag boundary has no stream to be " +
+                "keyed to — mark it [BoundaryAggregate] (JasperFx.Events.Aggregation) instead of giving " +
+                "it an identity it has no use for.");
+        }
 
         // Unwrap Nullable<T> so a `PublicId? Id` closes the projection over PublicId. The source
         // generator unwraps the same way; a mismatch here means the generated evolver would never be
@@ -112,6 +134,18 @@ internal static class AggregateIdentity
                 break;
         }
     }
+
+    /// <summary>
+    ///     Whether the aggregate type has opted out of single-stream identity with
+    ///     <see cref="BoundaryAggregateAttribute" />.
+    /// </summary>
+    /// <remarks>
+    ///     Not inherited: the attribute is what makes the source generator emit an evolver, and the
+    ///     generator reads it off the declaring type in its own compilation. A subclass that inherited
+    ///     the marker here would resolve to <c>string</c> and then fail to find a dispatcher of its own.
+    /// </remarks>
+    private static bool IsBoundaryAggregate(Type aggregateType)
+        => aggregateType.GetCustomAttribute<BoundaryAggregateAttribute>(false) is not null;
 
     private static Type MemberType(MemberInfo member) => member switch
     {


### PR DESCRIPTION
Closes #135.

## What changed

`AggregateIdentity.ResolveIdType` treats `JasperFx.Events.Aggregation.BoundaryAggregateAttribute` as an explicit opt-out of single-stream identity and answers `typeof(string)` — the vestigial `TId` the source generator already keys a marked identity-less type's evolver on, and therefore the only answer that finds the dispatcher. One branch, plus a message.

An aggregate reached only through a tag boundary is *defined* by spanning streams rather than being keyed to one, so "single stream aggregates need an `Id`" was accurate for the aggregate it was written about and misleading for this one.

**The marker is the whole exemption.** An unmarked identity-less aggregate is still refused, for the same reason the generator emits nothing for one: it is far more often a forgotten `Id` than a deliberate boundary aggregate. What changed beside the exemption is that the refusal now names `[BoundaryAggregate]`, so someone who arrived down a DCB path is not sent looking for an identity their model has no use for — that is the issue's point 2, kept rather than superseded by point 1.

**Not inherited.** The generator reads the attribute off the declaring type in its own compilation, so a subclass inheriting the marker here would resolve to `string` and then fail to find a dispatcher of its own.

## The coverage has to have events

Point 3, and it is the point rather than a detail. `FetchForWritingByTags` resolves the aggregator only when the query finds something, so a boundary over an empty result — the ordinary "this must not exist yet" assertion — succeeded before this was honoured.

`boundary_aggregates` (7 tests) folds an identity-less aggregate through `FetchForWritingByTags` and `AggregateByTagsAsync` with events present, appends through the boundary and reads it back, and pins both the refusal and the resolved `string` under either stream identity. **Verified by reverting the branch: five of the seven fail.** The two that survive are exactly the empty-boundary test and the refusal — which is the issue's diagnosis reproduced.

`concurrent_boundary_appends` drops the unused `Id` and the comment that filed this.

## Polecat does not actually honour it, and that changes the framing

The issue filed this as a Fisher-only divergence on the strength of [Polecat's DCB page](https://github.com/JasperFx/polecat/blob/main/docs/events/dcb.md), which documents the marker as the answer across the stack. That premise does not hold, and it seemed worth checking before writing it into `CLAUDE.md` as settled.

`BoundaryAggregate` appears nowhere in Polecat's `src/`. Its `IAggregationSourceFactory.Build<TDoc>()` resolves identity through `DocumentMapping`, whose constructor throws unconditionally for a type with no `Id`. Reproduced against Polecat 5.20.0 with a throwaway test rather than inferred from reading:

```
System.InvalidOperationException : Document type 'ProbeShowSeating' must have a public property
named 'Id' or a property marked with [Identity] of type Guid, string, int, or long.
   at Polecat.Storage.DocumentMapping..ctor(...) in DocumentMapping.cs:line 53
   at Polecat.Events.EventGraph...Build[TDoc]() in EventGraph.cs:line 367
```

So Fisher is the **first** store to honour it, and what is closed here is a gap against the attribute's documented contract rather than against a sibling's behaviour. Filed as [polecat#521](https://github.com/JasperFx/polecat/issues/521); the docs now carry the portability caveat so a reader is not told a model is behaviourally portable when it is only portable in source.

The shared suite catches neither store — every DCB aggregate in it happens to carry an identity. [jasperfx#718](https://github.com/JasperFx/jasperfx/issues/718) is the request to add one that does not, with the note that it has to fold with events present or it passes on a broken store.

## Docs

New *Identity-less boundary aggregates* section on `docs/events/dcb.md`, with the aggregate as a compiled `#region sample_` in `Documentation/dcb_samples.cs` rather than a hand-written fence — it is a type a reader would copy. `CLAUDE.md` and `HANDOFF.md` both record the decision and the Polecat finding.

## Verification

- `dotnet test fisher.slnx` — **1408 green on net9.0 and net10.0**, no failures, no skips.
- `check_scoreboard.py` agrees on both TFMs (1408 tests, 320 compliance across 37 suites); HANDOFF and README counts updated from the run.
- `npm run docs-build` clean.

No public API changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)