### PR TITLE
gh-153: Push the daemon loader's event-type filter into SQL

### DIFF
--- a/src/Fisher.Tests/Events/daemon_event_loading.cs
+++ b/src/Fisher.Tests/Events/daemon_event_loading.cs
@@ -181,4 +181,103 @@ public class daemon_event_loading : IAsyncLifetime
         page.Count.ShouldBe(2);
         page.ShouldAllBe(x => x.Data is QuestStarted);
     }
+
+    private FisherEventLoader FilteredLoader()
+    {
+        var filtering = new EventFilterable();
+        filtering.IncludeType<QuestStarted>();
+
+        return new FisherEventLoader(_store.Database, _store.Options, filtering);
+    }
+
+    /// <summary>
+    ///     The discriminating fact for pushing the type filter into SQL (fisher#153). The run of
+    ///     non-matching events is longer than the batch size, so a loader that read every row and
+    ///     filtered client-side would count the discarded rows against the batch and report a
+    ///     ceiling at the last <em>matched</em> sequence — paging through the run one batch of
+    ///     discards at a time. With the filter in SQL the query scans the whole range for matches,
+    ///     comes back short of the batch size, and honestly reports the high-water mark as its
+    ///     ceiling: the floor advances past the entire filtered-out run in one page, so a
+    ///     projection scoped to a few event types cannot stall behind events it will never apply.
+    /// </summary>
+    [Fact]
+    public async Task a_filtered_page_advances_past_a_run_of_non_matching_events()
+    {
+        await AppendAsync(new QuestStarted("one"));
+        await AppendAsync(Enumerable.Range(0, 10)
+            .Select(object (i) => new MemberJoined($"member-{i}"))
+            .ToArray());
+
+        var page = await FilteredLoader()
+            .LoadAsync(Request(0, 11, batchSize: 3), TestContext.Current.CancellationToken);
+
+        page.Count.ShouldBe(1);
+        page.Single().Data.ShouldBeOfType<QuestStarted>();
+
+        // Everything up to the high-water mark was scanned for matches, so the ceiling is the
+        // high-water mark — the next request's floor is already past the whole non-matching run.
+        page.Ceiling.ShouldBe(11);
+    }
+
+    /// <summary>
+    ///     The other half of the ceiling contract under a SQL-side filter: a page that fills the
+    ///     batch with matching events claims only as far as its last row. The non-matching events
+    ///     interleaved below the ceiling are stepped over for good; the ones above it are scanned
+    ///     again by the next request, which re-delivers nothing because they still do not match.
+    /// </summary>
+    [Fact]
+    public async Task a_full_page_of_matching_events_reports_the_last_matched_sequence()
+    {
+        await AppendAsync(new QuestStarted("one"), new MemberJoined("A"), new QuestStarted("two"),
+            new MemberJoined("B"), new QuestStarted("three"), new MemberJoined("C"));
+
+        var page = await FilteredLoader()
+            .LoadAsync(Request(0, 6, batchSize: 2), TestContext.Current.CancellationToken);
+
+        page.Select(x => x.Sequence).ShouldBe([1, 3]);
+        page.Ceiling.ShouldBe(3);
+
+        // And the next page picks up from there and finishes the range.
+        var next = await FilteredLoader()
+            .LoadAsync(Request(3, 6, batchSize: 2), TestContext.Current.CancellationToken);
+
+        next.Select(x => x.Sequence).ShouldBe([5]);
+        next.Ceiling.ShouldBe(6);
+    }
+
+    /// <summary>
+    ///     Direct proof the filter runs in SQL rather than after hydration: a non-matching row
+    ///     whose <c>dotnet_type</c> cannot resolve would throw <c>UnknownEventTypeException</c> if
+    ///     it were hydrated first (<c>SkipUnknownEvents</c> defaults to off). Filtered in SQL, the
+    ///     row never leaves SQLite and the page loads cleanly — which is also the performance
+    ///     claim: rows outside the allow-list are never read, hydrated or deserialized.
+    /// </summary>
+    [Fact]
+    public async Task a_non_matching_row_is_never_hydrated()
+    {
+        await AppendAsync(new QuestStarted("one"), new MemberJoined("Frodo"));
+
+        // Corrupt the MemberJoined row (sequence 2) so that hydrating it must fail.
+        await using (var connection =
+                     await _store.Database.OpenConnectionAsync(TestContext.Current.CancellationToken))
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText =
+                "update fi_events set dotnet_type = 'No.Such.Type, NoSuchAssembly' where seq_id = 2";
+            (await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
+        }
+
+        // Unfiltered, the daemon meets the poison row and refuses it by name — the pre-existing
+        // policy this test leans on as its control.
+        await Should.ThrowAsync<Fisher.Exceptions.UnknownEventTypeException>(async () =>
+            await TheLoader.LoadAsync(Request(0, 2), TestContext.Current.CancellationToken));
+
+        // Filtered to QuestStarted, the row is excluded by the SQL and never hydrated at all.
+        var page = await FilteredLoader()
+            .LoadAsync(Request(0, 2), TestContext.Current.CancellationToken);
+
+        page.Count.ShouldBe(1);
+        page.Single().Data.ShouldBeOfType<QuestStarted>();
+        page.Ceiling.ShouldBe(2);
+    }
 }

--- a/src/Fisher.Tests/Events/subscriptions.cs
+++ b/src/Fisher.Tests/Events/subscriptions.cs
@@ -129,6 +129,40 @@ public class subscriptions : IAsyncLifetime
         progress.ShouldBeGreaterThan(0);
     }
 
+    /// <summary>
+    ///     fisher#153 — the loader pushes a subscription's event-type allow-list into SQL, so rows
+    ///     of other types never leave SQLite. Two facts a daemon-level test can pin: events of
+    ///     non-allowed types do not reach the subscription, and the shard's recorded progress still
+    ///     advances past a long run of filtered-out events all the way to the head — get the
+    ///     ceiling accounting wrong under a server-side filter and this either stalls short of the
+    ///     head or skips the matching event entirely.
+    /// </summary>
+    [Fact]
+    public async Task a_filtered_subscription_sees_only_its_types_and_still_reaches_the_head()
+    {
+        var recorder = new FilteredRecordingSubscription();
+        await StartWithAsync(recorder);
+
+        await AppendAsync(new QuestStarted("Find the ring"));
+
+        // A run of events the subscription filters out, appended after the one it wants —
+        // progress has to advance past all of them.
+        for (var i = 0; i < 25; i++)
+        {
+            await AppendAsync(new MemberJoined($"member-{i}"));
+        }
+
+        await _store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(30));
+
+        recorder.Seen.Count.ShouldBe(1);
+        recorder.Seen.Single().Data.ShouldBeOfType<QuestStarted>();
+
+        var progress = await _store.Database
+            .ProjectionProgressFor(new ShardName(recorder.Name), TestContext.Current.CancellationToken);
+
+        progress.ShouldBe(26);
+    }
+
     // ---- the transactional guarantee ----
 
     /// <summary>
@@ -222,6 +256,28 @@ public class subscriptions : IAsyncLifetime
     {
         // A queue, not a ConcurrentBag: the bag is explicitly unordered, so asserting sequence
         // order against one tests nothing and fails at random.
+        public ConcurrentQueue<IEvent> Seen { get; } = new();
+
+        public override Task<IDaemonChangeListener> ProcessEventsAsync(EventRange page,
+            ISubscriptionController controller, IDocumentSession operations,
+            CancellationToken cancellationToken)
+        {
+            foreach (var @event in page.Events)
+            {
+                Seen.Enqueue(@event);
+            }
+
+            return Task.FromResult<IDaemonChangeListener>(NullDaemonChangeListener.Instance);
+        }
+    }
+
+    private sealed class FilteredRecordingSubscription : SubscriptionBase
+    {
+        public FilteredRecordingSubscription()
+        {
+            IncludeType<QuestStarted>();
+        }
+
         public ConcurrentQueue<IEvent> Seen { get; } = new();
 
         public override Task<IDaemonChangeListener> ProcessEventsAsync(EventRange page,

--- a/src/Fisher/Events/Daemon/FisherEventLoader.cs
+++ b/src/Fisher/Events/Daemon/FisherEventLoader.cs
@@ -27,6 +27,12 @@ namespace Fisher.Events.Daemon;
 ///         same reader the DCB tag queries use: a page spans streams, so each event's identity has to
 ///         come off its own row rather than from the hydration context.
 ///     </para>
+///     <para>
+///         A subscription or projection that names its event types gets that filter pushed into the
+///         SQL (<c>and type in (...)</c>), so non-matching rows are never read off disk, hydrated or
+///         deserialized — the same strategy as Marten's <c>EventTypeFilter</c>. See the constructor
+///         for why the page's ceiling accounting stays correct with the filter server-side.
+///     </para>
 /// </remarks>
 [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
     Justification = "Class-level: hydrates IEvent batches through the row reader, which routes to ISerializer.FromJson. Event types are preserved by EventGraph registration on the caller side per the AOT publishing guide.")]
@@ -38,6 +44,8 @@ internal sealed class FisherEventLoader : IEventLoader
     private readonly StoreOptions _options;
     private readonly EventGraph _events;
     private readonly HashSet<string>? _allowedEventTypeNames;
+    private readonly string[]? _allowedTypeNameParameters;
+    private readonly string _typeFilterSql = string.Empty;
 
     internal FisherEventLoader(FisherDatabase database, StoreOptions options, EventFilterable? filtering = null)
     {
@@ -55,6 +63,29 @@ internal sealed class FisherEventLoader : IEventLoader
             {
                 _allowedEventTypeNames.Add(_events.EventMappingFor(type).EventTypeName);
             }
+
+            // The filter is pushed into SQL so non-matching rows never leave SQLite — a
+            // subscription scoped to a few event types in a busy store would otherwise deserialize
+            // essentially the whole event log to produce nothing. Marten pushes the same filter
+            // down as its EventTypeFilter fragment.
+            //
+            // The page's ceiling accounting stays correct with the filter server-side, and it is
+            // worth spelling out why. EventPage.CalculateCeiling's contract is "a page that did not
+            // fill the batch exhausted everything up to the bound it was given": a filtered query
+            // returning fewer than batch_size MATCHING rows really has scanned the whole
+            // (floor, high-water] range, so taking the high-water mark as the ceiling steps the
+            // floor past every non-matching sequence in it — that is what keeps a shard from
+            // stalling on a run of filtered-out events. A full page takes the last matched
+            // sequence, and the non-matching rows above it are re-scanned by the next request,
+            // which never re-delivers anything (they still do not match).
+            //
+            // The set is materialized into a stable array because a HashSet's enumeration order is
+            // unspecified — the parameter names in the SQL and the values bound each LoadAsync
+            // must line up.
+            _allowedTypeNameParameters = _allowedEventTypeNames.ToArray();
+            var markers = string.Join(", ",
+                Enumerable.Range(0, _allowedTypeNameParameters.Length).Select(i => $"@t{i}"));
+            _typeFilterSql = $" and type in ({markers})";
         }
     }
 
@@ -66,7 +97,7 @@ internal sealed class FisherEventLoader : IEventLoader
         var sql = $"""
                    select {FisherEventsRowReader.ComposeSelectColumns(_options.Events)}
                    from {_events.EventsTableName}
-                   where seq_id > @floor and seq_id <= @ceiling and is_archived = 0
+                   where seq_id > @floor and seq_id <= @ceiling and is_archived = 0{_typeFilterSql}
                    order by seq_id
                    limit @batch_size
                    """;
@@ -78,6 +109,14 @@ internal sealed class FisherEventLoader : IEventLoader
         command.Parameters.AddWithValue("@floor", request.Floor);
         command.Parameters.AddWithValue("@ceiling", request.HighWater);
         command.Parameters.AddWithValue("@batch_size", request.BatchSize);
+
+        if (_allowedTypeNameParameters is not null)
+        {
+            for (var i = 0; i < _allowedTypeNameParameters.Length; i++)
+            {
+                command.Parameters.AddWithValue($"@t{i}", _allowedTypeNameParameters[i]);
+            }
+        }
 
         var ctx = new EventHydrationContext(_events, _options.Serializer, string.Empty,
             JasperFx.StorageConstants.DefaultTenantId);
@@ -107,9 +146,10 @@ internal sealed class FisherEventLoader : IEventLoader
 
             if (_allowedEventTypeNames != null && !_allowedEventTypeNames.Contains(@event.EventTypeName))
             {
-                // Filtered out by the subscription rather than skipped in error: it is not counted,
-                // because the ceiling calculation treats skips as "we consumed this slot" and a
-                // filtered event genuinely was consumed from the page's range.
+                // Belt and braces: the SQL type filter above already excludes these rows, so this
+                // only fires if the rendered filter and the set ever disagree. Counting it as
+                // skipped keeps the ceiling honest either way — the row consumed a slot of the
+                // page's range.
                 skipped++;
                 continue;
             }


### PR DESCRIPTION
Closes #153. Stoat plan `critter-performance-2026-09`, node `fisher-loader-filter`.

## What

`FisherEventLoader` applied a subscription/projection's event-type allow-list only **after** fully hydrating every row (JSON deserialization + reflection-driven `Event<T>` construction), so a shard scoped to a few event types in a busy store deserialized essentially the whole event log to produce nothing. The allow-list is fully known at construction, so it is now rendered as a parameterized `and type in (@t0, @t1, ...)` clause on the loader's SELECT — non-matching rows never leave SQLite. Same strategy as Marten's `EventTypeFilter` fragment. The client-side check stays as belt and braces.

## Why the ceiling/floor accounting stays correct

`EventPage.CalculateCeiling`'s contract is *"a page that did not fill the batch exhausted everything up to the bound it was given"*:

- A filtered query returning **fewer than `batch_size` matching rows** really has scanned the whole `(floor, high-water]` range, so it honestly claims the high-water mark as its ceiling — the floor advances past every non-matching sequence in the range in one page. That is what keeps a shard from stalling behind a run of filtered-out events, and it is *better* than the old client-side filter, which counted discards against the batch and crawled through such a run one batch of discards at a time (ceiling pinned at the last *matched* sequence).
- A **full page** of matching rows claims only its last matched sequence, exactly as before; the non-matching rows above it are re-scanned by the next request, which re-delivers nothing.

The set delivered to the shard is unchanged — only where the filtering happens moves.

## Tests

All four new tests fail against the old loader (verified by stashing the production change):

- `a_filtered_page_advances_past_a_run_of_non_matching_events` — one-page progression past a filtered-out run longer than the batch size (`Ceiling == HighWater`).
- `a_full_page_of_matching_events_reports_the_last_matched_sequence` — the full-page half of the contract, plus the follow-up request finishing the range.
- `a_non_matching_row_is_never_hydrated` — direct proof the filter runs in SQL rather than after hydration: a poison `dotnet_type` on a non-matching row would throw `UnknownEventTypeException` if hydrated first (and does, in the unfiltered control); filtered, the page loads cleanly.
- `subscriptions.a_filtered_subscription_sees_only_its_types_and_still_reaches_the_head` — daemon-level: events of non-allowed types never reach the subscription, and recorded progress advances to the head past 25 filtered-out events.

Full `Fisher.Tests` suite: **1457/1457 green on net10.0 and net9.0** (SQLite, no docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)