### PR TITLE
gh-139: answer IEventTenancySource so single-stream projections fold a single-tenanted store

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.56.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.56.0" />
+        <PackageVersion Include="JasperFx" Version="2.59.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.59.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.56.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.56.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.59.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.59.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,10 +12,15 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1408 tests green on net9.0 and net10.0**, with no known intermittent failures — 1353 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 320 of
-them are shared cross-store compliance tests — 251 event sourcing, which as of 2.56.0 is every event
-suite the shared library has, and 69 document. On JasperFx **2.56.0** / Weasel **9.27.0**.
+**1417 tests green on net9.0 and net10.0**, with no known intermittent failures — 1362 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 329 of
+them are shared cross-store compliance tests — 260 event sourcing and 69 document. On JasperFx **2.59.0** / Weasel **9.27.0**.
+
+Note that 260 is no longer *every* event suite the shared library has: 2.59.0 added
+`SingleTenantedEventSlicingCompliance` (jasperfx#724) and `CompositeProjectionCompliance`
+(jasperfx#725), both opt-in and neither enrolled here. The first cannot construct its precondition on
+Fisher at all — see jasperfx#727 — and the second needs an `AddCompositeProjection` seam on the
+fixture.
 
 ## Closed since the comparison
 
@@ -452,8 +457,8 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.56.0 ships **37 suites, 320 tests**. Fisher passes **all 320, all
-37 suites**. Every suite compiles; every one is also subclassed and running.
+`JasperFx.Events.ComplianceTests` 2.59.0 ships 39 suites; Fisher enrolls **37 of them, 329 tests**.
+Fisher passes **all 329, all 37 suites**. Every suite compiles; every one is also subclassed and running.
 
 **What that does and does not claim, because the difference is load-bearing** (fisher#124). The suite
 pins **API portability, not behavioural equivalence**: code written against one store compiles and
@@ -486,7 +491,7 @@ shape: `DocumentLoadAndStoreCompliance` gained three tests for `LoadAsync<T>(obj
 fisher#89) and `DocumentComplianceConfig` gained `ValueTypes`. Diffing the suite *list* would have
 reported a clean bump — diff the contents.
 
-The library is now two halves. The **event sourcing** half is 30 suites and 251 tests, and its
+The library is now two halves. The **event sourcing** half is 30 enrolled suites and 260 tests, and its
 upstream backlog has been empty since 2.45.0 — that is the whole of it rather than a snapshot. The
 **document** half arrived in 2.47.0 (jasperfx#647) and is now seven suites, 69 tests, over the
 store-agnostic document contract Fisher implements for fisher#68. Every suite added since 2.49.0 has
@@ -526,13 +531,13 @@ and `Query<T>` were already `notnull`. See "The store-agnostic document contract
 **Green on all thirty-seven is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 37 suites, 320 tests
+### Green — 37 suites, 329 tests
 
-Event sourcing — 30 suites, 251 tests:
+Event sourcing — 30 suites, 260 tests:
 
 | Suite | Tests |
 |---|---|
-| `DcbTagQueryAndConsistencyCompliance` | 26 |
+| `DcbTagQueryAndConsistencyCompliance` | 28 |
 | `StringStreamIdentityCompliance` | 19 |
 | `AggregateWriteCacheCompliance` | 14 |
 | `FetchForWritingCompliance` | 13 |
@@ -548,7 +553,7 @@ Event sourcing — 30 suites, 251 tests:
 | `ConjoinedEventTenancyCompliance` | 8 |
 | `FetchLatestCompliance` | 7 |
 | `LiveAggregationCompliance` | 7 |
-| `EventStoreExplorerCompliance` | 7 |
+| `EventStoreExplorerCompliance` | 14 |
 | `StringIdentitySingleStreamCompliance` | 6 |
 | `StreamArchivingCompliance` | 6 |
 | `SnapshotLifecycleCompliance` | 6 |

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 37 suites and 320 tests** of `JasperFx.Events.ComplianceTests`, the shared
-> cross-store suite Marten and Polecat also enroll in, alongside its own 1,353.
+> Fisher passes **all 37 suites and 329 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,362.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/scripts/check_scoreboard.py
+++ b/scripts/check_scoreboard.py
@@ -254,12 +254,18 @@ def main() -> int:
         document_total,
     )
 
+    # Until JasperFx 2.59.0 every shipped suite was an enrolled suite, so one number served both and
+    # the sentence read "ships **N suites, M tests**". 2.59.0 broke that: it added two opt-in suites
+    # Fisher does not enroll (jasperfx#724, whose precondition Fisher cannot construct at all -- see
+    # jasperfx#727 -- and jasperfx#725, which needs a fixture seam). The claim now has to separate what
+    # the library ships from what Fisher enrolls, and only the second is checkable from a test run.
     ships = re.search(
-        r"`JasperFx\.Events\.ComplianceTests` ([\d.]+) ships \*\*(\d+) suites, (\d+) tests\*\*",
+        r"`JasperFx\.Events\.ComplianceTests` ([\d.]+) ships \d+ suites; "
+        r"Fisher enrolls \*\*(\d+) of them, (\d+) tests\*\*",
         handoff,
     )
     if ships is None:
-        failures.expect("HANDOFF compliance section, 'ships N suites, M tests'", None,
+        failures.expect("HANDOFF compliance section, 'ships N suites; Fisher enrolls M of them, K tests'", None,
                         f"{len(compliance)} suites, {compliance_total} tests")
     else:
         failures.expect("compliance section, suites", ships.group(2), len(compliance))
@@ -335,14 +341,17 @@ def main() -> int:
         failures.expect("compliance section, package version", ships.group(1), compliance_pinned)
 
     # ---- the enrollment file's own prose count -------------------------------------------------
+    # Same wording change as `ships` above, and for the same reason: "All <n> that ship ... are
+    # enrolled" stopped being true at JasperFx 2.59.0.
     enrolled_claim = re.search(
-        r"All ([\w-]+) that ship in\s*\n?\s*\*?\s*JasperFx\.Events\.ComplianceTests ([\d.]+) are enrolled",
+        r"([\w-]+) are enrolled from\s*\n?\s*\*?\s*JasperFx\.Events\.ComplianceTests ([\d.]+)",
         (root / ENROLLMENT).read_text(encoding="utf-8"),
     )
     if enrolled_claim is None:
         failures.add(
-            f"{ENROLLMENT}: could not find its 'All <n> that ship in ... are enrolled' comment. "
-            f"It is the third place these numbers live; update this script if it was reworded."
+            f"{ENROLLMENT}: could not find its '<n> are enrolled from JasperFx.Events.ComplianceTests "
+            f"<version>' comment. It is the third place these numbers live; update this script if it "
+            f"was reworded."
         )
     else:
         failures.expect("enrollment comment, suite count", enrolled_claim.group(1),

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -8,8 +8,12 @@ namespace Fisher.Tests.Compliance;
  * Fisher's session pair through FisherComplianceFixture. Marten and Polecat enroll the same way, so
  * these tests cannot drift between the products.
  *
- * Suites were added one at a time as Fisher grew into them. All thirty-seven that ship in
- * JasperFx.Events.ComplianceTests 2.56.0 are enrolled; there is no suite Fisher declines.
+ * Suites were added one at a time as Fisher grew into them, and thirty-seven are enrolled from
+ * JasperFx.Events.ComplianceTests 2.59.0, which itself ships thirty-nine. The two not enrolled are both
+ * opt-in and both new in 2.59.0: SingleTenantedEventSlicingCompliance (jasperfx#724), whose
+ * mixed-tenancy precondition cannot be constructed on Fisher at all -- see jasperfx#727 -- and
+ * CompositeProjectionCompliance (jasperfx#725), which needs an AddCompositeProjection member on the
+ * fixture. Neither is a suite Fisher declines on behaviour.
  *
  * Nothing in the fixture throws any more, but the discipline stands for the next seam member that
  * arrives ahead of the feature: a member Fisher cannot honour throws a NotSupportedException naming

--- a/src/Fisher/Internal/FisherSession.cs
+++ b/src/Fisher/Internal/FisherSession.cs
@@ -26,8 +26,23 @@ namespace Fisher.Internal;
 ///         contention against itself rather than throughput.
 ///     </para>
 /// </remarks>
-internal partial class FisherSession : IDocumentSession, ITenantOperations, IStorageSession, IAsyncDisposable
+internal partial class FisherSession : IDocumentSession, ITenantOperations, IStorageSession, IEventTenancySource,
+    IAsyncDisposable
 {
+    /// <summary>
+    ///     The event store's tenancy style, for the shared single-stream projection base.
+    /// </summary>
+    /// <remarks>
+    ///     <b>fisher#139.</b> <c>JasperFxSingleStreamProjectionBase.BuildSlicer</c> reads this to decide
+    ///     whether to set <c>ForceSingleTenancy</c> on the slicer it builds. On a single-tenanted store,
+    ///     events whose tenant ids disagree must still fold into one aggregate rather than being sliced
+    ///     per tenant — wolverine#2053 / marten#4085, which only ever bit the async daemon, since live
+    ///     and inline aggregation fold the same events correctly. Marten got that fix by overriding
+    ///     <c>BuildSlicer</c> in its own subclass; ours is an empty class body, so we went without it
+    ///     until jasperfx#723 moved the decision into the base. Answering here is the whole of our side.
+    /// </remarks>
+    public JasperFx.MultiTenancy.TenancyStyle EventTenancyStyle => Options.Events.TenancyStyle;
+
     private readonly List<Weasel.Storage.IStorageOperation> _operations;
 
     /// <summary>


### PR DESCRIPTION
Closes #139.

## What was wrong

On a **single-tenanted** store, events whose tenant ids disagree must still fold into one aggregate rather than being sliced per tenant. Fisher sliced them per tenant, splitting one stream into several partial documents — each having seen only part of its own history.

This is wolverine#2053, transferred to [marten#4085](https://github.com/JasperFx/marten/issues/4085). It only ever bit the **async daemon**; live and inline aggregation fold the same events correctly, which is exactly why it stayed invisible.

## Why Fisher had it

The fix is `ForceSingleTenancy` on `TenantedEventSlicer`, set when the projection builds its slicer. Marten set it by overriding `BuildSlicer` in its own `SingleStreamProjection<TDoc,TId>`. Ours is an empty class body, so we inherited the base's slicer without it — and `EventStoreOptions.TenancyStyle` defaults to `Single`, so the precondition is the default configuration.

It stayed latent because the flag was inert on the async path in JasperFx.Events itself until jasperfx#721/#722. Once that landed, Marten got the fix and Fisher did not.

## The change

jasperfx#723 moved the decision into `JasperFxSingleStreamProjectionBase`, which resolves it from `IEventTenancySource` on the session — the only thing `BuildSlicer` is handed. Fisher's whole side is answering that member:

```csharp
public JasperFx.MultiTenancy.TenancyStyle EventTenancyStyle => Options.Events.TenancyStyle;
```

`FisherSession` is the single session class, and its tenant scopes are themselves `FisherSession` instances, so one implementation covers every path. Fully qualified because Fisher has no `TenancyStyle` global-using alias.

Also rolls JasperFx 2.56.0 → 2.59.0, which is the release the seam ships in — three releases, so worth a look at the diff beyond this change.

## Verification

`Fisher.Tests` — **1362 passed, 0 failed**, 9.9s on net9.0. That includes the shared compliance suites, which recompile inside `Fisher.Tests` against 2.59.0.

Note that no test here yet asserts the fixed behaviour directly: jasperfx#724 adds `SingleTenantedEventSlicingCompliance` for exactly this, and it is opt-in. Enrolling it is worth a follow-up — it is what would keep this from regressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)