### PR TITLE
JasperFx 2.61.0 and Weasel 9.29.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,20 +7,20 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.59.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.59.0" />
+        <PackageVersion Include="JasperFx" Version="2.61.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.61.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.59.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.59.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.61.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.61.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage
              runtime extracted from Marten, which Fisher plugs a SQLite dialect into rather than
              hand-writing storage. -->
-        <PackageVersion Include="Weasel.Sqlite" Version="9.27.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.27.0" />
+        <PackageVersion Include="Weasel.Sqlite" Version="9.29.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.29.0" />
 
         <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
         <!-- Override the transitive SQLitePCLRaw 2.1.11 (vulnerable native lib,

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -14,7 +14,7 @@ scoreboard and the things that are true right now but not obvious from either.
 
 **1435 tests green on net9.0 and net10.0**, with no known intermittent failures — 1380 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 329 of
-them are shared cross-store compliance tests — 260 event sourcing and 69 document. On JasperFx **2.59.0** / Weasel **9.27.0**.
+them are shared cross-store compliance tests — 260 event sourcing and 69 document. On JasperFx **2.61.0** / Weasel **9.29.0**.
 
 Note that 260 is no longer *every* event suite the shared library has: 2.59.0 added
 `SingleTenantedEventSlicingCompliance` (jasperfx#724) and `CompositeProjectionCompliance`
@@ -457,7 +457,7 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.59.0 ships 39 suites; Fisher enrolls **37 of them, 329 tests**.
+`JasperFx.Events.ComplianceTests` 2.61.0 ships 39 suites; Fisher enrolls **37 of them, 329 tests**.
 Fisher passes **all 329, all 37 suites**. Every suite compiles; every one is also subclassed and running.
 
 **What that does and does not claim, because the difference is load-bearing** (fisher#124). The suite

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -9,7 +9,7 @@ namespace Fisher.Tests.Compliance;
  * these tests cannot drift between the products.
  *
  * Suites were added one at a time as Fisher grew into them, and thirty-seven are enrolled from
- * JasperFx.Events.ComplianceTests 2.59.0, which itself ships thirty-nine. The two not enrolled are both
+ * JasperFx.Events.ComplianceTests 2.61.0, which itself ships thirty-nine. The two not enrolled are both
  * opt-in and both new in 2.59.0: SingleTenantedEventSlicingCompliance (jasperfx#724), whose
  * mixed-tenancy precondition cannot be constructed on Fisher at all -- see jasperfx#727 -- and
  * CompositeProjectionCompliance (jasperfx#725), which needs an AddCompositeProjection member on the


### PR DESCRIPTION
A pure dependency bump. **No production change, no test change, no seam member** — the diff is six version numbers and four version strings in the scoreboard.

| | was | now |
|---|---|---|
| `JasperFx`, `JasperFx.Events`, `.ComplianceTests`, `.SourceGenerator` | 2.59.0 | **2.61.0** |
| `Weasel.Sqlite`, `Weasel.Storage` | 9.27.0 | **9.29.0** |
| `Weasel.Core` (transitive) | 9.27.0 | **9.29.0** |

Weasel moves with JasperFx as its pin comment requires, rather than being left to resolve transitively — and it was two releases behind independently of this.

## The compliance delta is nothing, and that was checked properly

The JasperFx side crosses **two** releases, so there were two releases of suite delta to account for. There is none:

- same 39 suite files — no additions, no removals;
- **no content change in any of them**;
- same 333 `[Fact]`/`[Theory]` between 2.59.0 and 2.61.0.

That was established by diffing the extracted `contentFiles` **contents**, not the file list. The standing lesson is that a bump whose suite *list* is unchanged can still demand production work (that was jasperfx#665 in 2.49.0, which added three tests to an existing suite and needed real production work), so the file-list diff is precisely the check that does not settle it.

Fisher's enrollment therefore stands unchanged at **37 of 39 suites, 329 tests**. The two not enrolled are the same two as before, both opt-in and neither declined on behaviour: `SingleTenantedEventSlicingCompliance`, whose mixed-tenancy precondition [cannot be constructed on Fisher at all](https://github.com/JasperFx/jasperfx/issues/727), and `CompositeProjectionCompliance`, which needs an `AddCompositeProjection` member on the fixture.

## On the scoreboard edits

Only the **current-tense** version claims moved. The historical mentions are deliberately untouched — "2.59.0 added `SingleTenantedEventSlicingCompliance`" and "both new in 2.59.0" are statements about when those suites arrived, not about the pin, and blanket-replacing them would be rewriting history in exactly the way `check_scoreboard.py`'s own ROADMAP rule warns about.

## Verification

- `dotnet test fisher.slnx` — **1435 green on net9.0 and net10.0**, no failures, no skips. Same count as 1.0.6, which is the expected result given the suite is byte-identical.
- `check_scoreboard.py` agrees on both TFMs.
- `npm run docs-build` clean; no stale version references anywhere in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)