### PR TITLE
Read the host-level JasperFxOptions (gh-141)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2013,6 +2013,25 @@ hosted services. The store is a singleton, sessions are scoped, and the returned
   a non-WAL store projects correctly, just serialised against its writers.
 - **`AutoCreate.None` wins over `ApplyAllDatabaseChangesOnStartup()`.** The hosted service starts and
   does nothing, rather than the registration being the thing that quietly overrides schema policy.
+- **The host-level `JasperFxOptions` is read in `Configured`, which is one call where the siblings
+  need two** (fisher#141). `JasperFxOptions.EnableAdvancedTracking` is documented as telling *all*
+  Critter Stack tools to opt in and is what a CritterWatch host sets; Fisher had
+  `Events.EnableExtendedProgressionTracking` and read `JasperFxOptions` **nowhere**, so the same host
+  configuration lit up Marten and Polecat and silently did nothing here. Silent in the direction that
+  hurts: a console showing no per-shard state is indistinguishable from a store with none to report.
+  - **Every registration path already funnels through `Configured`**, primary and ancillary alike, so
+    "and the ancillary stores too" holds by construction. Marten and Polecat each call their
+    equivalent at two sites because their two paths are separate, and a third path added there is a
+    third place to remember.
+  - **After the `IConfigureFisher` chain, not before**, so a per-store instrumentation default cannot
+    clobber the host's opt-in. `the_host_opt_in_outranks_a_store_level_contribution` pins it and is
+    the only test that fails when the call is moved.
+  - **One-way.** A false `EnableAdvancedTracking` is the default rather than a statement, so it must
+    not turn *off* a store that opted in for itself — which a plain assignment would do.
+  - `JasperFxOptions.ApplicationAssemblyReuseWarning` is deliberately **not** read. Polecat buffers it
+    in the same method and logs it from an always-registered activator; Fisher has no unconditional
+    startup hosted service to log it from, so surfacing it means registering one. Filed rather than
+    folded in as fisher#142.
 
 **Everything Fisher hands a container now implements `IDisposable` as well as `IAsyncDisposable`** —
 `DocumentStore`, `FisherDatabase`, `FisherSession`, and `IQuerySession` with them. That is not a

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1417 tests green on net9.0 and net10.0**, with no known intermittent failures — 1362 in
+**1423 tests green on net9.0 and net10.0**, with no known intermittent failures — 1368 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 329 of
 them are shared cross-store compliance tests — 260 event sourcing and 69 document. On JasperFx **2.59.0** / Weasel **9.27.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 37 suites and 329 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,362.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,368.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/configuration/hostbuilder.md
+++ b/docs/configuration/hostbuilder.md
@@ -167,6 +167,34 @@ services.ConfigureFisher((serviceProvider, options) =>
 Contributions run after the `AddFisher(...)` lambda, in registration order, and may be registered
 either side of it — they are resolved when the store is built, not when the call is made.
 
+## Host-level JasperFx options
+
+`AddJasperFx(...)` configures the whole application rather than one store, and Fisher reads it when
+each store is built:
+
+```cs
+builder.Services.AddJasperFx(o => o.EnableAdvancedTracking = true);
+builder.Services.AddFisher(options => options.Connection("Data Source=app.db"));
+```
+
+`EnableAdvancedTracking` is the switch a CritterWatch host throws, and it turns on
+`Events.EnableExtendedProgressionTracking` for **every** Fisher store the container builds — the
+primary and every `AddFisherStore<T>` alike — so extended per-shard state reaches a monitoring
+console without naming each store.
+
+::: tip
+It only ever **adds**. A host that leaves `EnableAdvancedTracking` at its default does not switch off
+a store that asked for extended tracking in its own configuration, and the read runs *after* the
+`IConfigureFisher` chain so a per-store contribution cannot clobber the host's opt-in.
+:::
+
+::: warning
+Before 1.0.6 Fisher never read `JasperFxOptions` at all, so this switch lit up Marten and Polecat and
+silently did nothing here ([#141](https://github.com/JasperFx/fisher/issues/141)). A console then
+showed no per-shard state for Fisher stores with nothing to indicate why, which is the same failure
+shape as having nothing to report.
+:::
+
 ## Session Factories
 
 By default, the scoped `IDocumentSession` is a lightweight session. Supply your own `ISessionFactory`

--- a/src/Fisher.Tests/Configuration/host_level_jasperfx_options.cs
+++ b/src/Fisher.Tests/Configuration/host_level_jasperfx_options.cs
@@ -1,0 +1,166 @@
+using JasperFx;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Fisher.Tests.Configuration;
+
+/// <summary>
+///     fisher#141 — the host-level <see cref="JasperFxOptions" /> reaches every Fisher store the
+///     container builds.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>JasperFxOptions.EnableAdvancedTracking</c> is documented as telling <em>all</em> Critter
+///         Stack tools to opt into advanced tracking, and is the one switch a CritterWatch host throws.
+///         Fisher had <c>Events.EnableExtendedProgressionTracking</c> and never read <c>JasperFxOptions</c> at
+///         all, so the same host configuration lit up Marten and Polecat and silently did nothing here
+///         — and a console then shows no per-shard state for those stores with nothing to say why. The
+///         absence of monitoring data is indistinguishable from having none to report, which is the
+///         shape that makes this worth a test rather than a line in the docs.
+///     </para>
+///     <para>
+///         Fisher reads it in one place, where the siblings each need two: every registration path goes
+///         through <c>FisherServiceCollectionExtensions.Configured</c>, primary and ancillary alike, so
+///         "and the ancillary stores too" holds by construction. The ancillary test below is what keeps
+///         that true if the paths ever diverge.
+///     </para>
+/// </remarks>
+public class host_level_jasperfx_options : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _primary = TemporaryDatabase.Create("jasperfx-options-primary");
+    private readonly TemporaryDatabase _secondary = TemporaryDatabase.Create("jasperfx-options-secondary");
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        _primary.Dispose();
+        _secondary.Dispose();
+
+        return ValueTask.CompletedTask;
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private Task<IHost> HostWith(Action<IServiceCollection> configure)
+        => Host.CreateDefaultBuilder().ConfigureServices(configure).StartAsync(Token);
+
+    [Fact]
+    public async Task advanced_tracking_reaches_the_primary_store()
+    {
+        using var host = await HostWith(services =>
+        {
+            services.AddJasperFx(o => o.EnableAdvancedTracking = true);
+            services.AddFisher(options => options.ConnectionString = _primary.ConnectionString);
+        });
+
+        host.Services.GetRequiredService<IDocumentStore>()
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+
+        await host.StopAsync(Token);
+    }
+
+    /// <summary>
+    ///     The half a monitoring console actually notices, since a modular monolith's stores are the
+    ///     ancillary ones. Marten applies its equivalent to both explicitly; here they share a code path,
+    ///     and this is what says so.
+    /// </summary>
+    [Fact]
+    public async Task advanced_tracking_reaches_an_ancillary_store()
+    {
+        using var host = await HostWith(services =>
+        {
+            services.AddJasperFx(o => o.EnableAdvancedTracking = true);
+            services.AddFisher(options => options.ConnectionString = _primary.ConnectionString);
+            services.AddFisherStore<IAdvancedTrackingStore>(options =>
+                options.ConnectionString = _secondary.ConnectionString);
+        });
+
+        host.Services.GetRequiredService<IDocumentStore>()
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+
+        host.Services.GetRequiredService<IAdvancedTrackingStore>()
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+
+        await host.StopAsync(Token);
+    }
+
+    [Fact]
+    public async Task advanced_tracking_off_leaves_the_store_at_its_own_default()
+    {
+        using var host = await HostWith(services =>
+        {
+            services.AddJasperFx();
+            services.AddFisher(options => options.ConnectionString = _primary.ConnectionString);
+        });
+
+        host.Services.GetRequiredService<IDocumentStore>()
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+
+        await host.StopAsync(Token);
+    }
+
+    /// <summary>
+    ///     The host switch only ever adds. A false <c>EnableAdvancedTracking</c> is the default rather
+    ///     than a statement, so reading it must not turn <em>off</em> a store that asked for extended
+    ///     tracking in its own configuration — which is what a plain assignment would do.
+    /// </summary>
+    [Fact]
+    public async Task a_store_that_opted_in_itself_is_not_switched_off_by_a_quiet_host()
+    {
+        using var host = await HostWith(services =>
+        {
+            services.AddJasperFx();
+            services.AddFisher(options =>
+            {
+                options.ConnectionString = _primary.ConnectionString;
+                options.Events.EnableExtendedProgressionTracking = true;
+            });
+        });
+
+        host.Services.GetRequiredService<IDocumentStore>()
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+
+        await host.StopAsync(Token);
+    }
+
+    /// <summary>
+    ///     Where the read sits in the registration is a decision, not an accident: it runs <b>after</b>
+    ///     the <c>IConfigureFisher</c> chain, so a per-store contribution cannot clobber the host's
+    ///     opt-in. Moving the call above the loop makes this fail and nothing else.
+    /// </summary>
+    [Fact]
+    public async Task the_host_opt_in_outranks_a_store_level_contribution()
+    {
+        using var host = await HostWith(services =>
+        {
+            services.AddJasperFx(o => o.EnableAdvancedTracking = true);
+            services.AddFisher(options => options.ConnectionString = _primary.ConnectionString);
+            services.ConfigureFisher(options => options.Events.EnableExtendedProgressionTracking = false);
+        });
+
+        host.Services.GetRequiredService<IDocumentStore>()
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+
+        await host.StopAsync(Token);
+    }
+
+    /// <summary>
+    ///     A host that never calls <c>AddJasperFx</c> registers no options at all, which is the ordinary
+    ///     case for an application using Fisher on its own. The read has to tolerate the null rather than
+    ///     making JasperFx's host integration a prerequisite for building a store.
+    /// </summary>
+    [Fact]
+    public async Task a_host_with_no_jasperfx_options_registered_still_builds_a_store()
+    {
+        using var host = await HostWith(services =>
+            services.AddFisher(options => options.ConnectionString = _primary.ConnectionString));
+
+        host.Services.GetRequiredService<IDocumentStore>()
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+
+        await host.StopAsync(Token);
+    }
+}
+
+public interface IAdvancedTrackingStore : IDocumentStore;

--- a/src/Fisher/FisherServiceCollectionExtensions.cs
+++ b/src/Fisher/FisherServiceCollectionExtensions.cs
@@ -269,6 +269,11 @@ public static class FisherServiceCollectionExtensions
             }
         }
 
+        // fisher#141. After the contribution chain, not before: the host switch is the outer statement,
+        // and applying it first would let a per-store instrumentation default clobber it. It only ever
+        // adds, so a store that asked for extended tracking itself is unaffected either way.
+        options.ReadJasperFxOptions(services.GetService<JasperFx.JasperFxOptions>());
+
         return options;
     }
 

--- a/src/Fisher/StoreOptions.cs
+++ b/src/Fisher/StoreOptions.cs
@@ -114,6 +114,43 @@ public class StoreOptions
     public EventStoreOptions Events { get; } = new();
 
     /// <summary>
+    ///     Apply the host-level <see cref="JasperFxOptions" /> to this store, so a switch thrown once for
+    ///     the application reaches every Critter Stack store in it (fisher#141).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="JasperFxOptions.EnableAdvancedTracking" /> is documented as telling <em>all</em>
+    ///         Critter Stack tools to opt into advanced tracking, and is what a CritterWatch host sets.
+    ///         Fisher had <see cref="EventStoreOptions.EnableExtendedProgressionTracking" /> and no way
+    ///         for that switch to reach it, so a host lighting up Marten and Polecat left its Fisher
+    ///         stores reporting
+    ///         nothing — and the absence of monitoring data is indistinguishable from having none to
+    ///         report, which is why this was silent.
+    ///     </para>
+    ///     <para>
+    ///         <b>One-way.</b> A false <see cref="JasperFxOptions.EnableAdvancedTracking" /> is the
+    ///         default rather than a statement, so it must not turn <em>off</em> a store that asked for
+    ///         extended tracking in its own configuration. The host opt-in can only add.
+    ///     </para>
+    ///     <para>
+    ///         Called from one place — <c>FisherServiceCollectionExtensions.Configured</c>, which every
+    ///         registration path already funnels through, primary and ancillary alike. Marten and Polecat
+    ///         each call their equivalent at two sites because their two paths are separate; the single
+    ///         choke point here is what makes "and the ancillary stores too" true by construction rather
+    ///         than by remembering.
+    ///     </para>
+    /// </remarks>
+    internal void ReadJasperFxOptions(JasperFxOptions? options)
+    {
+        if (options is null) return;
+
+        if (options.EnableAdvancedTracking)
+        {
+            Events.EnableExtendedProgressionTracking = true;
+        }
+    }
+
+    /// <summary>
     ///     Settings for the async projection daemon.
     /// </summary>
     public DaemonSettings DaemonSettings { get; } = new();


### PR DESCRIPTION
Closes #141.

## The gap

`JasperFxOptions.EnableAdvancedTracking` is documented as telling **all** Critter Stack tools to opt into advanced tracking, and is the one switch a CritterWatch host throws. Fisher had `Events.EnableExtendedProgressionTracking` and **read `JasperFxOptions` nowhere** — confirmed by grep, zero occurrences in `src/Fisher/`. So a host lighting up Marten and Polecat left its Fisher stores reporting nothing.

Silent in the direction that hurts, and the same shape as fisher#120: a console showing no per-shard state for a store is indistinguishable from a store with none to report.

## What changed

`StoreOptions.ReadJasperFxOptions(JasperFxOptions?)`, mirroring the siblings' method of the same name — internal there, internal here, so **no public API changed**.

It is called from **one** place, `FisherServiceCollectionExtensions.Configured`, where Marten and Polecat each need **two**. Their primary and ancillary registration paths are separate; Fisher's both funnel through `Configured` already, so "and the ancillary stores too" holds by construction, and a third path added later inherits it rather than becoming a third place to remember.

Two things about it are decisions rather than mechanics, and each is pinned by exactly one test:

- **After the `IConfigureFisher` chain, not before**, so a per-store instrumentation default cannot clobber the host's opt-in. Verified by moving the call above the loop: `the_host_opt_in_outranks_a_store_level_contribution` fails and **nothing else does**.
- **One-way.** A false `EnableAdvancedTracking` is the default rather than a statement, so it must not turn *off* a store that opted in for itself — which a plain assignment would do. `a_store_that_opted_in_itself_is_not_switched_off_by_a_quiet_host`.

The other four cover the primary store, an ancillary store, the off case leaving the store's own default alone, and a host that never calls `AddJasperFx` at all — the ordinary case for an application using Fisher on its own, where `GetService` returns null and building a store must not become conditional on JasperFx's host integration.

**Verified load-bearing by removing the call: three of the six fail.**

## Deliberately not in scope

`JasperFxOptions.ApplicationAssemblyReuseWarning`, which Polecat buffers in the same method. Its buffering half is two lines; its **surfacing** half is not. Polecat logs it from `PolecatActivator`, an always-registered hosted service — and all three of Fisher's hosted services are conditional (`FisherSchemaActivator`, `FisherInitialDataActivator`, `FisherDaemonHostedService` each register only behind an opt-in), so a plain `AddFisher(...)` has no startup hook at all. Buffering a warning nothing reads is worse than not buffering it.

Filed as #142 with that reasoning, including the case for simply declining it.

## Verification

- `dotnet test fisher.slnx` — **1423 green on net9.0 and net10.0**, no failures, no skips.
- `check_scoreboard.py` agrees on both TFMs; HANDOFF and README counts updated from the run.
- `npm run docs-build` clean. New *Host-level JasperFx options* section on the bootstrapping page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)