### PR TITLE
Parameterize modulo operands and escape JSON-path locators (LINQ SQL-injection audit)

### DIFF
--- a/src/Fisher.Tests/Linq/sql_injection_hardening.cs
+++ b/src/Fisher.Tests/Linq/sql_injection_hardening.cs
@@ -1,0 +1,180 @@
+using System.Globalization;
+using System.Linq.Expressions;
+using System.Text.Json.Serialization;
+using Fisher.Linq;
+using Fisher.Linq.Members;
+using Fisher.Linq.Parsing;
+using JasperFx;
+using Weasel.Core;
+
+namespace Fisher.Tests.Linq;
+
+/// <summary>
+///     Regression tests from the LINQ-provider SQL-injection audit (the marten#4911 / marten#4954
+///     class): every runtime value reaching generated SQL must arrive as a bound parameter or be
+///     escaped, never interpolated as text.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The audited hole was the modulo translation, which rendered both of its runtime operands
+///         with an interpolated <c>ToString()</c> — no parameter, no type guard, current-culture
+///         formatting. The expression tree's typing confines the ordinary API to numeric operands,
+///         so the practical exposure was malformed SQL under a comma-decimal culture and a breakout
+///         via a user-defined <c>operator %</c>'s <c>ToString()</c>; both are closed by binding, and
+///         the SQL-text assertions here are what hold it closed.
+///     </para>
+///     <para>
+///         The member-locator half mirrors marten#4911's <c>DictionaryItemMember</c> fix: a value
+///         inlined into the single-quoted JSON-path literal must have its quotes escaped. Fisher's
+///         only path source today is <c>[JsonPropertyName]</c> — compile-time configuration — so
+///         this is defence in depth rather than a live exploit, pinned so a future runtime-supplied
+///         path segment cannot inherit a breakout.
+///     </para>
+/// </remarks>
+public class sql_injection_hardening : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("sqli");
+    private DocumentStore _store = null!;
+
+    public class Specimen
+    {
+        public Guid Id { get; set; }
+        public int Number { get; set; }
+        public double Weight { get; set; }
+
+        // A quote in the stored key is exactly the character that would close the JSON-path string
+        // literal the locator embeds it in.
+        [JsonPropertyName("o'brien")]
+        public string Quoted { get; set; } = "";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<Specimen>();
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using var session = _store.LightweightSession();
+        session.Store(new Specimen { Id = Guid.NewGuid(), Number = 3, Weight = 1.25, Quoted = "match" });
+        session.Store(new Specimen { Id = Guid.NewGuid(), Number = 4, Weight = 2.5, Quoted = "other" });
+        session.Store(new Specimen { Id = Guid.NewGuid(), Number = 5, Weight = 4.5, Quoted = "other" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private Microsoft.Data.Sqlite.SqliteCommand CommandFor(Expression<Func<Specimen, bool>> predicate)
+    {
+        var factory = new MemberFactory(_store.Options, _store.Options.Schema.For<Specimen>().Mapping);
+        var builder = new Weasel.Sqlite.CommandBuilder();
+        new WhereClauseParser(factory).Parse(predicate.Body).Apply(builder);
+        return (Microsoft.Data.Sqlite.SqliteCommand)builder.Compile();
+    }
+
+    [Fact]
+    public void modulo_operands_are_bound_as_parameters_not_interpolated()
+    {
+        var divisor = 2;
+        var remainder = 0;
+
+        var command = CommandFor(x => x.Number % divisor == remainder);
+
+        command.CommandText.ShouldBe("(json_extract(data, '$.number') % @p0) = @p1");
+        command.Parameters.Count.ShouldBe(2);
+        command.Parameters["p0"].Value.ShouldBe(2);
+        command.Parameters["p1"].Value.ShouldBe(0);
+    }
+
+    [Fact]
+    public void a_reversed_modulo_comparison_is_bound_the_same_way()
+    {
+        var command = CommandFor(x => 0 < x.Number % 3);
+
+        command.CommandText.ShouldBe("(json_extract(data, '$.number') % @p0) > @p1");
+        command.Parameters["p0"].Value.ShouldBe(3);
+        command.Parameters["p1"].Value.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_modulo_predicate_still_answers_correctly()
+    {
+        await using var session = _store.LightweightSession();
+
+        var even = await session.Query<Specimen>()
+            .Where(x => x.Number % 2 == 0)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        even.ShouldHaveSingleItem().Number.ShouldBe(4);
+    }
+
+    /// <summary>
+    ///     The old interpolation rendered a fractional operand with the current culture, so under a
+    ///     comma-decimal culture <c>x.Weight % 1.5</c> became <c>(… % 1,5) = …</c> — SQL whose shape
+    ///     depends on the server's locale. A bound parameter cannot.
+    /// </summary>
+    [Fact]
+    public async Task a_fractional_modulo_operand_survives_a_comma_decimal_culture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+        try
+        {
+            var command = CommandFor(x => x.Weight % 1.5 == 0);
+
+            command.CommandText.ShouldBe("(json_extract(data, '$.weight') % @p0) = @p1");
+            command.Parameters["p0"].Value.ShouldBe(1.5);
+
+            // SQLite's % casts both operands to INTEGER, so every weight satisfies "% 1.5 == 0"
+            // (n % 1 is always 0). The assertion here is that the statement is *valid* whatever
+            // the culture — the old interpolation rendered "(… % 1,5) = 0", which SQLite refuses —
+            // not a claim about float-modulo semantics.
+            await using var session = _store.LightweightSession();
+            var matches = await session.Query<Specimen>()
+                .Where(x => x.Weight % 1.5 == 0)
+                .ToListAsync(TestContext.Current.CancellationToken);
+
+            matches.Count.ShouldBe(3);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    /// <summary>
+    ///     The marten#4911 shape: a value inlined into the locator's single-quoted JSON-path literal
+    ///     is escaped, so a quote in an explicit <c>[JsonPropertyName]</c> stays part of the path
+    ///     rather than closing the string.
+    /// </summary>
+    [Fact]
+    public void a_quoted_json_property_name_is_escaped_in_the_locator()
+    {
+        var factory = new MemberFactory(_store.Options, _store.Options.Schema.For<Specimen>().Mapping);
+        var member = factory.ResolveMember(
+            (MemberExpression)((Expression<Func<Specimen, string>>)(x => x.Quoted)).Body);
+
+        member.RawLocator.ShouldBe("json_extract(data, '$.o''brien')");
+    }
+
+    [Fact]
+    public async Task a_quoted_json_property_name_still_queries_end_to_end()
+    {
+        await using var session = _store.LightweightSession();
+
+        var matches = await session.Query<Specimen>()
+            .Where(x => x.Quoted == "match")
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        matches.ShouldHaveSingleItem().Number.ShouldBe(3);
+    }
+}

--- a/src/Fisher/Linq/Members/MemberFactory.cs
+++ b/src/Fisher/Linq/Members/MemberFactory.cs
@@ -157,7 +157,13 @@ internal class MemberFactory : IMemberResolver
 
     private IQueryableMember CreateMember(string jsonPath, Type memberType)
     {
-        var locator = $"json_extract({_qualifier}data, '{jsonPath}')";
+        // The path is inlined into a single-quoted SQL literal. A CLR member name cannot carry a
+        // quote, but an explicit [JsonPropertyName] can — so escape embedded single quotes to keep
+        // the path data rather than SQL (the marten#4911 class, where the escaped runtime value was
+        // a dictionary key reaching the same position). Defence in depth here: the name is
+        // compile-time configuration today, and this is what keeps a future runtime-supplied path
+        // segment from inheriting a breakout.
+        var locator = $"json_extract({_qualifier}data, '{jsonPath.Replace("'", "''")}')";
         var underlying = Nullable.GetUnderlyingType(memberType) ?? memberType;
 
         if (underlying.IsEnum)

--- a/src/Fisher/Linq/Parsing/WhereClauseParser.cs
+++ b/src/Fisher/Linq/Parsing/WhereClauseParser.cs
@@ -305,6 +305,17 @@ internal class WhereClauseParser
         }
     }
 
+    /// <summary>
+    ///     <c>x.Number % 2 == 0</c> → <c>(locator % @p0) = @p1</c>, both operands bound as
+    ///     parameters.
+    /// </summary>
+    /// <remarks>
+    ///     The divisor and the comparison operand used to be interpolated into the SQL text as
+    ///     <c>ToString()</c> — unparameterised runtime values, the marten#4911/#4954 class. See
+    ///     <see cref="ModuloFilter" /> for why binding is a security invariant here. A null operand
+    ///     declines rather than rendering, so the caller's "cannot translate" refusal names the
+    ///     expression instead of SQLite reporting malformed SQL.
+    /// </remarks>
     private bool TryParseModulo(BinaryExpression binary, string op, out ISqlFragment? fragment)
     {
         fragment = null;
@@ -312,19 +323,26 @@ internal class WhereClauseParser
         if (binary.Left is BinaryExpression { NodeType: ExpressionType.Modulo } modulo
             && StripConvert(modulo.Left) is MemberExpression left && IsDocumentMember(left))
         {
+            if (ExtractValue(modulo.Right) is not { } divisor || ExtractValue(binary.Right) is not { } operand)
+            {
+                return false;
+            }
+
             var member = _memberFactory.ResolveMember(left);
-            fragment = new WhereFragment(
-                $"({member.TypedLocator} % {ExtractValue(modulo.Right)}) {op} {ExtractValue(binary.Right)}");
+            fragment = new ModuloFilter(member.TypedLocator, divisor, op, operand);
             return true;
         }
 
         if (binary.Right is BinaryExpression { NodeType: ExpressionType.Modulo } moduloRight
             && StripConvert(moduloRight.Left) is MemberExpression right && IsDocumentMember(right))
         {
+            if (ExtractValue(moduloRight.Right) is not { } divisor || ExtractValue(binary.Left) is not { } operand)
+            {
+                return false;
+            }
+
             var member = _memberFactory.ResolveMember(right);
-            fragment = new WhereFragment(
-                $"({member.TypedLocator} % {ExtractValue(moduloRight.Right)}) "
-                + $"{ReverseOperator(op)} {ExtractValue(binary.Left)}");
+            fragment = new ModuloFilter(member.TypedLocator, divisor, ReverseOperator(op), operand);
             return true;
         }
 

--- a/src/Fisher/Linq/SqlGeneration/ModuloFilter.cs
+++ b/src/Fisher/Linq/SqlGeneration/ModuloFilter.cs
@@ -1,0 +1,59 @@
+using Weasel.Core;
+using Weasel.Core.SqlGeneration;
+
+namespace Fisher.Linq.SqlGeneration;
+
+/// <summary>
+///     A modulo comparison with both operands bound as parameters —
+///     <c>(locator % @p0) op @p1</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Parameterised as a security invariant, not a style choice</b> (the marten#4911 /
+///         marten#4954 class). The divisor and the comparison operand are runtime values —
+///         <c>WhereClauseParser.ExtractValue</c> evaluates captured locals — and the previous shape
+///         interpolated their <c>ToString()</c> straight into the SQL text with no type guard, no
+///         escaping, and the current culture's formatting. The expression tree's typing keeps the
+///         ordinary API to numeric operands, but a user-defined <c>operator %</c> puts an arbitrary
+///         <c>ToString()</c> into the statement, and even a plain <c>double</c> renders as
+///         <c>1,5</c> under a comma-decimal culture — malformed SQL that depends on the server's
+///         locale. Binding removes both.
+///     </para>
+///     <para>
+///         A <see cref="decimal" /> operand is normalised to <see cref="double" /> before binding,
+///         because Microsoft.Data.Sqlite binds a raw decimal as TEXT — see
+///         <c>SqliteParameterValue</c>, which makes the identical conversion for raw SQL and records
+///         why: <c>json_extract</c> yields REAL for a JSON number and there is no column affinity
+///         inside an expression to rescue the comparison.
+///     </para>
+/// </remarks>
+internal class ModuloFilter : ISqlFragment
+{
+    private readonly string _locator;
+    private readonly object _divisor;
+    private readonly string _op;
+    private readonly object _operand;
+
+    public ModuloFilter(string locator, object divisor, string op, object operand)
+    {
+        _locator = locator;
+        _divisor = Normalize(divisor);
+        _op = op;
+        _operand = Normalize(operand);
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append('(');
+        builder.Append(_locator);
+        builder.Append(" % ");
+        builder.AppendParameter(_divisor);
+        builder.Append(") ");
+        builder.Append(_op);
+        builder.Append(' ');
+        builder.AppendParameter(_operand);
+    }
+
+    private static object Normalize(object value)
+        => value is decimal number ? (double)number : value;
+}


### PR DESCRIPTION
Closes the two hardening findings from the LINQ provider SQL-injection audit in #161 (Stoat plan `critter-hardening-audit`, node `fisher-sqli-audit`; marten#4911 / marten#4954 as the checklist).

## What changed

- **`WhereClauseParser.TryParseModulo` now binds both operands as parameters** through a new `ModuloFilter` fragment instead of interpolating `ExtractValue(...).ToString()` into the SQL text. The old shape was the marten#4954 class one type over: unparameterized runtime values with no type guard and current-culture formatting — malformed SQL under a comma-decimal culture (`(x % 1,5) = 0`), and a text breakout available to a user-defined `operator %`'s `ToString()`. A `decimal` operand normalizes to `double` before binding (the same conversion `SqliteParameterValue` records for raw SQL, since Microsoft.Data.Sqlite binds a raw decimal as TEXT); a null operand declines to the ordinary "cannot translate" refusal instead of rendering broken SQL.
- **`MemberFactory.CreateMember` escapes embedded single quotes in the JSON path** before inlining it into the locator's single-quoted literal — mirroring marten#4911's `DictionaryItemMember` fix. Fisher's path sources are compile-time (`[JsonPropertyName]`, member names), so this is defense in depth rather than a live exploit; it also makes a quote-bearing `[JsonPropertyName]` query correctly end to end, where it previously produced broken SQL.

## Tests

`Linq/sql_injection_hardening.cs` (6 tests): the exact modulo SQL shape with bound parameters (both operand orders), the comma-decimal-culture case executed against real rows, the escaped locator, and end-to-end queries proving behavior is unchanged. Full suite: 1459/1459 Fisher.Tests on net10.0 **and** net9.0, 36/36 AspNetCore, 19/19 EntityFrameworkCore.

Everything else audited already renders runtime values as bound parameters — the full findings table is in #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)