### PR TITLE
Register IProjectionCoordinator, and pause it around a reset (gh-138)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -513,6 +513,59 @@ Six things that are decisions rather than mechanics:
   `EventStoreOptions.HighWaterLivenessInterval` bounds it (five seconds; zero turns it off and leaves
   the health check on the gap heuristic alone).
 
+**The hosted service is the store's `IProjectionCoordinator`** (fisher#138). It registered only as an
+`IHostedService` over an internal class implementing nothing else, so **both** documented routes to the
+running daemon failed — the service was not resolvable, and the
+`GetServices<IHostedService>().OfType<IProjectionCoordinator>()` fallback found nothing either. Marten
+and Polecat have registered JasperFx's interface since jasperfx#430, so store-agnostic code could do
+daemon operations against them and not against Fisher. **No shared suite covers this** — Fisher passed
+all 37 suites throughout, which is jasperfx#732, the third instance of the pattern after jasperfx#700
+and jasperfx#718.
+
+- **JasperFx's interface, not a Fisher-local sub-interface.** Both siblings have a local one that adds
+  no members; theirs are historical (Marten's predates the lift, Polecat copied it) and a
+  store-agnostic consumer resolves the shared one anyway. Nothing new lands on Fisher's public API.
+- **No `ProjectionCoordinatorBase`.** The siblings close over it for leadership election across nodes;
+  Fisher refuses `HotCold` outright, so what is left of a coordinator here is the daemon cache and the
+  pause/resume pair, which this class already had in all but name.
+- **One instance, registered as the coordinator and resolved from there as the hosted service.**
+  Registering them separately would run two daemons over one file — two writers contending for one
+  write lock, which is the thing `_running` exists to prevent.
+- **`StartAsync` had to learn to resume**, and this is the non-obvious half. It only ever called
+  `StartAnyNewDaemonsAsync`, which *skips* a database already in `_running` — so after a pause it
+  would have started nothing at all. It now restarts agents on the daemons it holds first, which makes
+  a second `StartAsync` equivalent to `PauseAsync` + `StartAsync`, the property JasperFx's own
+  coordinator base establishes and the one `ResumeAsync` rests on.
+- **Pausing stops the tenant poller too.** It builds and starts daemons of its own, so leaving it
+  running would let a tenant appearing mid-pause quietly begin projecting; "paused" has to mean paused
+  for tenants that do not exist yet.
+- **An ancillary store gets `IProjectionCoordinator<T>` and not the unmarked one**, so resolving
+  `IProjectionCoordinator` is never ambiguous about whose daemons come back.
+
+**`Advanced.ResetAllDataAsync` pauses a hosted daemon around the wipe, and that is a deliberate
+divergence from Marten**, which leaves its daemon alone. The wipe deletes `fi_event_progression` out
+from under agents holding their positions in memory: they carry on from where they were, record nothing
+against an event store that now starts at zero, and every later `WaitForNonStaleData` times out naming
+shards that recorded no progress. Silent until something waits.
+
+- **The reason to diverge is that the alternative was unreachable rather than merely manual.** Until
+  the coordinator existed there was no handle on the running daemon, so the caller this method
+  overwhelmingly has — a spec fixture resetting between scenarios — could not have paused it by hand.
+- **`DocumentStore.RunningDaemons` is the seam**, set by the hosted service on start and cleared on
+  stop, because `Advanced` reaches the store and not the container. It is a claim about *right now*
+  rather than about registration, and it is deliberately not a general escape hatch — application code
+  resolves `IProjectionCoordinator` from DI, which is the store-agnostic route.
+  **Unwrapped through `SecondaryStoreProxy`**, or an ancillary store — which arrives as its marker
+  proxy rather than as a `DocumentStore` — would silently get the old behaviour.
+- **The resume is in a `finally`.** A half-done wipe with the daemon left paused is the worse of the
+  two failures: the caller sees the exception either way, and a daemon that never resumes turns one
+  failed reset into every subsequent projection silently not running.
+- **Only a daemon this process hosts is paused.** `ExternallyManaged`, a hand-built store, or another
+  process all keep the hazard, which is the honest outcome since nothing here can reach them.
+- `a_reset_leaves_the_running_daemon_able_to_project_again` needs **two rounds** — the first
+  establishes real in-memory positions to be stranded, and a single-round test passes against the old
+  behaviour. Verified by reverting: it fails with the reported `TimeoutException` verbatim.
+
 WAL is what lets the daemon read while a session writes. It is on by default via
 `SqlitePragmaSettings.Default`; `BuildProjectionDaemonAsync` warns when it is not, because without it
 the daemon and every writer serialize against each other and that presents as a slow projection

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1423 tests green on net9.0 and net10.0**, with no known intermittent failures — 1368 in
+**1430 tests green on net9.0 and net10.0**, with no known intermittent failures — 1375 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 329 of
 them are shared cross-store compliance tests — 260 event sourcing and 69 document. On JasperFx **2.59.0** / Weasel **9.27.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 37 suites and 329 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,368.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,375.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -175,6 +175,71 @@ await daemon.RewindSubscriptionAsync("ReleasedTally", token, sequenceFloor: 0);
 Sharing a published type between two projections is legal and costs nothing until somebody rebuilds,
 so Fisher warns rather than refusing.
 
+## Reaching the running daemon
+
+`AddAsyncDaemon()` registers a JasperFx `IProjectionCoordinator`, which is how application code gets
+at the daemons the host is running:
+
+```cs
+var coordinator = services.GetRequiredService<IProjectionCoordinator>();
+
+var daemon = coordinator.DaemonForMainDatabase();
+await daemon.WaitForNonStaleData(TimeSpan.FromSeconds(30));
+
+// Under database-per-tenant, one daemon per file.
+var forTenant = await coordinator.DaemonForDatabase("tenant-a");
+var all = await coordinator.AllDaemonsAsync();
+```
+
+`PauseAsync()` stops every agent without disposing anything, and `ResumeAsync()` restarts them — which
+is what a maintenance window or a test fixture wants:
+
+```cs
+await coordinator.PauseAsync();
+// ... do the thing the daemon must not be running for ...
+await coordinator.ResumeAsync();
+```
+
+::: tip
+The coordinator **is** the hosted service, registered once and resolved from both places. Two
+registrations would be two daemons over one file, which on SQLite is two writers contending for the
+single write lock.
+:::
+
+::: tip
+Pausing stops the tenant poller too. It builds and starts daemons of its own, so leaving it running
+would let a tenant appearing mid-pause quietly begin projecting.
+:::
+
+::: warning
+The coordinator's daemons exist only once the **host has started** — it is a hosted service. Resolving
+it while the container is still being built and calling `DaemonForMainDatabase()` throws saying so.
+`DaemonMode.Disabled` and `DaemonMode.ExternallyManaged` register no coordinator at all.
+:::
+
+## Resetting data under a running daemon
+
+`Advanced.ResetAllDataAsync()` pauses a daemon this process is hosting, wipes, and resumes it.
+
+Without that the wipe **strands the daemon**: the delete takes `fi_event_progression` out from under
+agents holding their positions in memory, so they carry on from where they were, record nothing
+against an event store that now starts at zero, and every later `WaitForNonStaleData` times out saying
+shards have recorded no progress. Silent until something waits — which for the spec suite that
+reported it ([#138](https://github.com/JasperFx/fisher/issues/138)) was the next scenario.
+
+::: warning
+Only a daemon **this process is hosting** is paused, because that is the only one the store knows
+about. `DaemonMode.ExternallyManaged`, a store built with `DocumentStore.For(...)`, or a daemon in
+another process all keep the hazard — pause them yourself around the wipe.
+:::
+
+::: tip
+This is a deliberate divergence from Marten, which leaves its daemon alone here. The reason to take it
+is that the alternative was unreachable rather than merely manual: before #138 there was no way to get
+at the running daemon at all, so the caller this method overwhelmingly has — a test fixture resetting
+between scenarios — could not have paused it by hand.
+:::
+
 ## Catching up and waiting
 
 ```cs

--- a/src/Fisher.Tests/Events/projection_coordinator.cs
+++ b/src/Fisher.Tests/Events/projection_coordinator.cs
@@ -1,0 +1,232 @@
+using JasperFx;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Fisher.Tests.Events;
+
+public record WardOpened(string Name);
+
+public class WardRoster
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; } = "";
+
+    public void Apply(WardOpened e) => Name = e.Name;
+}
+
+/// <summary>
+///     fisher#138 — the running daemon is reachable from application code as an
+///     <see cref="IProjectionCoordinator" />, and <c>Advanced.ResetAllDataAsync</c> no longer strands it.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Before this, <c>AddAsyncDaemon</c> registered only <c>IHostedService</c> over an internal
+///         class that implemented nothing else, so <b>both</b> documented routes failed: the service was
+///         not registered under any reachable interface, and the
+///         <c>GetServices&lt;IHostedService&gt;().OfType&lt;IProjectionCoordinator&gt;()</c> fallback
+///         found nothing either. Marten and Polecat have registered JasperFx's interface since
+///         jasperfx#430, so store-agnostic code could do daemon operations against them and not here.
+///     </para>
+///     <para>
+///         Fisher registers <em>JasperFx's</em> interface rather than a Fisher-local sub-interface. Both
+///         siblings have a local one that adds no members; theirs are historical, and a store-agnostic
+///         consumer resolves the shared one anyway.
+///     </para>
+/// </remarks>
+public class projection_coordinator : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("projection-coordinator");
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        _database.Dispose();
+
+        return ValueTask.CompletedTask;
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private Task<IHost> StartedHost()
+        => Host.CreateDefaultBuilder()
+            .ConfigureServices(services => services.AddFisher(options =>
+                {
+                    options.ConnectionString = _database.ConnectionString;
+                    options.AutoCreateSchemaObjects = AutoCreate.All;
+                    options.Projections.Snapshot<WardRoster>(SnapshotLifecycle.Async);
+                })
+                .ApplyAllDatabaseChangesOnStartup()
+                .AddAsyncDaemon())
+            .StartAsync(Token);
+
+    private async Task<Guid> OpenWardAsync(IHost host, string name)
+    {
+        var id = Guid.NewGuid();
+
+        await using var session = host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        session.Events.StartStream<WardRoster>(id, new WardOpened(name));
+        await session.SaveChangesAsync(Token);
+
+        return id;
+    }
+
+    [Fact]
+    public async Task the_coordinator_is_resolvable_from_the_container()
+    {
+        using var host = await StartedHost();
+
+        host.Services.GetRequiredService<IProjectionCoordinator>().ShouldNotBeNull();
+
+        await host.StopAsync(Token);
+    }
+
+    /// <summary>
+    ///     The documented fallback for a host that does not register the interface — walking the hosted
+    ///     services and casting. It found nothing before, because the class implemented no such
+    ///     interface; now it finds the same instance the container hands out, which is the property that
+    ///     matters. Two registrations of one coordinator would be two daemons over one file, which on
+    ///     SQLite is two writers contending for the single write lock.
+    /// </summary>
+    [Fact]
+    public async Task the_hosted_service_and_the_resolved_coordinator_are_one_instance()
+    {
+        using var host = await StartedHost();
+
+        var resolved = host.Services.GetRequiredService<IProjectionCoordinator>();
+        var walked = host.Services.GetServices<IHostedService>()
+            .OfType<IProjectionCoordinator>()
+            .ShouldHaveSingleItem();
+
+        walked.ShouldBeSameAs(resolved);
+
+        await host.StopAsync(Token);
+    }
+
+    [Fact]
+    public async Task the_coordinator_hands_back_the_running_daemon()
+    {
+        using var host = await StartedHost();
+        var coordinator = host.Services.GetRequiredService<IProjectionCoordinator>();
+
+        var id = await OpenWardAsync(host, "Ward A");
+
+        var daemon = coordinator.DaemonForMainDatabase();
+        await daemon.WaitForNonStaleData(TimeSpan.FromSeconds(30));
+
+        await using var query = host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        (await query.LoadAsync<WardRoster>(id, Token)).ShouldNotBeNull().Name.ShouldBe("Ward A");
+
+        (await coordinator.AllDaemonsAsync()).ShouldHaveSingleItem().ShouldBeSameAs(daemon);
+
+        await host.StopAsync(Token);
+    }
+
+    /// <summary>
+    ///     Pause stops the agents without disposing anything, so resume restarts the same daemons rather
+    ///     than needing fresh ones — which is what makes the stop/reset/start sequence below possible.
+    /// </summary>
+    [Fact]
+    public async Task pause_then_resume_leaves_the_daemon_projecting()
+    {
+        using var host = await StartedHost();
+        var coordinator = host.Services.GetRequiredService<IProjectionCoordinator>();
+
+        await coordinator.PauseAsync();
+        await coordinator.ResumeAsync();
+
+        var id = await OpenWardAsync(host, "Ward B");
+
+        await coordinator.DaemonForMainDatabase().WaitForNonStaleData(TimeSpan.FromSeconds(30));
+
+        await using var query = host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        (await query.LoadAsync<WardRoster>(id, Token)).ShouldNotBeNull().Name.ShouldBe("Ward B");
+
+        await host.StopAsync(Token);
+    }
+
+    [Fact]
+    public async Task an_unknown_database_is_refused_by_name()
+    {
+        using var host = await StartedHost();
+        var coordinator = host.Services.GetRequiredService<IProjectionCoordinator>();
+
+        var ex = await Should.ThrowAsync<ArgumentOutOfRangeException>(
+            async () => await coordinator.DaemonForDatabase("no-such-database"));
+
+        ex.Message.ShouldContain("no-such-database");
+
+        await host.StopAsync(Token);
+    }
+
+    /// <summary>
+    ///     <b>The failure fisher#138 was reported for.</b> A wipe deletes <c>fi_event_progression</c> out
+    ///     from under a running daemon whose agents hold their positions in memory, so they carry on from
+    ///     where they were and record nothing against an event store that now starts at zero. Every later
+    ///     wait then times out saying shards have recorded no progress — silent until something waits,
+    ///     which in the reporting case was a spec suite resetting between scenarios.
+    /// </summary>
+    /// <remarks>
+    ///     Two rounds, and the second is the assertion: the first establishes real in-memory positions to
+    ///     be stranded, and a single-round test would pass against the old behaviour.
+    /// </remarks>
+    [Fact]
+    public async Task a_reset_leaves_the_running_daemon_able_to_project_again()
+    {
+        using var host = await StartedHost();
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+
+        var before = await OpenWardAsync(host, "Ward C");
+        await store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(30));
+
+        await store.Advanced.ResetAllDataAsync(Token);
+
+        await using (var query = store.LightweightSession())
+        {
+            (await query.LoadAsync<WardRoster>(before, Token)).ShouldBeNull();
+        }
+
+        var after = await OpenWardAsync(host, "Ward D");
+        await store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(30));
+
+        await using (var query = store.LightweightSession())
+        {
+            (await query.LoadAsync<WardRoster>(after, Token)).ShouldNotBeNull().Name.ShouldBe("Ward D");
+        }
+
+        await host.StopAsync(Token);
+    }
+
+    /// <summary>
+    ///     A store nobody is hosting a daemon for still resets. The pause is conditional on a daemon this
+    ///     process is actually running, which is the only one the store can know about — an externally
+    ///     managed daemon, or one in another process, keeps the hazard above because nothing here can
+    ///     reach it.
+    /// </summary>
+    [Fact]
+    public async Task a_reset_without_a_hosted_daemon_still_works()
+    {
+        await using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid(), new WardOpened("Ward E"));
+            await session.SaveChangesAsync(Token);
+        }
+
+        await store.Advanced.ResetAllDataAsync(Token);
+
+        await using var query = store.LightweightSession();
+        (await query.Events.QueryEventsAsync(new JasperFx.Events.EventQuery(), Token))
+            .Events.ShouldBeEmpty();
+    }
+}

--- a/src/Fisher/AdvancedOperations.cs
+++ b/src/Fisher/AdvancedOperations.cs
@@ -29,10 +29,54 @@ public class AdvancedOperations
     /// <summary>
     ///     Delete every document and every event belonging to this store, keeping the schema.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>A running async daemon is paused around the wipe and resumed afterwards</b>
+    ///         (fisher#138), and without that the wipe strands it. The delete takes
+    ///         <c>fi_event_progression</c> out from under agents that hold their positions in memory,
+    ///         so they carry on from where they were, record no progress against an event store that
+    ///         now starts at zero, and every later <c>WaitForNonStaleData</c> times out with a message
+    ///         about shards that have recorded nothing. Silent until something waits.
+    ///     </para>
+    ///     <para>
+    ///         <b>This is a divergence from Marten, which leaves its daemon alone here.</b> The reason
+    ///         to take it is that the alternative was unreachable rather than merely manual: until
+    ///         fisher#138 there was no way to get at the running daemon from application code at all,
+    ///         so a spec fixture resetting between scenarios — the caller this method overwhelmingly
+    ///         has — could not have paused it by hand.
+    ///     </para>
+    ///     <para>
+    ///         Only a daemon <em>this process is hosting</em> is paused, since that is the only one the
+    ///         store knows about. <c>DaemonMode.ExternallyManaged</c>, a store built by
+    ///         <see cref="DocumentStore.For(System.Action{StoreOptions})" />, or a daemon in another
+    ///         process are all unaffected and keep the hazard above — which is the honest outcome, as
+    ///         nothing here can reach them.
+    ///     </para>
+    /// </remarks>
     public async Task ResetAllDataAsync(CancellationToken token = default)
     {
-        await Clean.DeleteAllDocumentsAsync(token).ConfigureAwait(false);
-        await Clean.DeleteAllEventDataAsync(token).ConfigureAwait(false);
+        var daemons = _store.RunningDaemons;
+
+        if (daemons is not null)
+        {
+            await daemons.PauseAsync().ConfigureAwait(false);
+        }
+
+        try
+        {
+            await Clean.DeleteAllDocumentsAsync(token).ConfigureAwait(false);
+            await Clean.DeleteAllEventDataAsync(token).ConfigureAwait(false);
+        }
+        finally
+        {
+            // In a finally, because a half-done wipe with the daemon left paused is the worse of the
+            // two failures: the caller sees the exception either way, and a paused daemon that never
+            // resumes turns one failed reset into every subsequent projection silently not running.
+            if (daemons is not null)
+            {
+                await daemons.ResumeAsync().ConfigureAwait(false);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Fisher/DocumentStore.cs
+++ b/src/Fisher/DocumentStore.cs
@@ -100,6 +100,26 @@ public partial class DocumentStore : IDocumentStore
     /// </summary>
     public AdvancedOperations Advanced => _advanced ??= new AdvancedOperations(this);
 
+    /// <summary>
+    ///     The projection coordinator currently running this store's daemons, or null when none is.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Set by <c>FisherDaemonHostedService</c> when the host starts it and cleared when it
+    ///         stops, so it is a fact about <em>right now</em> rather than about registration:
+    ///         <c>AddAsyncDaemon(DaemonMode.ExternallyManaged)</c> leaves it null, and so does a store
+    ///         built directly with <see cref="For(System.Action{StoreOptions})" />.
+    ///     </para>
+    ///     <para>
+    ///         It exists because <see cref="AdvancedOperations.ResetAllDataAsync" /> has to pause the
+    ///         daemon around the wipe (fisher#138) and reaches the store, not the container. Deliberately
+    ///         <b>not</b> a general escape hatch onto the coordinator — application code resolves
+    ///         <c>IProjectionCoordinator</c> from DI, which is the store-agnostic route and the one the
+    ///         siblings offer.
+    ///     </para>
+    /// </remarks>
+    internal JasperFx.Events.Daemon.IProjectionCoordinator? RunningDaemons { get; set; }
+
     private AdvancedOperations? _advanced;
 
     internal EventGraph EventGraph => Options.EventGraph;

--- a/src/Fisher/FisherServiceCollectionExtensions.cs
+++ b/src/Fisher/FisherServiceCollectionExtensions.cs
@@ -408,9 +408,15 @@ public sealed class FisherStoreConfigurationExpression<T> where T : class, IDocu
         switch (mode)
         {
             case DaemonMode.Solo:
-                _services.AddSingleton<IHostedService>(sp => new FisherDaemonHostedService(
+                // One instance, reachable two ways — as the hosted service that runs it and as the
+                // coordinator application code resolves. Registering the hosted service on its own is
+                // what left the daemon unreachable (fisher#138); registering them separately would run
+                // two daemons over one file, which is two writers contending for one write lock.
+                _services.AddSingleton<IProjectionCoordinator<T>>(sp => new FisherDaemonHostedService<T>(
                     sp.GetRequiredService<T>(),
                     sp.GetService<ILogger<FisherDaemonHostedService>>()));
+                _services.AddSingleton<IHostedService>(sp =>
+                    sp.GetRequiredService<IProjectionCoordinator<T>>());
                 break;
 
             case DaemonMode.HotCold:
@@ -527,7 +533,11 @@ public sealed class FisherConfigurationExpression
         switch (mode)
         {
             case DaemonMode.Solo:
-                _services.AddSingleton<IHostedService, FisherDaemonHostedService>();
+                // See the ancillary overload: one instance, registered as the coordinator and resolved
+                // from there as the hosted service, so the daemon that runs is the daemon you reach.
+                _services.AddSingleton<IProjectionCoordinator, FisherDaemonHostedService>();
+                _services.AddSingleton<IHostedService>(sp =>
+                    sp.GetRequiredService<IProjectionCoordinator>());
                 break;
 
             case DaemonMode.HotCold:
@@ -596,6 +606,23 @@ internal sealed class FisherInitialDataActivator : IHostedService
 ///         opposite situation, and they do not contend at all.
 ///     </para>
 ///     <para>
+///         <b>It is also the store's <see cref="IProjectionCoordinator" />, which is how application
+///         code reaches the running daemon</b> (fisher#138). Before that it held its daemons privately
+///         and implemented nothing else, so neither documented route worked — the service was not
+///         registered, and the <c>GetServices&lt;IHostedService&gt;().OfType&lt;IProjectionCoordinator&gt;()</c>
+///         fallback found nothing. Marten and Polecat have registered the JasperFx interface since
+///         jasperfx#430, so store-agnostic code could do daemon operations against them and not
+///         against Fisher. Fisher registers <em>that</em> interface rather than a Fisher-local
+///         sub-interface: the siblings' local ones add no members and are historical.
+///     </para>
+///     <para>
+///         <b>No leadership loop, deliberately.</b> Polecat and Marten close over JasperFx's
+///         <c>ProjectionCoordinatorBase</c>, which exists to elect a leader across nodes; Fisher
+///         refuses <see cref="DaemonMode.HotCold" /> outright, because a Fisher store is a file. What
+///         is left of a coordinator here is the daemon cache and the pause/resume pair, both of which
+///         this class already had in all but name.
+///     </para>
+///     <para>
 ///         <b>The WAL check runs here, and this is the point of putting it here.</b>
 ///         <c>BuildProjectionDaemonAsync</c> has warned about a non-WAL journal since the daemon
 ///         landed, but only a consumer building a daemon by hand ever saw it. Under a hosted service
@@ -605,7 +632,7 @@ internal sealed class FisherInitialDataActivator : IHostedService
 ///         a non-WAL store still projects correctly, just serialised against its writers.
 ///     </para>
 /// </remarks>
-internal sealed class FisherDaemonHostedService : IHostedService, IDisposable
+internal class FisherDaemonHostedService : IProjectionCoordinator, IDisposable
 {
     private readonly IDocumentStore _store;
     private readonly ILogger<FisherDaemonHostedService> _logger;
@@ -635,6 +662,23 @@ internal sealed class FisherDaemonHostedService : IHostedService, IDisposable
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        // Published so Advanced.ResetAllDataAsync can pause around a wipe (fisher#138). Set on every
+        // start rather than in the constructor, because it is a claim that daemons are running, and
+        // unwrapped because an ancillary store arrives here as its marker proxy.
+        if (Concrete() is { } starting) starting.RunningDaemons = this;
+
+        // Drain first, so a second StartAsync is equivalent to PauseAsync followed by StartAsync —
+        // the property JasperFx's own coordinator base establishes, and the one ResumeAsync rests on.
+        await StopPollingAsync().ConfigureAwait(false);
+
+        // Agents on daemons this instance already holds, which is what a resume after PauseAsync
+        // needs: StartAnyNewDaemonsAsync skips a database already in _running, so on its own it would
+        // resume nothing at all.
+        foreach (var daemon in _daemons)
+        {
+            await daemon.StartAllAsync().ConfigureAwait(false);
+        }
+
         await StartAnyNewDaemonsAsync().ConfigureAwait(false);
 
         if (_store.Tenancy.Cardinality != DatabaseCardinality.DynamicMultiple)
@@ -644,6 +688,117 @@ internal sealed class FisherDaemonHostedService : IHostedService, IDisposable
 
         _polling = new CancellationTokenSource();
         _poller = PollForNewTenantsAsync(_polling.Token);
+    }
+
+    /// <inheritdoc />
+    public IProjectionDaemon DaemonForMainDatabase()
+        => _daemons.Count > 0
+            ? _daemons[0]
+            : throw new InvalidOperationException(
+                "No projection daemon is running. AddAsyncDaemon() registers this coordinator as a "
+                + "hosted service, so its daemons exist only once the host has started — resolve it "
+                + "after StartAsync rather than while the container is still being built.");
+
+    /// <inheritdoc />
+    public async ValueTask<IProjectionDaemon> DaemonForDatabase(string databaseIdentifier)
+    {
+        if (TryFindDaemon(databaseIdentifier, out var daemon)) return daemon;
+
+        // A tenant database that has appeared since the last poll has no daemon yet, and the
+        // interface's own contract expects an implementation to go and look. Only worth a sweep under
+        // a tenancy that can gain a database; anywhere else the answer cannot change.
+        if (_store.Tenancy.Cardinality == DatabaseCardinality.DynamicMultiple)
+        {
+            await StartAnyNewDaemonsAsync().ConfigureAwait(false);
+
+            if (TryFindDaemon(databaseIdentifier, out daemon)) return daemon;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(databaseIdentifier),
+            $"No projection daemon is running for database '{databaseIdentifier}'. Running: "
+            + $"{string.Join(", ", _running)}.");
+    }
+
+    /// <inheritdoc />
+    public ValueTask<IReadOnlyList<IProjectionDaemon>> AllDaemonsAsync()
+        => new((IReadOnlyList<IProjectionDaemon>)_daemons.ToArray());
+
+    /// <summary>
+    ///     Stop every agent without disposing anything, so <see cref="ResumeAsync" /> can restart them.
+    /// </summary>
+    /// <remarks>
+    ///     The tenant poller stops too, and that is the half a caller would not think to ask for: it
+    ///     builds and starts daemons of its own, so leaving it running would let a tenant appearing
+    ///     mid-pause quietly begin projecting. "Paused" has to mean paused for tenants that do not
+    ///     exist yet.
+    /// </remarks>
+    public async Task PauseAsync()
+    {
+        await StopPollingAsync().ConfigureAwait(false);
+
+        foreach (var daemon in _daemons)
+        {
+            try
+            {
+                await daemon.StopAllAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException e)
+            {
+                // Benign during shutdown, where a second pause can fan out over daemons the first
+                // already disposed. Same reading JasperFx's own coordinator base takes.
+                _logger.LogDebug(e, "Fisher projection daemon was already disposed while pausing.");
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public Task ResumeAsync() => StartAsync(CancellationToken.None);
+
+    /// <summary>
+    ///     The concrete store behind whatever this service was handed — an ancillary store arrives as
+    ///     the <see cref="DispatchProxy" /> over its marker interface, which is not a
+    ///     <see cref="DocumentStore" />.
+    /// </summary>
+    private DocumentStore? Concrete() => SecondaryStoreProxy.Unwrap(_store) as DocumentStore;
+
+    private bool TryFindDaemon(string databaseIdentifier, out IProjectionDaemon daemon)
+    {
+        foreach (var candidate in _daemons)
+        {
+            if (string.Equals(((Events.Daemon.FisherProjectionDaemon)candidate).Database.Identifier,
+                    databaseIdentifier, StringComparison.OrdinalIgnoreCase))
+            {
+                daemon = candidate;
+                return true;
+            }
+        }
+
+        daemon = null!;
+        return false;
+    }
+
+    private async Task StopPollingAsync()
+    {
+        if (_polling is not null)
+        {
+            await _polling.CancelAsync().ConfigureAwait(false);
+        }
+
+        if (_poller is not null)
+        {
+            try
+            {
+                await _poller.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected: that is how the loop ends.
+            }
+        }
+
+        _polling?.Dispose();
+        _polling = null;
+        _poller = null;
     }
 
     private async Task StartAnyNewDaemonsAsync()
@@ -690,27 +845,11 @@ internal sealed class FisherDaemonHostedService : IHostedService, IDisposable
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        if (_polling is not null)
-        {
-            await _polling.CancelAsync().ConfigureAwait(false);
-        }
+        // Withdrawn before the agents stop, so a wipe racing shutdown does not pause a coordinator
+        // that is on its way out and then resume it.
+        if (Concrete() is { } stopping) stopping.RunningDaemons = null;
 
-        if (_poller is not null)
-        {
-            try
-            {
-                await _poller.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected: that is how the loop ends.
-            }
-        }
-
-        foreach (var daemon in _daemons)
-        {
-            await daemon.StopAllAsync().ConfigureAwait(false);
-        }
+        await PauseAsync().ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="Storage.FisherDatabase.Dispose" />
@@ -725,5 +864,24 @@ internal sealed class FisherDaemonHostedService : IHostedService, IDisposable
 
         _daemons.Clear();
         _running.Clear();
+    }
+}
+
+/// <summary>
+///     The same coordinator, addressable by an ancillary store's marker interface.
+/// </summary>
+/// <remarks>
+///     One non-generic <see cref="IProjectionCoordinator" /> can only mean one store, so a second store
+///     needs a second registration to be reachable at all — which is what JasperFx's marker variant is
+///     for. The primary store keeps the unmarked registration; a marker-typed store gets this and not
+///     that, so resolving <see cref="IProjectionCoordinator" /> is never ambiguous about which store's
+///     daemons it hands back.
+/// </remarks>
+internal sealed class FisherDaemonHostedService<T> : FisherDaemonHostedService, IProjectionCoordinator<T>
+    where T : class
+{
+    public FisherDaemonHostedService(IDocumentStore store, ILogger<FisherDaemonHostedService>? logger = null)
+        : base(store, logger)
+    {
     }
 }


### PR DESCRIPTION
Closes #138. Two halves — the first restores parity, the second is a deliberate divergence the first makes possible.

## 1. The running daemon is reachable

`AddAsyncDaemon` registered only `IHostedService` over an `internal sealed` class that implemented nothing else, so **both** documented routes failed: the service was not resolvable under any public interface, and the `GetServices<IHostedService>().OfType<IProjectionCoordinator>()` fallback found nothing either. Marten and Polecat have registered JasperFx's interface since jasperfx#430, so store-agnostic code could do daemon operations against them and not against Fisher.

`FisherDaemonHostedService` now implements it. Four decisions:

- **JasperFx's interface directly, not a Fisher-local sub-interface.** Both siblings have a local one that adds **no members** — Marten's predates the lift, Polecat copied it. A store-agnostic consumer resolves the shared one anyway, and this way **nothing new lands on Fisher's public API**.
- **No `ProjectionCoordinatorBase`.** The siblings close over it for leadership election across nodes; Fisher refuses `HotCold` outright because a store is a file. What is left of a coordinator here is the daemon cache and the pause/resume pair, which this class already had in all but name.
- **One instance**, registered as the coordinator and resolved from there as the hosted service. Registering them separately would run two daemons over one file — two writers contending for one write lock, which is exactly what `_running` exists to prevent.
- **An ancillary store gets `IProjectionCoordinator<T>` and not the unmarked one**, so resolving `IProjectionCoordinator` is never ambiguous about whose daemons come back.

**`StartAsync` had to learn to resume, and that is the non-obvious part.** It only ever called `StartAnyNewDaemonsAsync`, which *skips* a database already in `_running` — so after a pause it would have started nothing at all. It now restarts agents on daemons it already holds first, making a second `StartAsync` equivalent to `PauseAsync` + `StartAsync`, the property JasperFx's own coordinator base establishes and the one `ResumeAsync` rests on.

**Pausing stops the tenant poller too.** It builds and starts daemons of its own, so leaving it running would let a tenant appearing mid-pause quietly begin projecting — "paused" has to mean paused for tenants that do not exist yet.

## 2. `ResetAllDataAsync` no longer strands the daemon

The wipe deletes `fi_event_progression` out from under agents holding their positions in memory: they carry on from where they were, record nothing against an event store that now starts at zero, and every later wait times out. Reproduced verbatim in the test before the fix:

```
System.TimeoutException : Projection data was still stale after 00:00:30. High water is at 2;
shards are at []. Registered shards that have not recorded any progress: [WardRoster:All]
— the daemon may not be running.
```

**This is a divergence from Marten**, which leaves its daemon alone here — I flagged that when we discussed it, and you called it, so here it is. The case for taking it: the alternative was *unreachable* rather than merely manual. Until part 1 there was no handle on the running daemon at all, so the caller this method overwhelmingly has — a spec fixture resetting between scenarios, which is where the issue came from — could not have paused it by hand.

- **The resume is in a `finally`.** A half-done wipe with the daemon left paused is the worse of the two failures: the caller sees the exception either way, and a daemon that never resumes turns one failed reset into every later projection silently not running.
- **Only a daemon this process hosts is paused.** `ExternallyManaged`, a hand-built `DocumentStore.For(...)`, and another process all keep the hazard — honest, since nothing here can reach them. Documented and covered.
- **`DocumentStore.RunningDaemons` is the seam** — set on start, cleared on stop, because `Advanced` reaches the store and not the container. Deliberately not a general escape hatch; application code resolves `IProjectionCoordinator` from DI. **Unwrapped through `SecondaryStoreProxy`**, or an ancillary store — which arrives as its marker proxy — would silently keep the old behaviour.

## Verification

Both halves reverted individually, and they turn out to be **coupled**: dropping either the pause *or* `StartAsync`'s resume makes `a_reset_leaves_the_running_daemon_able_to_project_again` fail with the reported timeout. That test needs **two rounds** — the first establishes real in-memory positions to be stranded, and a single-round version passes against the old behaviour.

- `dotnet test fisher.slnx` — **1430 green on net9.0 and net10.0**, no failures, no skips. Full suite matters here: this touched hosted-service lifecycle, so `database_per_tenant` and `multi_store_registration` were the regression risk.
- `check_scoreboard.py` agrees on both TFMs; HANDOFF and README updated from the run.
- `npm run docs-build` clean. Two new sections on the async daemon page.

## Filed alongside

[jasperfx#732](https://github.com/JasperFx/jasperfx/issues/732) — **no shared suite covers any of this**, and Fisher passed all 37 suites and 329 tests the entire time the daemon was unreachable. Third instance of one pattern, after jasperfx#700 (`TryCreateUsage` slots) and jasperfx#718 (identity-less boundary aggregate): the store is silently the odd one out, nothing dialect-specific prompts anyone to look, and the symptom surfaces in a downstream consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)