### PR TITLE
gh-154: enroll CompositeProjectionCompliance via AddCompositeProjection (jasperfx#725)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,15 +12,15 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1435 tests green on net9.0 and net10.0**, with no known intermittent failures — 1380 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 329 of
-them are shared cross-store compliance tests — 260 event sourcing and 69 document. On JasperFx **2.61.0** / Weasel **9.29.0**.
+**1511 tests green on net9.0 and net10.0**, with no known intermittent failures — 1456 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 391 of
+them are shared cross-store compliance tests — 322 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 
-Note that 260 is no longer *every* event suite the shared library has: 2.59.0 added
-`SingleTenantedEventSlicingCompliance` (jasperfx#724) and `CompositeProjectionCompliance`
-(jasperfx#725), both opt-in and neither enrolled here. The first cannot construct its precondition on
-Fisher at all — see jasperfx#727 — and the second needs an `AddCompositeProjection` seam on the
-fixture.
+Note that 322 is not quite *every* event suite the shared library has: 2.59.0's opt-in
+`SingleTenantedEventSlicingCompliance` (jasperfx#724) is not enrolled, because its mixed-tenancy
+precondition cannot be constructed on Fisher at all — see jasperfx#727 — and its own guard would make
+every fact skip itself. Its 2.59.0 sibling `CompositeProjectionCompliance` (jasperfx#725) *is*
+enrolled since fisher#154 closed the `AddCompositeProjection` seam on the fixture.
 
 ## Closed since the comparison
 
@@ -457,8 +457,8 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.61.0 ships 39 suites; Fisher enrolls **37 of them, 329 tests**.
-Fisher passes **all 329, all 37 suites**. Every suite compiles; every one is also subclassed and running.
+`JasperFx.Events.ComplianceTests` 2.63.0 ships 41 suites; Fisher enrolls **40 of them, 391 tests**.
+Fisher passes **all 391, all 40 suites**. Every suite compiles; every one is also subclassed and running.
 
 **What that does and does not claim, because the difference is load-bearing** (fisher#124). The suite
 pins **API portability, not behavioural equivalence**: code written against one store compiles and
@@ -466,7 +466,7 @@ runs against another. It does not pin that the three *behave* the same, and the 
 "Behaviour that differs" list is exactly what it does not pin — the exclusive methods failing rather
 than waiting, Marten's strictly-greater revision guard rather than Polecat's equality one, a stricter
 `QueryForNonStaleData`, ordinal string comparison, applied inner-side join predicates. Read as
-equivalence, "passes all 37 suites" invites using Fisher as a test double for a Marten or Polecat
+equivalence, "passes all 40 suites" invites using Fisher as a test double for a Marten or Polecat
 application, which the divergence list argues against.
 
 **The bump crossed three releases and the whole compliance delta is one test.** 2.54.0 and 2.55.0
@@ -491,7 +491,7 @@ shape: `DocumentLoadAndStoreCompliance` gained three tests for `LoadAsync<T>(obj
 fisher#89) and `DocumentComplianceConfig` gained `ValueTypes`. Diffing the suite *list* would have
 reported a clean bump — diff the contents.
 
-The library is now two halves. The **event sourcing** half is 30 enrolled suites and 260 tests, and its
+The library is now two halves. The **event sourcing** half is 33 enrolled suites and 322 tests, and its
 upstream backlog has been empty since 2.45.0 — that is the whole of it rather than a snapshot. The
 **document** half arrived in 2.47.0 (jasperfx#647) and is now seven suites, 69 tests, over the
 store-agnostic document contract Fisher implements for fisher#68. Every suite added since 2.49.0 has
@@ -528,17 +528,19 @@ by-identity document read surface was `where T : class` where the contract is `w
 Widening it removed an inconsistency rather than creating one, since `Store`, `Delete`, `DeleteWhere`
 and `Query<T>` were already `notnull`. See "The store-agnostic document contract" in CLAUDE.md.
 
-**Green on all thirty-seven is not the same as feature-complete.** The suites cover what is portable
+**Green on all forty is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 37 suites, 329 tests
+### Green — 40 suites, 391 tests
 
-Event sourcing — 30 suites, 260 tests:
+Event sourcing — 33 suites, 322 tests:
 
 | Suite | Tests |
 |---|---|
+| `EventQueryCompliance` | 41 |
 | `DcbTagQueryAndConsistencyCompliance` | 28 |
 | `StringStreamIdentityCompliance` | 19 |
+| `StreamStateQueryCompliance` | 15 |
 | `AggregateWriteCacheCompliance` | 14 |
 | `FetchForWritingCompliance` | 13 |
 | `StreamReadCompliance` | 11 |
@@ -550,7 +552,7 @@ Event sourcing — 30 suites, 260 tests:
 | `EventMetadataCompliance` | 9 |
 | `SelfAggregatingEvolveCompliance` | 8 |
 | `FlatTableProjectionCompliance` | 8 |
-| `ConjoinedEventTenancyCompliance` | 8 |
+| `ConjoinedEventTenancyCompliance` | 11 |
 | `FetchLatestCompliance` | 7 |
 | `LiveAggregationCompliance` | 7 |
 | `EventStoreExplorerCompliance` | 14 |
@@ -563,6 +565,7 @@ Event sourcing — 30 suites, 260 tests:
 | `SubscriptionCompliance` | 6 |
 | `RebuildConcurrencyCapCompliance` | 5 |
 | `ActivityCorrelationCompliance` | 4 |
+| `CompositeProjectionCompliance` | 3 |
 | `EventProjectionRegistrationCompliance` | 3 |
 | `EventProjectionEnrichmentCompliance` | 3 |
 | `AsyncDaemonCompliance` | 2 |

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 37 suites and 329 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,380.
+> Fisher passes **all 40 suites and 391 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,456.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -433,7 +433,7 @@ Test counts keep understating the suites that matter. `AsyncDaemonCompliance` is
 the whole daemon; `FlatTableProjectionCompliance` is eight that demand an upsert generator, a
 migration hook and rebuild teardown.
 
-Being green on all thirty-seven is not the same as being feature-complete against Marten. The suites
+Being green on all forty is not the same as being feature-complete against Marten. The suites
 cover what is portable across stores; the deliberate gaps listed in HANDOFF.md are still gaps.
 
 ## Filed follow-ups

--- a/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
+++ b/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
@@ -1,4 +1,5 @@
 using Fisher.Events;
+using Fisher.Projections;
 using JasperFx;
 using JasperFx.Events;
 using JasperFx.Events.ComplianceTests;
@@ -418,6 +419,35 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
 
         public void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle)
             => _options.Projections.Add(projection, lifecycle);
+
+        /// <summary>
+        ///     jasperfx#725 — build a composite projection and populate its stages, enrolling
+        ///     <c>CompositeProjectionCompliance</c>.
+        /// </summary>
+        /// <remarks>
+        ///     The seam exists because a composite cannot be constructed by a suite at all:
+        ///     <see cref="Fisher.Projections.FisherCompositeProjection" /> keeps its constructor
+        ///     internal, needing the store's options, so one only comes into being through
+        ///     <c>Projections.CompositeProjectionFor(name, configure)</c> — whose <c>configure</c> is
+        ///     typed to Fisher's own subclass. This is the forward-plus-adapter the shared registrar's
+        ///     remarks predict, and the adapter carries the one member the suite needs
+        ///     (<c>Snapshot&lt;T&gt;(stageNumber)</c>), which all three stores spell identically.
+        /// </remarks>
+        public void AddCompositeProjection(string name, Action<IComplianceCompositeBuilder> configure)
+            => _options.Projections.CompositeProjectionFor(name,
+                composite => configure(new ComplianceCompositeBuilder(composite)));
+
+        /// <inheritdoc cref="AddCompositeProjection" />
+        private sealed class ComplianceCompositeBuilder : IComplianceCompositeBuilder
+        {
+            private readonly FisherCompositeProjection _composite;
+
+            internal ComplianceCompositeBuilder(FisherCompositeProjection composite)
+                => _composite = composite;
+
+            public void Snapshot<TDoc>(int stageNumber) where TDoc : notnull
+                => _composite.Snapshot<TDoc>(stageNumber);
+        }
 
         /// <summary>
         ///     Register the shared compliance subscription with Fisher's async daemon.

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -8,12 +8,14 @@ namespace Fisher.Tests.Compliance;
  * Fisher's session pair through FisherComplianceFixture. Marten and Polecat enroll the same way, so
  * these tests cannot drift between the products.
  *
- * Suites were added one at a time as Fisher grew into them, and thirty-nine are enrolled from
- * JasperFx.Events.ComplianceTests 2.63.0, which itself ships forty-one. The two not enrolled are both
- * opt-in and both new in 2.59.0: SingleTenantedEventSlicingCompliance (jasperfx#724), whose
- * mixed-tenancy precondition cannot be constructed on Fisher at all -- see jasperfx#727 -- and
- * CompositeProjectionCompliance (jasperfx#725), which needs an AddCompositeProjection member on the
- * fixture. Neither is a suite Fisher declines on behaviour.
+ * Suites were added one at a time as Fisher grew into them, and forty are enrolled from
+ * JasperFx.Events.ComplianceTests 2.63.0, which itself ships forty-one. The one not enrolled is
+ * SingleTenantedEventSlicingCompliance (jasperfx#724, new in 2.59.0), and it is opt-in for a reason
+ * that is a precondition rather than a behaviour: the suite plants events whose tenant ids disagree
+ * on a single-tenanted store and drives the daemon over them, and Fisher cannot construct that state
+ * at all -- see jasperfx#727. The suite's own guard reads the events back and skips when the store
+ * normalised the tenant ids away, so enrolling it would be forty-odd facts that skip themselves;
+ * the non-enrollment stays documented here instead. It is not a suite Fisher declines on behaviour.
  *
  * Nothing in the fixture throws any more, but the discipline stands for the next seam member that
  * arrives ahead of the feature: a member Fisher cannot honour throws a NotSupportedException naming
@@ -136,6 +138,24 @@ public class event_query_compliance
 
 public class stream_state_query_compliance
     : StreamStateQueryCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
+
+/*
+ * fisher#154 / jasperfx#725 — composite projections: several members sharing one shard, one
+ * progression row and one event batch, executed in stage order and torn down together on rebuild.
+ * Opt-in through the registrar's AddCompositeProjection, whose throwing default is what kept this
+ * suite unenrolled — never a behaviour Fisher declined: Projections.CompositeProjectionFor is
+ * fisher#19, and composite_member_teardown is one of the two local regression tests (with Polecat's
+ * Bug_439) whose existence is the suite's own argument for being shared.
+ *
+ * The suite's load-bearing fact is the rebuild one, with deliberately additive members: a store that
+ * replayed the stream over surviving rows instead of tearing each member down reads back exactly
+ * doubled — the fisher#63 / marten#5175 class of bug. The single-shard fact pins what a composite
+ * is; a store expanding one into a shard per member would pass the other two and still have changed
+ * the model.
+ */
+
+public class composite_projection_compliance
+    : CompositeProjectionCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
 
 /*
  * fisher#93 — binary event serialization, arriving in JasperFx.Events.ComplianceTests 2.50.0 and


### PR DESCRIPTION
Closes #154.

Fisher had every behaviour `CompositeProjectionCompliance` (jasperfx#725) asserts — composites since fisher#19, member teardown since fisher#63 — and was unenrolled only because `FisherComplianceRegistrar` left `AddCompositeProjection` on its throwing default. This implements the seam member and enrolls the suite, taking Fisher to **40 of the 41 suites** in JasperFx.Events.ComplianceTests 2.63.0.

## What changed

- `src/Fisher.Tests/Compliance/FisherComplianceFixture.cs` — `AddCompositeProjection(name, configure)` forwards to `Projections.CompositeProjectionFor`, with a private `ComplianceCompositeBuilder : IComplianceCompositeBuilder` adapter forwarding `Snapshot<TDoc>(stageNumber)` onto `FisherCompositeProjection.Snapshot<T>`. This is exactly the forward-plus-adapter shape the shared registrar's remarks predict for all three stores.
- `src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs` — the `composite_projection_compliance` enrollment (3 facts: every stage materializes from one pass, rebuild tears members down rather than replaying over them, a composite presents itself as exactly one shard), plus an updated header: the one remaining non-enrollment is `SingleTenantedEventSlicingCompliance` (jasperfx#724 / jasperfx#727) alone, sharpened to say *why* it stays out — its mixed-tenancy precondition cannot be constructed on Fisher, and the suite's own `SkipWhen(distinctTenants < 2)` guard would make every fact skip itself.

No production change was needed — the suite went green on the seam member alone, which is what fisher#19/#63 already having local coverage (`composite_projections`, `composite_member_teardown`) predicted.

## Tests

- `composite_projection_compliance`: 3/3 passed on net10.0 and net9.0.
- Full `Fisher.Tests.Compliance` namespace on net10.0: 391/391 passed (388 existing + 3 new).

Stoat plan `event-compliance-wave-13`, node `fisher-enroll-composite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)