### PR TITLE
Surface the application-assembly reuse warning (gh-142)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2081,10 +2081,25 @@ hosted services. The store is a singleton, sessions are scoped, and the returned
     the only test that fails when the call is moved.
   - **One-way.** A false `EnableAdvancedTracking` is the default rather than a statement, so it must
     not turn *off* a store that opted in for itself — which a plain assignment would do.
-  - `JasperFxOptions.ApplicationAssemblyReuseWarning` is deliberately **not** read. Polecat buffers it
-    in the same method and logs it from an always-registered activator; Fisher has no unconditional
-    startup hosted service to log it from, so surfacing it means registering one. Filed rather than
-    folded in as fisher#142.
+  - **`JasperFxOptions.ApplicationAssemblyReuseWarning` is surfaced from `Configured` too**
+    (fisher#142), where the siblings log it from an always-registered startup activator. All three of
+    Fisher's hosted services are conditional — `ApplyAllDatabaseChangesOnStartup`,
+    `SeedInitialDataOnStartup`, `AddAsyncDaemon` — so a plain `AddFisher` has no startup hook at all,
+    and registering an unconditional one for a single rare warning would change what every consumer's
+    container holds. `Configured` already runs exactly once per store with the container in hand.
+    JasperFx only *detects* the condition and says plainly that consumers surface it, so a warning
+    nobody prints is a warning that does not exist.
+    - **Once per container**, keyed on the `JasperFxOptions` instance through a
+      `ConditionalWeakTable`. Several Fisher stores share one host condition and would otherwise each
+      repeat the same four-sentence warning. **A process-wide flag would be worse than the noise it
+      saves**: the warning exists *because* a second host started in this process, so suppressing
+      repeats globally would silence it for precisely the host that needs it.
+      `a_second_host_in_the_same_process_gets_its_own_warning` is that half.
+    - **The value is planted by reflection in the tests, and that is the right amount of test.** The
+      setter is internal to JasperFx and reproducing the real condition needs two hosts from two
+      assemblies in one process in a fixed order — an intermittent under xUnit's parallel collections
+      rather than a test. What is Fisher's to get right is read it, buffer it, log it once; detecting
+      it is JasperFx's and is tested there.
 
 **Everything Fisher hands a container now implements `IDisposable` as well as `IAsyncDisposable`** —
 `DocumentStore`, `FisherDatabase`, `FisherSession`, and `IQuerySession` with them. That is not a

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1430 tests green on net9.0 and net10.0**, with no known intermittent failures — 1375 in
+**1435 tests green on net9.0 and net10.0**, with no known intermittent failures — 1380 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 329 of
 them are shared cross-store compliance tests — 260 event sourcing and 69 document. On JasperFx **2.59.0** / Weasel **9.27.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 37 suites and 329 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,375.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,380.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/configuration/hostbuilder.md
+++ b/docs/configuration/hostbuilder.md
@@ -195,6 +195,20 @@ showed no per-shard state for Fisher stores with nothing to indicate why, which 
 shape as having nothing to report.
 :::
 
+### The application-assembly reuse warning
+
+JasperFx pins the application assembly used for discovery **process-wide**, to whichever Critter Stack
+host starts first. A later host registered from a different assembly therefore gets discovery over
+somebody else's assembly, and JasperFx sets a warning saying so. Fisher logs it once per container
+when the store is built.
+
+::: tip
+It typically only bites a **test harness** that stands up several hosts across different assemblies.
+The symptom without the warning is a type this host registered simply not being discovered — silent,
+and dependent on which host happened to start first. Set the application assembly explicitly on the
+later host if you hit it.
+:::
+
 ## Session Factories
 
 By default, the scoped `IDocumentSession` is a lightweight session. Supply your own `ISessionFactory`

--- a/src/Fisher.Tests/Configuration/application_assembly_reuse_warning.cs
+++ b/src/Fisher.Tests/Configuration/application_assembly_reuse_warning.cs
@@ -1,0 +1,202 @@
+using System.Reflection;
+using JasperFx;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Fisher.Tests.Configuration;
+
+/// <summary>
+///     fisher#142 — Fisher surfaces JasperFx's application-assembly-reuse warning, which JasperFx
+///     detects and explicitly leaves to its consumers to say out loud.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The condition (GH-3521) is a host adopting an application assembly pinned by an <em>earlier</em>
+///         host in the same process. It is order-dependent and presents as a type this host registered
+///         simply not being discovered — so a warning nobody prints is a warning that does not exist.
+///     </para>
+///     <para>
+///         <b>The warning value is planted by reflection, and that is the right amount of test.</b>
+///         <c>JasperFxOptions.ApplicationAssemblyReuseWarning</c> has an internal setter, and reproducing
+///         the real condition needs two hosts from two assemblies in one process in a specific order —
+///         which under xUnit's parallel collections would be an intermittent rather than a test. What is
+///         Fisher's to get right is narrow and entirely covered here: read it, buffer it, log it once.
+///         Detecting it is JasperFx's, and is tested there.
+///     </para>
+/// </remarks>
+public class application_assembly_reuse_warning : IAsyncLifetime
+{
+    private const string Warning = "JasperFx adopted application assembly 'Other.Assembly' for code generation";
+
+    private readonly TemporaryDatabase _primary = TemporaryDatabase.Create("assembly-reuse-primary");
+    private readonly TemporaryDatabase _secondary = TemporaryDatabase.Create("assembly-reuse-secondary");
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        _primary.Dispose();
+        _secondary.Dispose();
+
+        return ValueTask.CompletedTask;
+    }
+
+    private static void Plant(JasperFxOptions options, string warning)
+        => typeof(JasperFxOptions)
+            .GetProperty(nameof(JasperFxOptions.ApplicationAssemblyReuseWarning),
+                BindingFlags.Public | BindingFlags.Instance)!
+            .SetValue(options, warning);
+
+    private static ServiceProvider ProviderWith(Action<IServiceCollection> configure, RecordingLoggerProvider log)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(x => x.AddProvider(log).SetMinimumLevel(LogLevel.Debug));
+        configure(services);
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void the_warning_is_logged_when_the_host_carries_one()
+    {
+        var log = new RecordingLoggerProvider();
+
+        using var provider = ProviderWith(services =>
+        {
+            services.AddJasperFx(o => Plant(o, Warning));
+            services.AddFisher(options => options.ConnectionString = _primary.ConnectionString);
+        }, log);
+
+        provider.GetRequiredService<IDocumentStore>();
+
+        log.Warnings.ShouldContain(x => x.Contains(Warning, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void nothing_is_logged_when_the_host_carries_no_warning()
+    {
+        var log = new RecordingLoggerProvider();
+
+        using var provider = ProviderWith(services =>
+        {
+            services.AddJasperFx();
+            services.AddFisher(options => options.ConnectionString = _primary.ConnectionString);
+        }, log);
+
+        provider.GetRequiredService<IDocumentStore>();
+
+        log.Warnings.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     The condition belongs to the host, not to a store, so several stores in one container must not
+    ///     each repeat the same four-sentence warning.
+    /// </summary>
+    [Fact]
+    public void several_stores_in_one_container_warn_once()
+    {
+        var log = new RecordingLoggerProvider();
+
+        using var provider = ProviderWith(services =>
+        {
+            services.AddJasperFx(o => Plant(o, Warning));
+            services.AddFisher(options => options.ConnectionString = _primary.ConnectionString);
+            services.AddFisherStore<IReuseWarningStore>(options =>
+                options.ConnectionString = _secondary.ConnectionString);
+        }, log);
+
+        provider.GetRequiredService<IDocumentStore>();
+        provider.GetRequiredService<IReuseWarningStore>();
+
+        log.Warnings.Count(x => x.Contains(Warning, StringComparison.Ordinal)).ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     And the other half of that rule, which matters more than the noise it saves: the warning exists
+    ///     <em>because</em> a second host started in this process, so a process-wide "already said it"
+    ///     flag would silence it for exactly the host that needs to hear it. Dedupe is per container.
+    /// </summary>
+    [Fact]
+    public void a_second_host_in_the_same_process_gets_its_own_warning()
+    {
+        var first = new RecordingLoggerProvider();
+        var second = new RecordingLoggerProvider();
+
+        using (var provider = ProviderWith(services =>
+               {
+                   services.AddJasperFx(o => Plant(o, Warning));
+                   services.AddFisher(options => options.ConnectionString = _primary.ConnectionString);
+               }, first))
+        {
+            provider.GetRequiredService<IDocumentStore>();
+        }
+
+        using (var provider = ProviderWith(services =>
+               {
+                   services.AddJasperFx(o => Plant(o, Warning));
+                   services.AddFisher(options => options.ConnectionString = _secondary.ConnectionString);
+               }, second))
+        {
+            provider.GetRequiredService<IDocumentStore>();
+        }
+
+        first.Warnings.ShouldContain(x => x.Contains(Warning, StringComparison.Ordinal));
+        second.Warnings.ShouldContain(x => x.Contains(Warning, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    ///     A host with no logging registered is the ordinary case for a console application, and building
+    ///     a store must not become conditional on one.
+    /// </summary>
+    [Fact]
+    public void a_container_without_logging_still_builds_a_store()
+    {
+        var services = new ServiceCollection();
+        services.AddJasperFx(o => Plant(o, Warning));
+        services.AddFisher(options => options.ConnectionString = _primary.ConnectionString);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IDocumentStore>().ShouldNotBeNull();
+    }
+
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        private readonly List<string> _warnings = [];
+
+        public List<string> Warnings
+        {
+            get
+            {
+                lock (_warnings) return [.._warnings];
+            }
+        }
+
+        public ILogger CreateLogger(string categoryName) => new Recording(_warnings);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class Recording : ILogger
+        {
+            private readonly List<string> _warnings;
+
+            public Recording(List<string> warnings) => _warnings = warnings;
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel != LogLevel.Warning) return;
+
+                lock (_warnings) _warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}
+
+public interface IReuseWarningStore : IDocumentStore;

--- a/src/Fisher/FisherServiceCollectionExtensions.cs
+++ b/src/Fisher/FisherServiceCollectionExtensions.cs
@@ -272,10 +272,54 @@ public static class FisherServiceCollectionExtensions
         // fisher#141. After the contribution chain, not before: the host switch is the outer statement,
         // and applying it first would let a per-store instrumentation default clobber it. It only ever
         // adds, so a store that asked for extended tracking itself is unaffected either way.
-        options.ReadJasperFxOptions(services.GetService<JasperFx.JasperFxOptions>());
+        var jasperFx = services.GetService<JasperFx.JasperFxOptions>();
+        options.ReadJasperFxOptions(jasperFx);
+        WarnAboutApplicationAssemblyReuse(services, options, jasperFx);
 
         return options;
     }
+
+    /// <summary>
+    ///     Surface JasperFx's application-assembly-reuse warning, which JasperFx detects and leaves to
+    ///     its consumers to say out loud (fisher#142).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Logged here rather than from a startup activator, which is where the siblings put
+    ///         it.</b> Polecat logs it from <c>PolecatActivator</c>, an always-registered hosted service;
+    ///         all three of Fisher's are conditional (<c>ApplyAllDatabaseChangesOnStartup</c>,
+    ///         <c>SeedInitialDataOnStartup</c>, <c>AddAsyncDaemon</c>), so a plain <c>AddFisher</c> has no
+    ///         startup hook at all. Registering an unconditional one for a single rare warning would
+    ///         change what every consumer's container holds, and <c>Configured</c> already runs exactly
+    ///         once per store with the container in hand.
+    ///     </para>
+    ///     <para>
+    ///         <b>Once per container, not once per store or once per process.</b> The condition belongs
+    ///         to the host, so several Fisher stores in one container would otherwise each repeat the
+    ///         same four-sentence warning. A process-wide flag would be worse than the noise it saves:
+    ///         the warning exists <em>because</em> a second host started in this process, so suppressing
+    ///         repeats globally would silence it for precisely the host that needs it. Keying on the
+    ///         <see cref="JasperFx.JasperFxOptions" /> instance — one per container — draws the line in
+    ///         the right place, and the weak table lets a finished container's entry go.
+    ///     </para>
+    /// </remarks>
+    private static void WarnAboutApplicationAssemblyReuse(IServiceProvider services, StoreOptions options,
+        JasperFx.JasperFxOptions? jasperFx)
+    {
+        if (options.ApplicationAssemblyReuseWarning is not { } warning || jasperFx is null) return;
+
+        lock (WarnedContainers)
+        {
+            if (!WarnedContainers.TryAdd(jasperFx, WarnedContainers)) return;
+        }
+
+        services.GetService<ILoggerFactory>()?
+            .CreateLogger(typeof(DocumentStore))
+            .LogWarning("{Warning}", warning);
+    }
+
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<JasperFx.JasperFxOptions, object>
+        WarnedContainers = new();
 
     [UnconditionalSuppressMessage("Trimming", "IL2055:MakeGenericType",
         Justification = "IConfigureFisher<T> is closed over a marker interface the caller supplied to "

--- a/src/Fisher/StoreOptions.cs
+++ b/src/Fisher/StoreOptions.cs
@@ -148,7 +148,24 @@ public class StoreOptions
         {
             Events.EnableExtendedProgressionTracking = true;
         }
+
+        // fisher#142. Buffered rather than logged here, because options construction is not where a
+        // logger belongs; FisherServiceCollectionExtensions.Configured logs it immediately after this
+        // returns. ??= so the first non-null value wins and a later null cannot clobber it.
+        ApplicationAssemblyReuseWarning ??= options.ApplicationAssemblyReuseWarning;
     }
+
+    /// <summary>
+    ///     JasperFx's GH-3521 warning that this host adopted an application assembly pinned by an
+    ///     earlier host in the same process, buffered on its way to the log.
+    /// </summary>
+    /// <remarks>
+    ///     JasperFx only detects the condition and says plainly that consumers surface it. It bites a
+    ///     test harness that stands up several Critter Stack hosts across different assemblies, where a
+    ///     later implicit host silently scans the first host's assembly — order-dependent, and it
+    ///     presents as a type this host registered simply not being discovered.
+    /// </remarks>
+    internal string? ApplicationAssemblyReuseWarning { get; set; }
 
     /// <summary>
     ///     Settings for the async projection daemon.


### PR DESCRIPTION
Closes #142.

## The gap

JasperFx pins the application assembly used for discovery **process-wide**, to whichever Critter Stack host starts first (GH-3521). A later host registered from a different assembly therefore gets discovery over somebody else's assembly, and JasperFx sets `ApplicationAssemblyReuseWarning` saying so.

JasperFx only *detects* it — the doc comment says plainly that consumers surface it. Fisher surfaced nothing, so the symptom was a type this host registered simply not being discovered: silent, and dependent on which host happened to start first.

## Where it is logged, which is the whole design question

**From `Configured`, not from a startup activator** — and that resolves the reservation #142 raised against itself.

Polecat logs it from `PolecatActivator`, an always-registered hosted service. Fisher has no equivalent: all three of its hosted services are conditional (`ApplyAllDatabaseChangesOnStartup`, `SeedInitialDataOnStartup`, `AddAsyncDaemon`), so a plain `AddFisher(...)` has no startup hook at all. The issue concluded the work was therefore "register an unconditional activator", and weighed that against just declining — an always-on hosted service for one rare warning being a poor trade for an embedded store, and one that changes what every consumer's container holds (including what `service_registration`'s hosted-service counts assert).

Neither was necessary. `Configured` already runs **exactly once per store, with the container in hand**, and #141 just established it as the place host-level concerns are read. Zero new registrations.

## Once per container

Keyed on the `JasperFxOptions` instance through a `ConditionalWeakTable`. Several Fisher stores share one host condition and would otherwise each repeat the same four-sentence warning.

**A process-wide flag would be worse than the noise it saves**, and this is the part worth pausing on: the warning exists *because* a second host started in this process, so suppressing repeats globally would silence it for precisely the host that needs to hear it. Per-container is the only line that is right in both directions, and `a_second_host_in_the_same_process_gets_its_own_warning` is the half that says so.

## On the tests

**The warning value is planted by reflection, deliberately.** `JasperFxOptions.ApplicationAssemblyReuseWarning` has an internal setter, and reproducing the real condition needs two hosts from two assemblies in one process in a fixed order — which under xUnit's parallel collections would be an intermittent rather than a test.

What is Fisher's to get right is narrow and fully covered: read it, buffer it, log it once, and don't make building a store conditional on the container having logging registered. Detecting it is JasperFx's job and is tested there. Said in the test class so the next reader does not mistake the planting for a shortcut.

**Both pieces verified load-bearing by removing them**: without the log call three of five fail; without the dedupe, `several_stores_in_one_container_warn_once` fails alone.

## Verification

- `dotnet test fisher.slnx` — **1435 green on net9.0 and net10.0**, no failures, no skips.
- `check_scoreboard.py` agrees on both TFMs; HANDOFF and README updated from the run.
- `npm run docs-build` clean.

No public API changed — the buffer is internal, as on Polecat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)