### PR TITLE
Cache event wrapping and event type resolution on the per-event hot paths

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1509 tests green on net9.0 and net10.0**, with no known intermittent failures — 1454 in
+**1515 tests green on net9.0 and net10.0**, with no known intermittent failures — 1460 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 391 of
 them are shared cross-store compliance tests — 322 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 40 suites and 391 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,454.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,460.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/src/Fisher.Tests/Events/event_wrapping_and_type_resolution.cs
+++ b/src/Fisher.Tests/Events/event_wrapping_and_type_resolution.cs
@@ -1,0 +1,114 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Fisher.Events;
+using JasperFx.Events;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>
+///     The two per-event hot-path caches on <see cref="EventGraph" /> (fisher#156): the compiled
+///     <c>Event&lt;T&gt;</c> wrapper on <see cref="FisherEventType.Wrap" />, and the memoized
+///     <c>Type.GetType</c> behind <c>ResolveEventType</c>. Both run once per event row hydrated, so
+///     these tests pin the behaviour the caches must not change and the one property a behavioural
+///     test cannot see — that a resolution miss is cached rather than re-probed per row.
+/// </summary>
+public class event_wrapping_and_type_resolution
+{
+    private record LineWetted(Guid RodId, string Fly);
+
+    private static EventGraph NewGraph() => new StoreOptions().EventGraph;
+
+    [Fact]
+    public void wrap_produces_a_typed_envelope_carrying_the_mappings_metadata()
+    {
+        var graph = NewGraph();
+        var mapping = graph.EventMappingFor(typeof(LineWetted));
+        var data = new LineWetted(Guid.NewGuid(), "elk hair caddis");
+
+        var @event = mapping.Wrap(data);
+
+        var typed = @event.ShouldBeOfType<Event<LineWetted>>();
+        typed.Data.ShouldBeSameAs(data);
+        @event.EventTypeName.ShouldBe(mapping.EventTypeName);
+        @event.DotNetTypeName.ShouldBe(mapping.DotNetTypeName);
+    }
+
+    /// <remarks>
+    ///     Two wraps of one mapping must hand back two envelopes — the compiled wrapper is a cached
+    ///     <em>constructor</em>, and caching the envelope instead would let one event's stamped
+    ///     metadata (sequence, version, timestamp) bleed into the next row's.
+    /// </remarks>
+    [Fact]
+    public void a_second_wrap_is_a_fresh_envelope()
+    {
+        var mapping = NewGraph().EventMappingFor(typeof(LineWetted));
+        var data = new LineWetted(Guid.NewGuid(), "woolly bugger");
+
+        var first = mapping.Wrap(data);
+        var second = mapping.Wrap(data);
+
+        second.ShouldNotBeSameAs(first);
+        second.Data.ShouldBeSameAs(data);
+    }
+
+    [Fact]
+    public void a_known_dotnet_type_name_resolves_and_is_cached()
+    {
+        var graph = NewGraph();
+        var name = graph.EventMappingFor(typeof(LineWetted)).DotNetTypeName;
+
+        graph.ResolveEventType(name).ShouldBe(typeof(LineWetted));
+
+        var cache = CacheOf(graph);
+        cache.TryGetValue(name, out var cached).ShouldBeTrue();
+        cached.ShouldBe(typeof(LineWetted));
+    }
+
+    /// <remarks>
+    ///     The half of fisher#156 a behavioural assertion cannot see. Fisher deliberately answers
+    ///     null for a type this process does not know, so a stream holding foreign event types asks
+    ///     this question once per row — without the cached miss every one of those rows re-runs
+    ///     <c>Type.GetType</c>'s name parse and assembly probe. The stored null entry is the pin.
+    /// </remarks>
+    [Fact]
+    public void an_unresolvable_name_is_null_and_the_miss_is_cached()
+    {
+        var graph = NewGraph();
+        const string foreign = "Some.Other.Deployment.QuestStarted, Some.Other.Deployment";
+
+        graph.ResolveEventType(foreign).ShouldBeNull();
+        graph.ResolveEventType(foreign).ShouldBeNull();
+
+        var cache = CacheOf(graph);
+        cache.TryGetValue(foreign, out var cached).ShouldBeTrue();
+        cached.ShouldBeNull();
+    }
+
+    [Fact]
+    public void a_null_or_empty_name_is_null_and_never_reaches_the_cache()
+    {
+        var graph = NewGraph();
+
+        graph.ResolveEventType(null).ShouldBeNull();
+        graph.ResolveEventType("").ShouldBeNull();
+
+        CacheOf(graph).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void build_event_wraps_raw_data_through_the_mapping()
+    {
+        var graph = NewGraph();
+        var data = new LineWetted(Guid.NewGuid(), "royal wulff");
+
+        var @event = graph.BuildEvent(data);
+
+        @event.ShouldBeOfType<Event<LineWetted>>().Data.ShouldBeSameAs(data);
+        @event.EventTypeName.ShouldBe(graph.EventMappingFor(typeof(LineWetted)).EventTypeName);
+    }
+
+    private static ConcurrentDictionary<string, Type?> CacheOf(EventGraph graph)
+        => (ConcurrentDictionary<string, Type?>)typeof(EventGraph)
+            .GetField("_eventTypeByDotNetName", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(graph)!;
+}

--- a/src/Fisher/Events/EventGraph.cs
+++ b/src/Fisher/Events/EventGraph.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using Fisher.Events.Schema;
@@ -435,11 +436,33 @@ public partial class EventGraph : EventRegistry, IAggregationSourceFactory<IQuer
         return aggregateType.Name;
     }
 
+    private readonly ConcurrentDictionary<string, Type?> _eventTypeByDotNetName = new();
+
     /// <summary>
     ///     Resolve a .NET type from the <c>dotnet_type</c> name stored on an event row.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Memoized per name (fisher#156), because this runs once per event row hydrated —
+    ///         <c>Type.GetType(string)</c> parses the assembly-qualified name and probes loaded
+    ///         assemblies on every call. Marten does the same in <c>EventGraph.TypeForDotNetName</c>;
+    ///         the cache here is a <see cref="ConcurrentDictionary{TKey,TValue}" /> to match this
+    ///         class's other registries.
+    ///     </para>
+    ///     <para>
+    ///         <b>Misses are cached too</b>, as a stored null entry, and that is the half that pays:
+    ///         Fisher deliberately returns null for a type this deployment does not know (the stream
+    ///         reads skip such rows so a store stays readable by a process without every event
+    ///         assembly), so a stream holding foreign event types would otherwise re-probe
+    ///         <c>Type.GetType</c> per row forever — precisely the path the null policy exists to
+    ///         serve. Sound because the answer cannot change mid-process for Fisher's purposes:
+    ///         event assemblies are loaded by registration before rows naming them are read.
+    ///     </para>
+    /// </remarks>
     internal Type? ResolveEventType(string? dotNetTypeName)
-        => string.IsNullOrEmpty(dotNetTypeName) ? null : Type.GetType(dotNetTypeName);
+        => string.IsNullOrEmpty(dotNetTypeName)
+            ? null
+            : _eventTypeByDotNetName.GetOrAdd(dotNetTypeName, static name => Type.GetType(name));
 
     internal StreamsTable BuildStreamsTable() => new(this);
 
@@ -569,15 +592,44 @@ public class FisherEventType : IEventType
     public string DotNetTypeName { get; set; }
     public string Alias => EventTypeName;
 
+    private Func<object, IEvent>? _wrapper;
+
     /// <summary>
     ///     Wrap raw event data into an <c>Event&lt;T&gt;</c> envelope carrying type metadata.
     /// </summary>
+    /// <remarks>
+    ///     Runs once per event hydrated by <see cref="Internal.FisherEventsRowReader" /> and once per
+    ///     raw event appended through <see cref="EventGraph.BuildEvent" />, so the
+    ///     <c>MakeGenericType</c> + <c>Activator.CreateInstance</c> pair is paid exactly once per
+    ///     event type and the per-call cost is a compiled delegate invocation (fisher#156). JasperFx's
+    ///     own <c>EventTypeData&lt;T&gt;</c> gets the fast shape by being generic; this type cannot
+    ///     close over <c>T</c> without changing how <see cref="EventGraph.EventMappingFor" /> builds
+    ///     mappings, so it caches the constructor as a delegate instead — the same pattern
+    ///     <c>MessagePublishing</c> uses for <c>IMessageSink.PublishAsync&lt;T&gt;</c>, with the same
+    ///     BCL <c>Expression.Compile</c>. The lazy init races benignly: two threads may each compile,
+    ///     both delegates are correct, and one wins the field.
+    /// </remarks>
     public IEvent Wrap(object eventData)
     {
-        var genericType = typeof(Event<>).MakeGenericType(EventType);
-        var @event = (IEvent)Activator.CreateInstance(genericType, eventData)!;
+        var wrapper = _wrapper ??= CompileWrapper(EventType);
+        var @event = wrapper(eventData);
         @event.EventTypeName = EventTypeName;
         @event.DotNetTypeName = DotNetTypeName;
         return @event;
+    }
+
+    private static Func<object, IEvent> CompileWrapper(Type eventType)
+    {
+        var genericType = typeof(Event<>).MakeGenericType(eventType);
+        var constructor = genericType.GetConstructor(new[] { eventType })
+                          ?? throw new InvalidOperationException(
+                              $"Event<{eventType.Name}> has no ({eventType.Name}) constructor.");
+
+        var data = Expression.Parameter(typeof(object), "data");
+        var body = Expression.Convert(
+            Expression.New(constructor, Expression.Convert(data, eventType)),
+            typeof(IEvent));
+
+        return Expression.Lambda<Func<object, IEvent>>(body, data).Compile();
     }
 }


### PR DESCRIPTION
Closes #156. Stoat plan `critter-performance-2026-09`, node `fisher-event-hydration-caches`.

Two per-event costs removed from the hot read/write paths, and one investigated and declined with evidence.

## `FisherEventType.Wrap` — compiled wrapper per event type

`Wrap` ran `typeof(Event<>).MakeGenericType(EventType)` + `Activator.CreateInstance` for every event hydrated by `FisherEventsRowReader.ReadEventCore` and every raw event appended through `EventGraph.BuildEvent`. It now compiles the `Event<T>` constructor into a `Func<object, IEvent>` once per event type — the same pattern `MessagePublishing` already uses for `IMessageSink.PublishAsync<T>`, with the same BCL `Expression.Compile`. JasperFx's `EventTypeData<T>` gets the fast shape by being generic; `FisherEventType` cannot close over `T` without reshaping `EventMappingFor`, so the cached delegate is the equivalent. The lazy init races benignly (both compiled delegates are correct; one wins the field), and the remarks say so.

## `EventGraph.ResolveEventType` — memoized `Type.GetType`

Called once per event row (stream reads, the daemon's loader, DCB tag queries, the explorer's binary-body path); `Type.GetType(string)` parses the assembly-qualified name and probes loaded assemblies every call. Now memoized per `dotnet_type` name. Marten's `EventGraph.TypeForDotNetName` (`ImHashMap` behind a `Ref`) is the precedent; Fisher uses a `ConcurrentDictionary<string, Type?>` to match the two registries already on `EventGraph`, which gives the same lock-free reads. **Misses are cached as stored null entries** — the half that pays, since Fisher deliberately answers null for a foreign event type so a deployment stays able to read streams it does not fully know, and that is exactly the path that would otherwise re-probe per row forever.

## `GetGuid` in the row readers — investigated, declined

Verified against Microsoft.Data.Sqlite 10.0.9 before touching anything: `GetGuid` round-trips Fisher's lowercase-canonical TEXT (uppercase too), but for a TEXT column it is `new Guid(GetString(ordinal))` — the intermediate string is still allocated. Measured per read: `GetString` only 528 B, `Guid.Parse(GetString)` 528 B, `GetGuid` 524 B. No measurable win, and the row readers' explicit conversions are a documented invariant (CLAUDE.md "Row readers": the write path converts explicitly, so reads must not lean on provider coercion). `GetGuid` would also silently read a 16-byte BLOB — the mis-bound-Guid corruption shape Fisher's docs treat as something to surface. Left as is; details in #156.

## Tests

New `event_wrapping_and_type_resolution` (6 tests): the typed envelope with metadata, a fresh envelope per wrap (a cached *envelope* would bleed one row's stamped metadata into the next), resolution hit + cached entry, **the cached miss** (the property no behavioural assertion can see, pinned via the internal cache), null/empty never cached, and the `BuildEvent` path.

Results (net10.0, local):
- `Fisher.Tests.Events` namespace: 258/258 passed
- `Fisher.Tests.Compliance` (all 37 shared suites): 388/388 passed
- Full `Fisher.Tests`: 1459/1459 passed (one run hit the known `CliJsonCapture` console-capture race in `stream_query_command`, unrelated; green in isolation and on the full rerun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
