### PR TITLE
gh-155: trim local commit-listener and pending-streams tests to product-owned facts

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,11 +12,11 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1435 tests green on net9.0 and net10.0**, with no known intermittent failures — 1380 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 329 of
-them are shared cross-store compliance tests — 260 event sourcing and 69 document. On JasperFx **2.61.0** / Weasel **9.29.0**.
+**1506 tests green on net9.0 and net10.0**, with no known intermittent failures — 1451 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 388 of
+them are shared cross-store compliance tests — 319 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 
-Note that 260 is no longer *every* event suite the shared library has: 2.59.0 added
+Note that 319 is no longer *every* event suite the shared library has: 2.59.0 added
 `SingleTenantedEventSlicingCompliance` (jasperfx#724) and `CompositeProjectionCompliance`
 (jasperfx#725), both opt-in and neither enrolled here. The first cannot construct its precondition on
 Fisher at all — see jasperfx#727 — and the second needs an `AddCompositeProjection` seam on the
@@ -457,8 +457,8 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.61.0 ships 39 suites; Fisher enrolls **37 of them, 329 tests**.
-Fisher passes **all 329, all 37 suites**. Every suite compiles; every one is also subclassed and running.
+`JasperFx.Events.ComplianceTests` 2.63.0 ships 41 suites; Fisher enrolls **39 of them, 388 tests**.
+Fisher passes **all 388, all 39 suites**. Every suite compiles; every one is also subclassed and running.
 
 **What that does and does not claim, because the difference is load-bearing** (fisher#124). The suite
 pins **API portability, not behavioural equivalence**: code written against one store compiles and
@@ -466,7 +466,7 @@ runs against another. It does not pin that the three *behave* the same, and the 
 "Behaviour that differs" list is exactly what it does not pin — the exclusive methods failing rather
 than waiting, Marten's strictly-greater revision guard rather than Polecat's equality one, a stricter
 `QueryForNonStaleData`, ordinal string comparison, applied inner-side join predicates. Read as
-equivalence, "passes all 37 suites" invites using Fisher as a test double for a Marten or Polecat
+equivalence, "passes all 39 suites" invites using Fisher as a test double for a Marten or Polecat
 application, which the divergence list argues against.
 
 **The bump crossed three releases and the whole compliance delta is one test.** 2.54.0 and 2.55.0
@@ -491,7 +491,7 @@ shape: `DocumentLoadAndStoreCompliance` gained three tests for `LoadAsync<T>(obj
 fisher#89) and `DocumentComplianceConfig` gained `ValueTypes`. Diffing the suite *list* would have
 reported a clean bump — diff the contents.
 
-The library is now two halves. The **event sourcing** half is 30 enrolled suites and 260 tests, and its
+The library is now two halves. The **event sourcing** half is 32 enrolled suites and 319 tests, and its
 upstream backlog has been empty since 2.45.0 — that is the whole of it rather than a snapshot. The
 **document** half arrived in 2.47.0 (jasperfx#647) and is now seven suites, 69 tests, over the
 store-agnostic document contract Fisher implements for fisher#68. Every suite added since 2.49.0 has
@@ -528,17 +528,19 @@ by-identity document read surface was `where T : class` where the contract is `w
 Widening it removed an inconsistency rather than creating one, since `Store`, `Delete`, `DeleteWhere`
 and `Query<T>` were already `notnull`. See "The store-agnostic document contract" in CLAUDE.md.
 
-**Green on all thirty-seven is not the same as feature-complete.** The suites cover what is portable
+**Green on all thirty-nine is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 37 suites, 329 tests
+### Green — 39 suites, 388 tests
 
-Event sourcing — 30 suites, 260 tests:
+Event sourcing — 32 suites, 319 tests:
 
 | Suite | Tests |
 |---|---|
+| `EventQueryCompliance` | 41 |
 | `DcbTagQueryAndConsistencyCompliance` | 28 |
 | `StringStreamIdentityCompliance` | 19 |
+| `StreamStateQueryCompliance` | 15 |
 | `AggregateWriteCacheCompliance` | 14 |
 | `FetchForWritingCompliance` | 13 |
 | `StreamReadCompliance` | 11 |
@@ -550,7 +552,7 @@ Event sourcing — 30 suites, 260 tests:
 | `EventMetadataCompliance` | 9 |
 | `SelfAggregatingEvolveCompliance` | 8 |
 | `FlatTableProjectionCompliance` | 8 |
-| `ConjoinedEventTenancyCompliance` | 8 |
+| `ConjoinedEventTenancyCompliance` | 11 |
 | `FetchLatestCompliance` | 7 |
 | `LiveAggregationCompliance` | 7 |
 | `EventStoreExplorerCompliance` | 14 |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1511 tests green on net9.0 and net10.0**, with no known intermittent failures — 1456 in
+**1509 tests green on net9.0 and net10.0**, with no known intermittent failures — 1454 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 391 of
 them are shared cross-store compliance tests — 322 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 40 suites and 391 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,456.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,454.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 37 suites and 329 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,380.
+> Fisher passes **all 39 suites and 388 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,451.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -433,7 +433,7 @@ Test counts keep understating the suites that matter. `AsyncDaemonCompliance` is
 the whole daemon; `FlatTableProjectionCompliance` is eight that demand an upsert generator, a
 migration hook and rebuild teardown.
 
-Being green on all thirty-seven is not the same as being feature-complete against Marten. The suites
+Being green on all thirty-nine is not the same as being feature-complete against Marten. The suites
 cover what is portable across stores; the deliberate gaps listed in HANDOFF.md are still gaps.
 
 ## Filed follow-ups

--- a/src/Fisher.Tests/Documents/commit_listener_contract.cs
+++ b/src/Fisher.Tests/Documents/commit_listener_contract.cs
@@ -31,6 +31,11 @@ namespace Fisher.Tests.Documents;
 ///         them through the contract, which is the surface a store-agnostic consumer sees and the
 ///         one that could drift independently.
 ///     </para>
+///     <para>
+///         Nothing the shared suite already states is restated here — what the listener is handed,
+///         when it fires for real commits, and that the change set is a stable snapshot are all
+///         <c>document_commit_listener_compliance</c>'s to own.
+///     </para>
 /// </remarks>
 public class commit_listener_contract : IAsyncLifetime
 {
@@ -96,24 +101,6 @@ public class commit_listener_contract : IAsyncLifetime
         var fisherListener = new RecordingListener();
 
         ((IDocumentCommitListener)fisherListener).AsSessionListener().ShouldBeSameAs(fisherListener);
-    }
-
-    [Fact]
-    public async Task the_contract_listener_sees_what_the_commit_wrote()
-    {
-        var id = Guid.NewGuid();
-
-        await using (var session = _store.LightweightSession())
-        {
-            session.Store(new ListenerFly { Id = id, Pattern = "Royal Coachman" });
-            await session.SaveChangesAsync(Token);
-        }
-
-        var commit = _listener.Commits.ShouldHaveSingleItem().Commit;
-
-        commit.Updated.ShouldHaveSingleItem().ShouldBeOfType<ListenerFly>().Id.ShouldBe(id);
-        commit.Inserted.ShouldBeEmpty();
-        commit.Deleted.ShouldBeEmpty();
     }
 
     /// <remarks>

--- a/src/Fisher.Tests/Documents/pending_stream_actions.cs
+++ b/src/Fisher.Tests/Documents/pending_stream_actions.cs
@@ -1,6 +1,5 @@
 using Fisher.Tests.Events;
 using JasperFx;
-using JasperFx.Events;
 using JasperFx.Events.Documents;
 using JasperFx.MultiTenancy;
 
@@ -23,6 +22,11 @@ namespace Fisher.Tests.Documents;
 ///         work's</em>. Fisher answers the second question, because that is the one the accessor exists
 ///         to ask: a pre-commit hook told what is about to be written and then handed only part of it
 ///         is wrong about the commit it is bracketing.
+///     </para>
+///     <para>
+///         Nothing the shared suite already states is restated here — the shape of the answer,
+///         including the non-covariance trap the contract's throwing default exists to catch, is
+///         <c>pending_stream_actions_compliance</c>'s to own.
 ///     </para>
 /// </remarks>
 public class pending_stream_actions : IAsyncLifetime
@@ -122,28 +126,5 @@ public class pending_stream_actions : IAsyncLifetime
 
         taken.ShouldHaveSingleItem();
         ((IDocumentSessionOperations)session).PendingStreams.Count.ShouldBe(2);
-    }
-
-    /// <remarks>
-    ///     The non-covariance trap, pinned rather than described. Fisher has a member <em>named</em>
-    ///     <c>PendingStreams</c> on <c>EventOperations</c> with a different collection type, so the
-    ///     interesting question is not whether the values agree but whether the contract member is
-    ///     implemented at all — an unimplemented one throws from the shared default, with a clean build
-    ///     either way.
-    /// </remarks>
-    [Fact]
-    public void the_contract_member_and_the_native_spelling_agree()
-    {
-        var streamId = Guid.NewGuid();
-
-        using var session = _store.LightweightSession("north");
-        session.Events.StartStream(streamId, new QuestStarted("North"));
-
-        var native = session.Events.PendingStreams.ShouldHaveSingleItem();
-        var contract = ((IDocumentSessionOperations)session).PendingStreams.ShouldHaveSingleItem();
-
-        contract.ShouldBeSameAs(native);
-        contract.Id.ShouldBe(streamId);
-        contract.ActionType.ShouldBe(StreamActionType.Start);
     }
 }


### PR DESCRIPTION
Closes #155.

`commit_listener_contract.cs` and `pending_stream_actions.cs` were compared fact by fact against `DocumentCommitListenerCompliance` (10 facts) and `PendingStreamActionsCompliance` (9 facts). Two local facts restated the suites and are removed; everything genuinely product-owned stays. Both file headers now state the boundary explicitly.

## Removed facts and their covering compliance facts

| Removed local fact | Covered by |
|---|---|
| `commit_listener_contract.the_contract_listener_sees_what_the_commit_wrote` | `DocumentCommitListenerCompliance.the_change_set_carries_the_written_document` (the written document arrives in exactly one of Inserted/Updated with Deleted empty) plus `a_listener_fires_after_a_successful_commit`. The one sliver the suite deliberately leaves open — which bucket a first write lands in — is not a stated Fisher decision, and the Inserted/Updated classification itself stays pinned through Fisher's own interface by `session_listeners.the_change_set_separates_inserts_from_stores`. |
| `pending_stream_actions.the_contract_member_and_the_native_spelling_agree` | The non-covariance trap it existed to pin is precisely what enrolling `PendingStreamActionsCompliance` catches: the contract member's throwing default fails `a_session_with_nothing_enlisted_has_no_pending_streams` (and the whole suite) on an unimplemented member. Key and `ActionType` content are covered by `a_started_stream_is_pending_before_the_commit` and `a_pending_stream_reports_whether_it_starts_a_stream_or_appends`. Its remaining assertion — reference identity between the contract's copied list and the native collection's `StreamAction` instances — pins no documented decision. |

## Kept, and why the suites cannot own them

- **`a_fisher_listener_is_reachable_through_the_shared_contract`** — the outbound default-interface forward (`IDocumentSessionListener` → `IDocumentCommitListener`). Fisher's own firing site calls Fisher's member and the suite registers contract-shaped listeners through `AsSessionListener()`, so nothing in the library ever executes this forward.
- **`adapting_a_listener_that_is_already_a_fisher_listener_returns_it_unchanged`** — `AsSessionListener()` unwrap identity; the suite only ever adapts non-Fisher listeners.
- **`an_empty_unit_of_work_does_not_reach_the_contract_listener`** and **`an_enlisted_session_does_not_reach_the_contract_listener`** — the two firing behaviours the compliance README names as deliberately NOT asserted upstream because the contract permits both answers (and enlistment is unreachable through `IDocumentSessionFactory`); these are Fisher's stated answers, pinned through the contract surface.
- **`a_tenant_scopes_streams_are_pending_on_the_session_that_will_commit_them`** / **`a_tenant_scope_reports_only_its_own`** — tenant-scope inclusion in `PendingStreams`; a suite written against three stores has no tenancy vocabulary.
- **`the_collection_is_a_snapshot_rather_than_a_live_view`** — the contract permits a live view or a copy; the copy is Fisher's decision.

## Tests

- `commit_listener_contract` (4), `pending_stream_actions` (3), and the covering suites `pending_stream_actions_compliance` (9) and `document_commit_listener_compliance` (10): all passed on net10.0 and net9.0.

Stoat plan `event-compliance-wave-13`, node `fisher-trim-local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)