### PR TITLE
gh-165: XS perf cleanups — DaemonTrace argument evaluation, one-connection high-water poll, dispose compiled commands

### DIFF
--- a/src/Fisher/Events/Daemon/FisherHighWaterDetector.cs
+++ b/src/Fisher/Events/Daemon/FisherHighWaterDetector.cs
@@ -75,8 +75,11 @@ internal sealed class FisherHighWaterDetector : IHighWaterDetector
 
     public async Task<HighWaterStatistics> Detect(CancellationToken token)
     {
-        var lastMark = await _database.ProjectionProgressFor(HighWaterShard, token).ConfigureAwait(false);
-        var highest = await _database.FetchHighestEventSequenceNumber(token).ConfigureAwait(false);
+        // One statement on one connection, not ProjectionProgressFor + FetchHighestEventSequenceNumber:
+        // this runs every poll cycle forever, and each of those opens its own pooled connection with
+        // its own per-connection PRAGMA batch.
+        var (lastMark, highest) = await _database.FetchHighWaterInputsAsync(HighWaterShard, token)
+            .ConfigureAwait(false);
 
         var now = _timeProvider.GetUtcNow();
 

--- a/src/Fisher/Events/Daemon/FisherProjectionBatch.cs
+++ b/src/Fisher/Events/Daemon/FisherProjectionBatch.cs
@@ -258,7 +258,9 @@ internal sealed class FisherProjectionBatch : IProjectionBatch<IDocumentSession,
             var builder = new Weasel.Sqlite.CommandBuilder();
             operation.ConfigureCommand(builder, context);
 
-            var command = builder.Compile();
+            // Disposed like every other compiled command — an undisposed SqliteCommand keeps its
+            // native prepared statement alive until finalization.
+            await using var command = builder.Compile();
             command.Connection = connection;
             command.Transaction = transaction;
             command.CommandTimeout = _store.Options.CommandTimeout;

--- a/src/Fisher/Internal/FisherSession.cs
+++ b/src/Fisher/Internal/FisherSession.cs
@@ -1067,7 +1067,9 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
             var builder = new Weasel.Sqlite.CommandBuilder();
             operation.ConfigureCommand(builder, this);
 
-            var command = builder.Compile();
+            // Disposed per operation: Compile hands back a fresh SqliteCommand, and an undisposed one
+            // keeps its native prepared statement alive until finalization.
+            await using var command = builder.Compile();
             command.Connection = connection;
             command.Transaction = transaction;
             command.CommandTimeout = CommandTimeout;

--- a/src/Fisher/Projections/FisherProjectionStorage.cs
+++ b/src/Fisher/Projections/FisherProjectionStorage.cs
@@ -107,9 +107,15 @@ internal class FisherProjectionStorage<TDoc, TId> : IProjectionStorage<TDoc, TId
         var documents = await _storage.LoadManyAsync(identities, _session, cancellationToken)
             .ConfigureAwait(false);
 
-        Fisher.Diagnostics.DaemonTrace.Record("slice.loadmany",
-            $"{typeof(TDoc).Name} asked=[{string.Join(",", identities)}] got={documents.Count}",
-            identities.Length, documents.Count);
+        // Guarded here as well as inside Record: the interpolated detail and its string.Join are
+        // evaluated at the call site, so without the guard this allocates on every load-many with
+        // tracing off — the exact cost DaemonTrace's recording path promises not to have.
+        if (Fisher.Diagnostics.DaemonTrace.Enabled)
+        {
+            Fisher.Diagnostics.DaemonTrace.Record("slice.loadmany",
+                $"{typeof(TDoc).Name} asked=[{string.Join(",", identities)}] got={documents.Count}",
+                identities.Length, documents.Count);
+        }
 
         return documents.ToDictionary(x => (TId)_storage.IdentityFor(x));
     }

--- a/src/Fisher/Storage/FisherDatabase.EventDatabase.cs
+++ b/src/Fisher/Storage/FisherDatabase.EventDatabase.cs
@@ -88,6 +88,39 @@ public partial class FisherDatabase : IEventDatabase
     }
 
     /// <summary>
+    ///     The high-water poll's two inputs — the mark's recorded position and the highest sequence
+    ///     physically present — in one statement on one connection.
+    /// </summary>
+    /// <remarks>
+    ///     The high-water agent asks both questions on every poll cycle, forever. Reading them through
+    ///     <see cref="ProjectionProgressFor" /> and <see cref="FetchHighestEventSequenceNumber" />
+    ///     costs two pooled connections per tick, each paying the per-connection PRAGMA batch
+    ///     <c>SqliteDataSource</c> applies — pure overhead for a loop that idles at
+    ///     <c>SlowPollingTime</c>. Those two methods stay for their other callers; this read exists for
+    ///     the poll loop. The subselects preserve their semantics exactly: a missing progression row
+    ///     reads as zero, and an empty events table reads as zero.
+    /// </remarks>
+    internal async Task<(long LastMark, long HighestSequence)> FetchHighWaterInputsAsync(ShardName name,
+        CancellationToken token)
+    {
+        return await _options.ResiliencePipeline.ExecuteAsync(async ct =>
+        {
+            await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"""
+                                   select coalesce((select last_seq_id from {_events.ProgressionTableName} where name = @name), 0),
+                                          (select coalesce(max(seq_id), 0) from {_events.EventsTableName})
+                                   """;
+            command.Parameters.AddWithValue("@name", name.Identity);
+
+            await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            await reader.ReadAsync(ct).ConfigureAwait(false);
+
+            return (reader.GetInt64(0), reader.GetInt64(1));
+        }, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
     ///     The high-water row, with the time its poll loop last stamped it — or null when the daemon has
     ///     never run against this database.
     /// </summary>


### PR DESCRIPTION
Closes #165. Stoat plan node: `critter-performance-2026-09` / `fisher-small-cleanups`. Three XS items:

## 1. DaemonTrace argument evaluation

`FisherProjectionStorage.LoadManyAsync` passed `$"{typeof(TDoc).Name} asked=[{string.Join(",", identities)}] got={documents.Count}"` to `DaemonTrace.Record` — evaluated at the call site before `Record`'s own `Enabled` check, so every daemon load-many allocated a `string.Join` plus interpolation with tracing off, breaking `DaemonTrace`'s documented "no allocation on the recording path" promise. Now guarded with `if (DaemonTrace.Enabled)`. Swept the other five `Record` call sites (`DocumentStore.Daemon`, `FisherEventLoader`, `FisherProjectionBatch` x2): they pass strings already in hand and integer widenings only — no other site allocates, so no other guard added.

## 2. High-water poll: one connection, one statement

`FisherHighWaterDetector.Detect` called `ProjectionProgressFor` + `FetchHighestEventSequenceNumber`, each opening its own pooled connection per poll tick, forever — each paying the per-connection PRAGMA batch. New `FisherDatabase.FetchHighWaterInputsAsync` reads both in one statement on one connection (`coalesce` subselects preserve missing-row-reads-as-zero and empty-table-reads-as-zero exactly); the two existing methods remain for their other callers.

## 3. Dispose compiled commands on the write paths

`FisherSession.ExecuteBatchAsync` (the save path, per operation) and `FisherProjectionBatch.ExecuteProgressAsync` compiled a `SqliteCommand` and never disposed it, leaking each native prepared statement until finalization. Both now `await using` the command, matching every other `builder.Compile()` site on the session paths. Checked open PRs first (#146, #157–#162): none touches these methods.

## Tests

- `--filter-class "*high_water*"`: 7/7 passed
- `--filter-class "*daemon*"`: 50/50 passed; `--filter-class "*appending*"`: 10/10 passed
- Full solution (net10.0, SQLite, no docker): **Fisher.Tests 1453, AspNetCore.Tests 36, EntityFrameworkCore.Tests 19 — 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)