### PR TITLE
gh-164: batch AppendPlanner's stream version reads into one query per pass

### DIFF
--- a/src/Fisher.Tests/Events/batched_version_reads.cs
+++ b/src/Fisher.Tests/Events/batched_version_reads.cs
@@ -1,0 +1,310 @@
+using Fisher.Exceptions;
+using Fisher.Projections;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using JasperFx.MultiTenancy;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>
+///     The append planner reads every stream's current version in one set-based query per planning
+///     pass (fisher#164), where it used to issue one scalar query per stream — 2N round trips per
+///     save with inline projections on, N of them under the exclusive write lock.
+/// </summary>
+/// <remarks>
+///     <para>
+///         There is no SQL-capture seam over the planner's connection, so these tests hold the
+///         batched read to the per-stream read's exact semantics instead: mixed new/existing/missing
+///         streams in one save, the optimistic guard and the start-collision guard inside a
+///         multi-stream save, archived streams (whose version still reads — the per-stream query
+///         never filtered on <c>is_archived</c> and the batched one must not either), both stream
+///         identity styles, per-tenant reads under conjoined tenancy, and the early best-effort pass
+///         that hands inline projections their versions.
+///     </para>
+///     <para>
+///         The two passes deliberately stay two reads rather than one. The early pass runs outside
+///         the write lock so inline projections have versions to fold; the in-transaction pass is the
+///         authoritative read the optimistic concurrency check and the final numbering rest on.
+///         Merging them, or seeding one from the other, is exactly the race the planner's class
+///         remarks forbid.
+///     </para>
+/// </remarks>
+public class batched_version_reads : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("batched-versions");
+    private DocumentStore _store = null!;
+    private DocumentStore _projectionStore = null!;
+    private DocumentStore _stringStore = null!;
+    private DocumentStore _conjoinedStore = null!;
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        _projectionStore = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.DatabaseSchemaName = "projected";
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<VersionSnapshot>();
+            options.Projections.Add(new VersionRecordingProjection(), ProjectionLifecycle.Inline);
+        });
+
+        _stringStore = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.DatabaseSchemaName = "strings";
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.StreamIdentity = StreamIdentity.AsString;
+        });
+
+        _conjoinedStore = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.DatabaseSchemaName = "conjoined";
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+        await _projectionStore.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+        await _stringStore.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+        await _conjoinedStore.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        await _projectionStore.DisposeAsync();
+        await _stringStore.DisposeAsync();
+        await _conjoinedStore.DisposeAsync();
+        _database.Dispose();
+    }
+
+    [Fact]
+    public async Task one_save_plans_new_existing_and_missing_streams_together()
+    {
+        var existingA = Guid.NewGuid();
+        var existingB = Guid.NewGuid();
+        var missing = Guid.NewGuid();
+        var started = Guid.NewGuid();
+
+        await using (var seed = _store.LightweightSession())
+        {
+            seed.Events.StartStream(existingA, new QuestStarted("A"), new MemberJoined("A1"));
+            seed.Events.StartStream(existingB, new QuestStarted("B"));
+            await seed.SaveChangesAsync(Token);
+        }
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.Append(existingA, new MonsterSlain("A troll"));
+            session.Events.Append(existingB, new MemberJoined("B1"), new MemberJoined("B2"));
+
+            // Appending to a stream that does not exist creates it — the batched read reports it
+            // as missing, exactly as the per-stream read did.
+            session.Events.Append(missing, new QuestStarted("M"));
+
+            var startedAction = session.Events.StartStream(started, new QuestStarted("S"), new MemberJoined("S1"));
+
+            await session.SaveChangesAsync(Token);
+
+            // Versions were assigned from each stream's own current version, not from a neighbour's.
+            startedAction.Events[0].Version.ShouldBe(1);
+            startedAction.Events[1].Version.ShouldBe(2);
+        }
+
+        await using var query = _store.LightweightSession();
+        (await query.Events.FetchStreamStateAsync(existingA, Token))!.Version.ShouldBe(3);
+        (await query.Events.FetchStreamStateAsync(existingB, Token))!.Version.ShouldBe(3);
+        (await query.Events.FetchStreamStateAsync(missing, Token))!.Version.ShouldBe(1);
+        (await query.Events.FetchStreamStateAsync(started, Token))!.Version.ShouldBe(2);
+
+        var streamA = await query.Events.FetchStreamAsync(existingA, token: Token);
+        streamA.Select(x => x.Version).ShouldBe([1, 2, 3]);
+    }
+
+    [Fact]
+    public async Task a_start_collision_inside_a_multi_stream_save_is_still_rejected()
+    {
+        var taken = Guid.NewGuid();
+
+        await using (var seed = _store.LightweightSession())
+        {
+            seed.Events.StartStream(taken, new QuestStarted("Taken"));
+            await seed.SaveChangesAsync(Token);
+        }
+
+        await using var session = _store.LightweightSession();
+        session.Events.StartStream(Guid.NewGuid(), new QuestStarted("Fine"));
+        session.Events.StartStream(taken, new QuestStarted("Collides"));
+
+        await Should.ThrowAsync<ExistingStreamIdCollisionException>(() => session.SaveChangesAsync(Token));
+    }
+
+    [Fact]
+    public async Task a_stale_expected_version_inside_a_multi_stream_save_is_still_rejected()
+    {
+        var guarded = Guid.NewGuid();
+
+        await using (var seed = _store.LightweightSession())
+        {
+            seed.Events.StartStream(guarded, new QuestStarted("Guarded"));
+            await seed.SaveChangesAsync(Token);
+        }
+
+        await using var session = _store.LightweightSession();
+        session.Events.StartStream(Guid.NewGuid(), new QuestStarted("Fine"));
+        session.Events.Append(guarded, 5, new MemberJoined("Too eager"));
+
+        await Should.ThrowAsync<EventStreamUnexpectedMaxEventIdException>(() => session.SaveChangesAsync(Token));
+    }
+
+    /// <summary>
+    ///     The per-stream version read never filtered on <c>is_archived</c> — an archived stream's
+    ///     version is still its version — and the batched read must not start.
+    /// </summary>
+    [Fact]
+    public async Task an_archived_stream_still_reads_its_version()
+    {
+        var archived = Guid.NewGuid();
+        var fresh = Guid.NewGuid();
+
+        await using (var seed = _store.LightweightSession())
+        {
+            seed.Events.StartStream(archived, new QuestStarted("Old"), new MemberJoined("Old timer"));
+            await seed.SaveChangesAsync(Token);
+        }
+
+        await using (var archiver = _store.LightweightSession())
+        {
+            archiver.Events.ArchiveStream(archived);
+            await archiver.SaveChangesAsync(Token);
+        }
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.Append(archived, new MonsterSlain("Posthumous"));
+            session.Events.StartStream(fresh, new QuestStarted("New"));
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = _store.LightweightSession();
+        (await query.Events.FetchStreamStateAsync(archived, Token))!.Version.ShouldBe(3);
+        (await query.Events.FetchStreamStateAsync(fresh, Token))!.Version.ShouldBe(1);
+
+        // And starting a stream over an archived id still collides — archived is not missing.
+        await using var collider = _store.LightweightSession();
+        collider.Events.StartStream(archived, new QuestStarted("Reused"));
+        await Should.ThrowAsync<ExistingStreamIdCollisionException>(() => collider.SaveChangesAsync(Token));
+    }
+
+    /// <summary>
+    ///     The early best-effort pass — the one that exists so inline projections fold events that
+    ///     already know their versions — batches too, and still hands every stream its own numbering.
+    /// </summary>
+    [Fact]
+    public async Task inline_projections_receive_per_stream_versions_across_a_multi_stream_save()
+    {
+        var seeded = Guid.NewGuid();
+
+        await using (var seed = _projectionStore.LightweightSession())
+        {
+            seed.Events.StartStream(seeded, new VersionRecorded("seeded-1"), new VersionRecorded("seeded-2"));
+            await seed.SaveChangesAsync(Token);
+        }
+
+        await using (var session = _projectionStore.LightweightSession())
+        {
+            session.Events.Append(seeded, new VersionRecorded("seeded-3"));
+            session.Events.StartStream(Guid.NewGuid(), new VersionRecorded("new-1"), new VersionRecorded("new-2"));
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = _projectionStore.LightweightSession();
+
+        (await query.LoadAsync<VersionSnapshot>("seeded-3", Token))!.Version.ShouldBe(3);
+        (await query.LoadAsync<VersionSnapshot>("new-1", Token))!.Version.ShouldBe(1);
+        (await query.LoadAsync<VersionSnapshot>("new-2", Token))!.Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task string_identified_streams_are_planned_together_too()
+    {
+        await using (var seed = _stringStore.LightweightSession())
+        {
+            seed.Events.StartStream("existing-key", new QuestStarted("Existing"));
+            await seed.SaveChangesAsync(Token);
+        }
+
+        await using (var session = _stringStore.LightweightSession())
+        {
+            session.Events.Append("existing-key", new MemberJoined("More"));
+            session.Events.StartStream("started-key", new QuestStarted("Started"));
+            session.Events.Append("missing-key", new QuestStarted("Missing"));
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = _stringStore.LightweightSession();
+        (await query.Events.FetchStreamStateAsync("existing-key", Token))!.Version.ShouldBe(2);
+        (await query.Events.FetchStreamStateAsync("started-key", Token))!.Version.ShouldBe(1);
+        (await query.Events.FetchStreamStateAsync("missing-key", Token))!.Version.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     Under conjoined tenancy the row key is <c>(tenant_id, id)</c> and one save can span
+    ///     tenants via <c>ForTenant</c> — so the same stream id must read each tenant's own version,
+    ///     never a neighbour tenant's.
+    /// </summary>
+    [Fact]
+    public async Task the_same_stream_id_reads_each_tenants_own_version_in_one_save()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var seed = _conjoinedStore.LightweightSession("north"))
+        {
+            seed.Events.StartStream(streamId, new QuestStarted("North 1"), new MemberJoined("North 2"));
+            await seed.SaveChangesAsync(Token);
+        }
+
+        await using (var session = _conjoinedStore.LightweightSession("north"))
+        {
+            session.Events.Append(streamId, new MonsterSlain("North 3"));
+            session.ForTenant("south").Events.StartStream(streamId, new QuestStarted("South 1"));
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var north = _conjoinedStore.LightweightSession("north");
+        await using var south = _conjoinedStore.LightweightSession("south");
+
+        (await north.Events.FetchStreamStateAsync(streamId, Token))!.Version.ShouldBe(3);
+        (await south.Events.FetchStreamStateAsync(streamId, Token))!.Version.ShouldBe(1);
+    }
+}
+
+public record VersionRecorded(string Name);
+
+// partial, because JasperFx's source generator emits the conventional-method dispatcher into it.
+public partial class VersionRecordingProjection : EventProjection
+{
+    public VersionSnapshot Create(IEvent<VersionRecorded> e) => new()
+    {
+        Id = e.Data.Name,
+        Version = e.Version,
+        StreamId = e.StreamId
+    };
+}
+
+public class VersionSnapshot
+{
+    public string Id { get; set; } = string.Empty;
+    public long Version { get; set; }
+    public Guid StreamId { get; set; }
+}

--- a/src/Fisher/Events/AppendPlanner.cs
+++ b/src/Fisher/Events/AppendPlanner.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Fisher.Internal;
 using Fisher.Storage;
 using JasperFx.Events;
@@ -43,18 +44,24 @@ internal sealed class AppendPlanner
         IReadOnlyCollection<StreamAction> streams, SqliteConnection connection, SqliteTransaction transaction,
         CancellationToken token)
     {
-        var operations = new List<Weasel.Storage.IStorageOperation>(streams.Count);
+        var actionable = CollectActionableStreams(streams);
 
-        foreach (var stream in streams)
+        if (actionable.Count == 0)
         {
-            if (stream.Events.Count == 0)
-            {
-                continue;
-            }
+            return [];
+        }
 
-            ApplySessionMetadata(stream);
+        // One set-based read for every stream in the unit of work, not one scalar query per stream.
+        // This read runs inside the write transaction, holding SQLite's exclusive write lock, so
+        // shrinking N round trips to one is worth the most exactly here.
+        var versions = await ReadCurrentVersionsAsync(actionable, connection, transaction, token)
+            .ConfigureAwait(false);
 
-            var mode = await PlanStreamAsync(stream, connection, transaction, token).ConfigureAwait(false);
+        var operations = new List<Weasel.Storage.IStorageOperation>(actionable.Count);
+
+        foreach (var stream in actionable)
+        {
+            var mode = PlanStream(stream, versions[stream]);
 
             var operation = (Storage.FisherQuickAppendEventsOperation)QuickAppendEvents(stream);
             operation.Mode = mode;
@@ -78,7 +85,37 @@ internal sealed class AppendPlanner
     public async Task AssignVersionsAheadOfProjectionsAsync(IReadOnlyList<StreamAction> streams,
         CancellationToken token)
     {
+        var actionable = CollectActionableStreams(streams);
+
+        if (actionable.Count == 0)
+        {
+            return;
+        }
+
         var connection = await _session.ConnectionAsync(token).ConfigureAwait(false);
+
+        // One set-based read for the whole pass, mirroring PlanAsync. Deliberately NOT merged with
+        // the in-transaction read and NOT used to seed it: this pass runs outside the write lock so
+        // inline projections have versions to fold, and the authoritative read, the optimistic
+        // concurrency check and the final numbering must all still happen under the lock — seeding
+        // one from the other is exactly the race the class remarks forbid.
+        var versions = await ReadCurrentVersionsAsync(actionable, connection, transaction: null, token)
+            .ConfigureAwait(false);
+
+        foreach (var stream in actionable)
+        {
+            AssignVersions(stream, versions[stream] ?? 0);
+        }
+    }
+
+    /// <summary>
+    ///     The streams that will actually be written — everything with at least one event, with the
+    ///     session's metadata applied. Both planning passes share this so they agree about which
+    ///     streams a version read has to cover.
+    /// </summary>
+    private List<StreamAction> CollectActionableStreams(IReadOnlyCollection<StreamAction> streams)
+    {
+        var actionable = new List<StreamAction>(streams.Count);
 
         foreach (var stream in streams)
         {
@@ -88,20 +125,14 @@ internal sealed class AppendPlanner
             }
 
             ApplySessionMetadata(stream);
-
-            var current = await ReadCurrentVersionAsync(stream, connection, transaction: null, token)
-                .ConfigureAwait(false);
-
-            AssignVersions(stream, current ?? 0);
+            actionable.Add(stream);
         }
+
+        return actionable;
     }
 
-    private async Task<Storage.StreamWriteMode> PlanStreamAsync(StreamAction stream, SqliteConnection connection,
-        SqliteTransaction transaction, CancellationToken token)
+    private Storage.StreamWriteMode PlanStream(StreamAction stream, long? currentVersion)
     {
-        var currentVersion = await ReadCurrentVersionAsync(stream, connection, transaction, token)
-            .ConfigureAwait(false);
-
         if (stream.ActionType == StreamActionType.Start)
         {
             if (currentVersion is not null)
@@ -239,37 +270,98 @@ internal sealed class AppendPlanner
     }
 
     /// <summary>
-    ///     The stream's current version, or null when the stream row does not exist.
+    ///     Every stream's current version in one set-based read — null for a stream whose row does not
+    ///     exist.
     /// </summary>
-    private async Task<long?> ReadCurrentVersionAsync(StreamAction stream, SqliteConnection connection,
-        SqliteTransaction? transaction, CancellationToken token)
+    /// <remarks>
+    ///     <para>
+    ///         Replaces one interpolated scalar query per stream, which with inline projections on cost
+    ///         a multi-stream save 2N round trips — N of them under the exclusive write lock. The ids
+    ///         travel as a JSON array unpacked by <c>json_each</c>, the same shape
+    ///         <c>FisherDocumentStorage</c>'s load-many uses, so the parameter count does not vary with
+    ///         the stream count.
+    ///     </para>
+    ///     <para>
+    ///         Semantics are exactly the per-stream read's: a missing row reads as null (create, or
+    ///         collide on <c>Start</c>), and there is deliberately no <c>is_archived</c> filter — an
+    ///         archived stream's version is still its version, as before.
+    ///     </para>
+    ///     <para>
+    ///         Under conjoined tenancy the read is one statement per distinct tenant in the unit of
+    ///         work, because the row key is <c>(tenant_id, id)</c> and one save can span tenants via
+    ///         <c>ForTenant</c>. A single-tenant save — the ordinary case — is still one statement.
+    ///     </para>
+    /// </remarks>
+    private async Task<Dictionary<StreamAction, long?>> ReadCurrentVersionsAsync(
+        IReadOnlyList<StreamAction> streams, SqliteConnection connection, SqliteTransaction? transaction,
+        CancellationToken token)
     {
-        var conjoined = _graph.TenancyStyle == TenancyStyle.Conjoined;
+        var versions = new Dictionary<StreamAction, long?>(streams.Count);
+
+        foreach (var stream in streams)
+        {
+            versions[stream] = null;
+        }
+
+        if (_graph.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            foreach (var tenant in streams.GroupBy(x => x.TenantId))
+            {
+                await ReadVersionsAsync([.. tenant], tenant.Key, connection, transaction, versions, token)
+                    .ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            await ReadVersionsAsync(streams, tenantId: null, connection, transaction, versions, token)
+                .ConfigureAwait(false);
+        }
+
+        return versions;
+    }
+
+    private async Task ReadVersionsAsync(IReadOnlyList<StreamAction> streams, string? tenantId,
+        SqliteConnection connection, SqliteTransaction? transaction,
+        Dictionary<StreamAction, long?> versions, CancellationToken token)
+    {
+        // Keyed by the database's own rendering of the id — for a Guid identity that is the lowercase
+        // canonical text SqliteStorageDialect writes, so the row that comes back matches the key that
+        // went in without any per-row parsing.
+        var byDatabaseId = new Dictionary<string, StreamAction>(streams.Count, StringComparer.Ordinal);
+
+        foreach (var stream in streams)
+        {
+            byDatabaseId[DatabaseIdFor(stream)] = stream;
+        }
 
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText = conjoined
-            ? $"select version from {_graph.StreamsTableName} where id = @id and tenant_id = @tenant_id"
-            : $"select version from {_graph.StreamsTableName} where id = @id";
+        command.CommandText = tenantId is null
+            ? $"select id, version from {_graph.StreamsTableName} where id in (select value from json_each(@ids))"
+            : $"select id, version from {_graph.StreamsTableName} where tenant_id = @tenant_id and id in (select value from json_each(@ids))";
 
-        var id = _graph.StreamIdentity == StreamIdentity.AsGuid
-            ? SqliteStorageDialect<Guid>.ToDatabaseValue(stream.Id)
-            : stream.Key!;
-
-        command.Parameters.Add(new SqliteParameter("id", id) { SqliteType = SqliteType.Text });
-
-        if (conjoined)
+        command.Parameters.Add(new SqliteParameter("ids", JsonSerializer.Serialize(byDatabaseId.Keys))
         {
-            command.Parameters.Add(new SqliteParameter("tenant_id", stream.TenantId)
-            {
-                SqliteType = SqliteType.Text
-            });
+            SqliteType = SqliteType.Text
+        });
+
+        if (tenantId is not null)
+        {
+            command.Parameters.Add(new SqliteParameter("tenant_id", tenantId) { SqliteType = SqliteType.Text });
         }
 
-        var result = await command.ExecuteScalarAsync(token).ConfigureAwait(false);
+        await using var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
 
-        return result is null or DBNull ? null : Convert.ToInt64(result);
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            versions[byDatabaseId[reader.GetString(0)]] = reader.GetInt64(1);
+        }
     }
+
+    private string DatabaseIdFor(StreamAction stream)
+        => _graph.StreamIdentity == StreamIdentity.AsGuid
+            ? (string)SqliteStorageDialect<Guid>.ToDatabaseValue(stream.Id)
+            : stream.Key!;
 
     private Weasel.Storage.IStorageOperation QuickAppendEvents(StreamAction stream)
         => _graph.StreamIdentity == StreamIdentity.AsGuid


### PR DESCRIPTION
Closes #164. Stoat plan node: `critter-performance-2026-09` / `fisher-version-read-dedup`.

## What

`AppendPlanner` read stream versions through `ReadCurrentVersionAsync`, one interpolated scalar `ExecuteScalarAsync` per stream, from both planning passes:

- `AssignVersionsAheadOfProjectionsAsync` (best-effort, outside the transaction, only when inline projections are on): N queries
- `PlanAsync` → `PlanStreamAsync` (inside the write transaction, i.e. under SQLite's exclusive write lock via `BEGIN IMMEDIATE`): N more

So a multi-stream save with inline projections paid **2N round trips, N of them holding the write lock**. Each pass now issues **one set-based read**: `select id, version from <streams> where id in (select value from json_each(@ids))` — ids travel as a single JSON-array parameter (the same json1 shape `FisherDocumentStorage`'s load-many uses), so the parameter count doesn't vary with the stream count. Under conjoined tenancy the read is one statement per **distinct tenant** in the unit of work, because the row key there is `(tenant_id, id)` and one save can span tenants via `ForTenant`; the ordinary single-tenant save is still one statement.

`PlanStreamAsync` became the synchronous `PlanStream(stream, currentVersion)`; both passes share `CollectActionableStreams` so they agree on which streams a read has to cover.

## The dedup decision

The two passes **stay two reads (2 total with inline projections, 1 without — down from 2N/N), deliberately not merged and not seeded from each other**:

- The early pass cannot be skipped: it exists precisely to run *before* the write transaction so inline projections fold events that already know their versions, and the doc comment marks it best-effort by design.
- The in-transaction read cannot seed from the early read: it is the authoritative read that the optimistic concurrency check and the final event numbering rest on. The class remarks spell out why the version read and the write must not race — SQLite has no advisory lock / `UPDLOCK` equivalent, which is why the planner runs under `BEGIN IMMEDIATE` at all. Carrying a pre-lock value across would reopen exactly the two-writers-both-read-N window that design closes; a racing writer between the passes is already handled by the early numbers being overwritten and the commit failing on the real guard.

## Semantics preserved

- Missing stream rows still read as null → append creates the stream; `Start` over an existing row still throws `ExistingStreamIdCollisionException`.
- **No `is_archived` filter** — the per-stream read never had one, so an archived stream still reads its version (appends continue its numbering, `Start` over it still collides).
- Guid identity keys match by the dialect's lowercase-canonical text rendering; string identity uses the raw key; conjoined tenancy reads per tenant.

## Tests

No SQL-capture seam exists over the planner's connection, so per issue #164 the coverage is functional: new `src/Fisher.Tests/Events/batched_version_reads.cs` (7 tests) pins mixed new/existing/missing streams in one save, both guards inside a multi-stream save, archived-stream reads, inline-projection version assignment across a multi-stream save (the early pass), string identity, and same-stream-id-two-tenants under conjoined tenancy.

- `--filter-class "*batched_version_reads*"`: 7/7 passed
- append/aggregate/tenancy/compliance classes: 434/434 passed
- Full solution (net10.0, SQLite, no docker): **Fisher.Tests 1460, AspNetCore.Tests 36, EntityFrameworkCore.Tests 19 — 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)