### PR TITLE
Fisher.Benchmarks: perf harness + baseline numbers (gh-163)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,6 +45,9 @@
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.14" />
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.14" />
 
+        <!-- Benchmarking (Fisher.Benchmarks only) -->
+        <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+
         <!-- Testing -->
         <PackageVersion Include="NSubstitute" Version="5.3.0" />
         <PackageVersion Include="Shouldly" Version="4.3.0" />

--- a/fisher.slnx
+++ b/fisher.slnx
@@ -8,6 +8,7 @@
   <Folder Name="/src/">
     <Project Path="src/Fisher/Fisher.csproj" />
     <Project Path="src/Fisher.AspNetCore/Fisher.AspNetCore.csproj" />
+    <Project Path="src/Fisher.Benchmarks/Fisher.Benchmarks.csproj" />
     <Project Path="src/Fisher.AspNetCore.Tests/Fisher.AspNetCore.Tests.csproj" />
     <Project Path="src/Fisher.EntityFrameworkCore/Fisher.EntityFrameworkCore.csproj" />
     <Project Path="src/Fisher.EntityFrameworkCore.Tests/Fisher.EntityFrameworkCore.Tests.csproj" />

--- a/src/Fisher.Benchmarks/.gitignore
+++ b/src/Fisher.Benchmarks/.gitignore
@@ -1,0 +1,1 @@
+BenchmarkDotNet.Artifacts/

--- a/src/Fisher.Benchmarks/BenchmarkModels.cs
+++ b/src/Fisher.Benchmarks/BenchmarkModels.cs
@@ -1,0 +1,123 @@
+// The document, event and aggregate types every scenario shares. Deliberately small and boring:
+// the harness measures Fisher's write/append/projection machinery, not serialization of a large
+// document graph.
+
+namespace Fisher.Benchmarks;
+
+/// <summary>The document type the save and concurrency scenarios write.</summary>
+public sealed class BenchDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Number { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+}
+
+public sealed record BenchCheckIn(int Value);
+
+public sealed record BenchCheckOut(int Value);
+
+/// <summary>
+///     A self-aggregating snapshot for the daemon rebuild scenario, the same shape as the test
+///     suite's <c>AsyncQuestTally</c>. Dispatch is source-generated (see the csproj's analyzer
+///     reference); there is no runtime fallback.
+/// </summary>
+public sealed class BenchTally
+{
+    public Guid Id { get; set; }
+    public int CheckIns { get; set; }
+    public int CheckOuts { get; set; }
+    public int Balance { get; set; }
+
+    public void Apply(BenchCheckIn e)
+    {
+        CheckIns++;
+        Balance += e.Value;
+    }
+
+    public void Apply(BenchCheckOut e)
+    {
+        CheckOuts++;
+        Balance -= e.Value;
+    }
+}
+
+// The cold-start scenario needs T *distinct* CLR document types, because the first-use table
+// ensure runs once per type. 32 concrete classes rather than closed generics, so each gets an
+// ordinary alias and an ordinary fi_doc_* table name.
+public sealed class ColdDoc00 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc01 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc02 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc03 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc04 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc05 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc06 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc07 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc08 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc09 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc10 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc11 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc12 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc13 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc14 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc15 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc16 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc17 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc18 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc19 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc20 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc21 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc22 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc23 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc24 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc25 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc26 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc27 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc28 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc29 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc30 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+public sealed class ColdDoc31 { public Guid Id { get; set; } public string Name { get; set; } = string.Empty; }
+
+public static class ColdDocs
+{
+    /// <summary>
+    ///     One statically-typed writer per cold-start type, in a fixed order, so the scenario can
+    ///     store "one document of each of the first T types" without reflection over the generic
+    ///     <c>Store&lt;T&gt;</c>.
+    /// </summary>
+    public static readonly Action<IDocumentSession>[] Writers =
+    [
+        s => s.Store(new ColdDoc00 { Name = "cold-00" }),
+        s => s.Store(new ColdDoc01 { Name = "cold-01" }),
+        s => s.Store(new ColdDoc02 { Name = "cold-02" }),
+        s => s.Store(new ColdDoc03 { Name = "cold-03" }),
+        s => s.Store(new ColdDoc04 { Name = "cold-04" }),
+        s => s.Store(new ColdDoc05 { Name = "cold-05" }),
+        s => s.Store(new ColdDoc06 { Name = "cold-06" }),
+        s => s.Store(new ColdDoc07 { Name = "cold-07" }),
+        s => s.Store(new ColdDoc08 { Name = "cold-08" }),
+        s => s.Store(new ColdDoc09 { Name = "cold-09" }),
+        s => s.Store(new ColdDoc10 { Name = "cold-10" }),
+        s => s.Store(new ColdDoc11 { Name = "cold-11" }),
+        s => s.Store(new ColdDoc12 { Name = "cold-12" }),
+        s => s.Store(new ColdDoc13 { Name = "cold-13" }),
+        s => s.Store(new ColdDoc14 { Name = "cold-14" }),
+        s => s.Store(new ColdDoc15 { Name = "cold-15" }),
+        s => s.Store(new ColdDoc16 { Name = "cold-16" }),
+        s => s.Store(new ColdDoc17 { Name = "cold-17" }),
+        s => s.Store(new ColdDoc18 { Name = "cold-18" }),
+        s => s.Store(new ColdDoc19 { Name = "cold-19" }),
+        s => s.Store(new ColdDoc20 { Name = "cold-20" }),
+        s => s.Store(new ColdDoc21 { Name = "cold-21" }),
+        s => s.Store(new ColdDoc22 { Name = "cold-22" }),
+        s => s.Store(new ColdDoc23 { Name = "cold-23" }),
+        s => s.Store(new ColdDoc24 { Name = "cold-24" }),
+        s => s.Store(new ColdDoc25 { Name = "cold-25" }),
+        s => s.Store(new ColdDoc26 { Name = "cold-26" }),
+        s => s.Store(new ColdDoc27 { Name = "cold-27" }),
+        s => s.Store(new ColdDoc28 { Name = "cold-28" }),
+        s => s.Store(new ColdDoc29 { Name = "cold-29" }),
+        s => s.Store(new ColdDoc30 { Name = "cold-30" }),
+        s => s.Store(new ColdDoc31 { Name = "cold-31" })
+    ];
+}

--- a/src/Fisher.Benchmarks/Fisher.Benchmarks.csproj
+++ b/src/Fisher.Benchmarks/Fisher.Benchmarks.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <!-- Single-targeted, overriding the repo-wide net9.0;net10.0 pair: a perf harness is run,
+             not shipped, and one TFM keeps `dotnet run` unambiguous. -->
+        <TargetFrameworks></TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <!-- BenchmarkDotNet insists on optimized code, and the timed harness is meaningless
+             without it either. -->
+        <Optimize Condition="'$(Configuration)' == 'Release'">true</Optimize>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" />
+        <!-- Conventional Apply/Create dispatch on BenchTally is compile-time only; the generator
+             must run in the assembly that defines the aggregate, exactly as Fisher.Tests does. -->
+        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Fisher\Fisher.csproj" />
+        <!-- For TemporaryDatabase: the same throwaway-file-per-run isolation the tests use. -->
+        <ProjectReference Include="..\Fisher.TestUtils\Fisher.TestUtils.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Fisher.Benchmarks/MicroBenchmarks.cs
+++ b/src/Fisher.Benchmarks/MicroBenchmarks.cs
@@ -1,0 +1,142 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using Fisher.TestUtils;
+
+namespace Fisher.Benchmarks;
+
+/// <summary>
+///     The allocation-shaped half of the harness: BenchmarkDotNet with <c>MemoryDiagnoser</c> over a
+///     single unit of work, where per-operation allocations and tight per-commit timing matter and a
+///     wall-clock loop would hide them.
+/// </summary>
+/// <remarks>
+///     The checked-in default is a short in-process run so <c>dotnet run -c Release -- bdn</c>
+///     finishes in minutes; pass BenchmarkDotNet's own arguments after <c>bdn</c> (for example
+///     <c>--job medium</c>) for a publishable run — see the README.
+/// </remarks>
+public class MicroBenchmarkConfig : ManualConfig
+{
+    public MicroBenchmarkConfig()
+    {
+        AddJob(Job.ShortRun.WithToolchain(InProcessEmitToolchain.Instance));
+        AddDiagnoser(BenchmarkDotNet.Diagnosers.MemoryDiagnoser.Default);
+    }
+}
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class DocSaveBenchmarks
+{
+    private TemporaryDatabase _database = null!;
+    private DocumentStore _store = null!;
+    private BenchDoc[] _docs = null!;
+
+    [Params(100, 1000)]
+    public int Documents { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _database = TemporaryDatabase.Create("bdn-doc-save");
+        _store = Scenarios.Harness.BuildStore(_database);
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Fixed ids: every invocation upserts the same N rows, so the table does not grow across
+        // iterations and the first-use table ensure is paid here rather than in the measurement.
+        _docs = new BenchDoc[Documents];
+        for (var i = 0; i < Documents; i++)
+        {
+            _docs[i] = new BenchDoc
+            {
+                Id = Guid.NewGuid(),
+                Name = $"doc-{i}",
+                Number = i,
+                Timestamp = DateTimeOffset.UtcNow
+            };
+        }
+
+        await using var warm = _store.LightweightSession();
+        warm.Store(_docs[0]);
+        await warm.SaveChangesAsync();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    /// <summary>N documents through one SaveChangesAsync — wall clock and allocations per commit.</summary>
+    [Benchmark]
+    public async Task SaveDocuments()
+    {
+        await using var session = _store.LightweightSession();
+        session.Store(_docs);
+        await session.SaveChangesAsync();
+    }
+}
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class EventAppendBenchmarks
+{
+    private TemporaryDatabase _database = null!;
+    private DocumentStore _store = null!;
+    private Guid _streamId;
+
+    [Params(1, 10)]
+    public int EventsPerCommit { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _database = TemporaryDatabase.Create("bdn-append");
+        _store = Scenarios.Harness.BuildStore(_database);
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        _streamId = Guid.NewGuid();
+        await using var seed = _store.LightweightSession();
+        seed.Events.StartStream<BenchTally>(_streamId, new BenchCheckIn(0));
+        await seed.SaveChangesAsync();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    /// <summary>Append E events to an existing stream in one commit.</summary>
+    [Benchmark]
+    public async Task AppendToExistingStream()
+    {
+        await using var session = _store.LightweightSession();
+
+        var events = new object[EventsPerCommit];
+        for (var i = 0; i < EventsPerCommit; i++)
+        {
+            events[i] = i % 2 == 0 ? new BenchCheckIn(i) : new BenchCheckOut(i);
+        }
+
+        session.Events.Append(_streamId, events);
+        await session.SaveChangesAsync();
+    }
+
+    /// <summary>Start a brand-new stream with E events in one commit.</summary>
+    [Benchmark]
+    public async Task StartNewStream()
+    {
+        await using var session = _store.LightweightSession();
+
+        var events = new object[EventsPerCommit];
+        for (var i = 0; i < EventsPerCommit; i++)
+        {
+            events[i] = i % 2 == 0 ? new BenchCheckIn(i) : new BenchCheckOut(i);
+        }
+
+        session.Events.StartStream<BenchTally>(Guid.NewGuid(), events);
+        await session.SaveChangesAsync();
+    }
+}

--- a/src/Fisher.Benchmarks/Program.cs
+++ b/src/Fisher.Benchmarks/Program.cs
@@ -1,0 +1,177 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Running;
+using Fisher.Benchmarks;
+using Fisher.Benchmarks.Scenarios;
+
+// Fisher.Benchmarks — the perf harness described in the repo README under src/Fisher.Benchmarks.
+//
+// Timed scenarios (the EventAppenderPerfTester shape) for long-running/contended work:
+//   doc-save | event-append | daemon-rebuild | concurrent-writers | cold-start | all
+// BenchmarkDotNet (MemoryDiagnoser) for the allocation-shaped micro-benchmarks:
+//   bdn [BenchmarkDotNet args...]
+//
+// Run `dotnet run -c Release --project src/Fisher.Benchmarks -- help` for the options.
+
+var arguments = new Queue<string>(args);
+var command = arguments.Count > 0 ? arguments.Dequeue() : "help";
+
+var options = ParseOptions(arguments);
+
+switch (command)
+{
+    case "doc-save":
+    {
+        PrintEnvironment();
+        var report = await DocSaveScenario.RunAsync(
+            options.GetValueOrDefault("docs", 1000),
+            options.GetValueOrDefault("rounds", 5));
+        report.Print();
+        break;
+    }
+
+    case "event-append":
+    {
+        PrintEnvironment();
+        var many = await EventAppendScenario.RunManyStreamsAsync(
+            options.GetValueOrDefault("streams", 1000),
+            options.GetValueOrDefault("events-per-stream", 3));
+        many.Print();
+
+        var single = await EventAppendScenario.RunSingleStreamAsync(
+            options.GetValueOrDefault("events", 1000),
+            options.GetValueOrDefault("events-per-commit", 10));
+        single.Print();
+        break;
+    }
+
+    case "daemon-rebuild":
+    {
+        PrintEnvironment();
+        var report = await DaemonRebuildScenario.RunAsync(options.GetValueOrDefault("events", 10_000));
+        report.Print();
+        break;
+    }
+
+    case "concurrent-writers":
+    {
+        PrintEnvironment();
+        var report = await ConcurrentWritersScenario.RunAsync(
+            options.GetValueOrDefault("writers", 8),
+            options.GetValueOrDefault("commits", 50),
+            options.GetValueOrDefault("docs-per-commit", 5));
+        report.Print();
+
+        // The single-writer contrast: the same total work with no contention, so the delta is what
+        // the file's one write lock costs.
+        var solo = await ConcurrentWritersScenario.RunAsync(
+            1,
+            options.GetValueOrDefault("writers", 8) * options.GetValueOrDefault("commits", 50),
+            options.GetValueOrDefault("docs-per-commit", 5));
+        solo.Print();
+        break;
+    }
+
+    case "cold-start":
+    {
+        PrintEnvironment();
+        var report = await ColdStartScenario.RunAsync(
+            options.GetValueOrDefault("types", 20),
+            options.GetValueOrDefault("rounds", 5));
+        report.Print();
+        break;
+    }
+
+    case "all":
+    {
+        PrintEnvironment();
+        var reports = new List<ScenarioReport>
+        {
+            await DocSaveScenario.RunAsync(100, options.GetValueOrDefault("rounds", 5)),
+            await DocSaveScenario.RunAsync(1000, options.GetValueOrDefault("rounds", 5)),
+            await EventAppendScenario.RunManyStreamsAsync(1000, 3),
+            await EventAppendScenario.RunSingleStreamAsync(1000, 10),
+            await DaemonRebuildScenario.RunAsync(10_000),
+            await ConcurrentWritersScenario.RunAsync(8, 50, 5),
+            await ConcurrentWritersScenario.RunAsync(1, 400, 5),
+            await ColdStartScenario.RunAsync(20, options.GetValueOrDefault("rounds", 5))
+        };
+
+        foreach (var report in reports)
+        {
+            report.Print();
+        }
+
+        break;
+    }
+
+    case "bdn":
+        // Everything after `bdn` is handed to BenchmarkDotNet unaltered, so its own filters and
+        // job overrides work: `-- bdn --filter *DocSave*`, `-- bdn --job medium`.
+        BenchmarkSwitcher
+            .FromTypes([typeof(DocSaveBenchmarks), typeof(EventAppendBenchmarks)])
+            .Run(args.Skip(1).ToArray());
+        break;
+
+    default:
+        Console.WriteLine("""
+            Fisher.Benchmarks — perf harness for the Fisher SQLite store.
+
+            Usage: dotnet run -c Release --project src/Fisher.Benchmarks -- <command> [--option value ...]
+
+            Timed scenarios:
+              doc-save            [--docs 1000] [--rounds 5]
+              event-append        [--streams 1000] [--events-per-stream 3]
+                                  [--events 1000] [--events-per-commit 10]
+              daemon-rebuild      [--events 10000]
+              concurrent-writers  [--writers 8] [--commits 50] [--docs-per-commit 5]
+              cold-start          [--types 20] [--rounds 5]
+              all                 every scenario at its checked-in defaults
+
+            Micro-benchmarks (BenchmarkDotNet + MemoryDiagnoser):
+              bdn [BenchmarkDotNet args...]     e.g. bdn --filter *DocSave*
+
+            See src/Fisher.Benchmarks/README.md and Results.md.
+            """);
+        break;
+}
+
+return;
+
+static Dictionary<string, int> ParseOptions(Queue<string> arguments)
+{
+    var options = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+    while (arguments.Count > 0)
+    {
+        var flag = arguments.Dequeue();
+        if (!flag.StartsWith("--", StringComparison.Ordinal) || arguments.Count == 0)
+        {
+            continue;
+        }
+
+        if (int.TryParse(arguments.Dequeue(), out var value))
+        {
+            options[flag[2..]] = value;
+        }
+    }
+
+    return options;
+}
+
+static void PrintEnvironment()
+{
+    Console.WriteLine($"Fisher.Benchmarks — {DateTimeOffset.Now:yyyy-MM-dd HH:mm zzz}");
+    Console.WriteLine($"  OS:        {RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})");
+    Console.WriteLine($"  .NET:      {RuntimeInformation.FrameworkDescription}");
+    Console.WriteLine($"  CPUs:      {Environment.ProcessorCount}");
+    Console.WriteLine($"  Config:    {(IsRelease() ? "Release" : "DEBUG — numbers are not comparable")}");
+}
+
+static bool IsRelease()
+{
+#if DEBUG
+    return false;
+#else
+    return true;
+#endif
+}

--- a/src/Fisher.Benchmarks/README.md
+++ b/src/Fisher.Benchmarks/README.md
@@ -1,0 +1,81 @@
+# Fisher.Benchmarks
+
+A performance harness for Fisher, modeled on Marten's `EventAppenderPerfTester`. It exists to put
+wall-clock-under-contention numbers — not just allocation counts — behind the perf work on the
+write path (write batching inside the exclusive lock) and the first-use table-ensure migrations,
+so a before/after for those changes is one command away.
+
+Everything runs against throwaway SQLite files under the system temp directory
+(`TemporaryDatabase`, the same isolation the tests use). No servers, no docker.
+
+## Two kinds of measurement, on purpose
+
+The harness is deliberately mixed, because the scenarios split into two shapes:
+
+- **BenchmarkDotNet + `MemoryDiagnoser`** for the allocation-shaped work: one commit of N
+  documents, one append of E events. These are micro-benchmarks where per-operation allocations
+  and tight per-commit latency are the signal, and BDN's statistics are worth their setup cost.
+- **A plain timed console harness** (the `EventAppenderPerfTester` shape) for the long-running and
+  contended scenarios: daemon rebuilds, K parallel writers fighting over the file's one write
+  lock, cold-start migrations. BDN is the wrong tool there — the interesting number is one long
+  wall-clock stretch plus side telemetry (retry counts), not a distribution of nanosecond means.
+
+## Running
+
+Always `-c Release`; the harness prints a warning banner when built Debug.
+
+```bash
+# Every timed scenario at its checked-in (short) defaults, with a machine header
+dotnet run -c Release --project src/Fisher.Benchmarks -- all
+
+# Individual scenarios, with their knobs
+dotnet run -c Release --project src/Fisher.Benchmarks -- doc-save           --docs 1000 --rounds 5
+dotnet run -c Release --project src/Fisher.Benchmarks -- event-append       --streams 1000 --events-per-stream 3 --events 1000 --events-per-commit 10
+dotnet run -c Release --project src/Fisher.Benchmarks -- daemon-rebuild     --events 10000
+dotnet run -c Release --project src/Fisher.Benchmarks -- concurrent-writers --writers 8 --commits 50 --docs-per-commit 5
+dotnet run -c Release --project src/Fisher.Benchmarks -- cold-start         --types 20 --rounds 5
+
+# The BenchmarkDotNet micro-benchmarks (MemoryDiagnoser)
+dotnet run -c Release --project src/Fisher.Benchmarks -- bdn
+```
+
+The checked-in defaults are sized to finish in a few minutes so the harness stays cheap to run on
+every change. For a publishable number, scale up:
+
+- Timed scenarios: raise the knobs (`--events 100000`, `--commits 500`, `--rounds 11`, …) —
+  the defaults are floors, not recommendations.
+- Micro-benchmarks: the default BDN job is `ShortRun` on an in-process toolchain. Everything after
+  `bdn` is passed to BenchmarkDotNet unaltered, so `-- bdn --job medium` or `-- bdn --filter
+  '*DocSave*'` work as usual; use `--job medium` (or longer) for numbers you intend to publish.
+
+## The scenarios and what each one is for
+
+1. **`doc-save`** — N documents (100/1000) queued into one `SaveChangesAsync`. This is the harness
+   for the write-batching work: today every queued operation compiles and executes as its own
+   command and round trip inside the one `BEGIN IMMEDIATE` transaction, so per-commit time should
+   scale almost linearly with N until batching lands. The BDN `DocSaveBenchmarks` twin adds
+   allocations per commit.
+2. **`event-append`** — the two append shapes: many streams with a few events each (per-stream
+   version bookkeeping dominates) and one stream with many events in batched commits (the version
+   chain and trailing sequence read-back dominate). BDN twin: `EventAppendBenchmarks`.
+3. **`daemon-rebuild`** — M events (default 10k) through an async `Snapshot<BenchTally>`; measures
+   the initial catch-up from a standing start and a full `RebuildProjectionAsync` separately.
+4. **`concurrent-writers`** — K parallel writers against one database file, the discriminating
+   scenario for the write-lock and PRAGMA findings. Reports wall clock plus Fisher's own retry
+   telemetry: the `fisher.retry` activity events the Polly pipeline records (captured with an
+   `ActivityListener` on the `Fisher` source). It also runs the same total work single-writer, so
+   the delta is what contention costs. Two caveats printed in the source: a contended
+   `BEGIN IMMEDIATE` can wait inside the connection's 30s busy timeout and succeed with *no*
+   retry event — high wall clock with zero retries is still contention — and the retry event only
+   fires for a SQLITE_BUSY/SQLITE_LOCKED that reaches the resilience pipeline.
+5. **`cold-start`** — a fresh database file, base schema applied, then the first unit of work
+   touching T document types, which pays the first-use table-ensure migration once per type (the
+   O(types × objects) migration finding). The second, identical commit is the warm contrast, so
+   the report can isolate "table-ensure overhead" and "overhead per type".
+
+## Results
+
+`Results.md` holds the baseline numbers recorded on current `main` (machine noted there) and is
+where before/after tables for the gated perf fixes should be appended, in the same format Marten's
+`EventAppenderPerfTester/Results.md` uses: one fenced block per configuration, newest at the
+bottom, so the history of what each change bought stays readable.

--- a/src/Fisher.Benchmarks/Results.md
+++ b/src/Fisher.Benchmarks/Results.md
@@ -1,0 +1,126 @@
+# Fisher.Benchmarks results
+
+Before/after log for the perf work, in the `EventAppenderPerfTester/Results.md` style: one fenced
+block per configuration, newest at the bottom, so the history of what each change bought stays
+readable. Append a new section per change; do not rewrite old ones.
+
+All numbers are machine-dependent — record the machine header the harness prints with every run.
+
+## Template for a new entry
+
+```
+## <change being measured> (<date>, <commit>)
+
+<machine header from the harness>
+
+<paste of `-- all` output>
+
+<paste of the `-- bdn` summary table>
+
+Notes: <what changed, what moved, anything surprising>
+```
+
+---
+
+## Baseline — current `main` (2026-09-05, fa81b40)
+
+Recorded before any of the gated perf fixes (write batching inside the exclusive lock, per-type
+table-ensure migration work), as the reference those changes are measured against. Checked-in
+short defaults; treat deltas, not absolutes, as the signal.
+
+```
+Fisher.Benchmarks — 2026-09-05 17:29 -05:00
+  OS:        macOS 26.4.1 (Arm64)   (Apple Silicon, 18 logical CPUs)
+  .NET:      .NET 10.0.1
+  Config:    Release
+```
+
+Timed scenarios (`dotnet run -c Release --project src/Fisher.Benchmarks -- all`):
+
+```
+== doc-save (100 docs/commit, 5 rounds) ==
+  median commit                                              3.3 ms
+  fastest commit                                             1.7 ms
+  slowest commit                                             4.4 ms
+  docs/sec at median                                       30,344/s
+
+== doc-save (1000 docs/commit, 5 rounds) ==
+  median commit                                             23.4 ms
+  fastest commit                                            20.8 ms
+  slowest commit                                            26.6 ms
+  docs/sec at median                                       42,757/s
+
+== event-append many-streams (1000 streams x 3 events) ==
+  total                                                    280.0 ms
+  commits/sec                                               3,572/s
+  events/sec                                               10,716/s
+
+== event-append single-stream (1000 events, 10/commit) ==
+  total                                                    104.1 ms
+  commits/sec                                                 961/s
+  events/sec                                                9,608/s
+
+== daemon-rebuild (10000 events, 1000 streams, async Snapshot<BenchTally>) ==
+  seed (not daemon time)                                   837.4 ms
+  initial catch-up                                         186.5 ms
+  catch-up events/sec                                      53,631/s
+  rebuild                                                  109.9 ms
+  rebuild events/sec                                       90,960/s
+
+== concurrent-writers (8 writers x 50 commits x 5 docs) ==
+  total                                                    134.8 ms
+  commits/sec                                               2,968/s
+  docs/sec                                                 14,842/s
+  fisher.retry events                                             0
+  commits that retried                                            0
+  max retry attempt                                               0
+  failed commits                                                  0
+
+== concurrent-writers (1 writers x 400 commits x 5 docs) ==
+  total                                                     74.8 ms
+  commits/sec                                               5,350/s
+  docs/sec                                                 26,750/s
+  fisher.retry events                                             0
+  commits that retried                                            0
+  max retry attempt                                               0
+  failed commits                                                  0
+
+== cold-start (20 document types, 5 rounds) ==
+  median first commit (table ensure)                        61.0 ms
+  median second commit (warm)                                0.6 ms
+  table-ensure overhead                                     60.3 ms
+  overhead per type                                          3.0 ms
+```
+
+Micro-benchmarks (`dotnet run -c Release --project src/Fisher.Benchmarks -- bdn`, ShortRun,
+in-process — see README for the publishable-run configuration):
+
+```
+| Method        | Documents | Mean      | Error     | StdDev    | Gen0     | Gen1     | Allocated  |
+|-------------- |---------- |----------:|----------:|----------:|---------:|---------:|-----------:|
+| SaveDocuments | 100       |  1.481 ms |  1.179 ms | 0.0646 ms |  50.7813 |  11.7188 |   439.1 KB |
+| SaveDocuments | 1000      | 13.229 ms | 11.383 ms | 0.6239 ms | 515.6250 | 187.5000 | 4320.19 KB |
+
+| Method                 | EventsPerCommit | Mean      | Error     | StdDev    | Gen0    | Gen1   | Allocated |
+|----------------------- |---------------- |----------:|----------:|----------:|--------:|-------:|----------:|
+| AppendToExistingStream | 1               |  74.15 us |  35.45 us |  1.943 us |  3.2959 | 0.1221 |  27.23 KB |
+| StartNewStream         | 1               | 156.41 us | 209.58 us | 11.488 us |  3.4180 |      - |  28.13 KB |
+| AppendToExistingStream | 10              | 434.66 us |  51.07 us |  2.799 us | 33.6914 | 2.4414 | 275.55 KB |
+| StartNewStream         | 10              | 544.08 us | 561.55 us | 30.781 us | 34.1797 | 2.4414 | 279.27 KB |
+```
+
+Notes:
+
+- **doc-save**: per-commit time scales roughly linearly with N (3.3 ms @ 100 → 23.4 ms @ 1000),
+  which is the one-command-and-round-trip-per-operation shape the write-batching fix targets.
+- **concurrent-writers**: 8 writers doing the same total work as 1 writer took ~1.8x the wall
+  clock (134.8 ms vs 74.8 ms) with zero `fisher.retry` events — the contention cost shows up as
+  waiting inside `BEGIN IMMEDIATE` under the connection's busy timeout, not as pipeline retries.
+  Exactly the caveat in the scenario's remarks; both numbers matter for the write-lock work.
+- **cold-start**: ~3 ms of first-use table-ensure per document type on this machine, ~60 ms for a
+  20-type store — the per-type migration cost the table-ensure fix goes after; the warm commit of
+  the identical shape is 0.6 ms.
+- **micro-benchmarks**: allocations scale linearly with the operation count — ~4.3 KB per document
+  saved and ~27 KB per single-event append commit — consistent with the per-operation
+  command-building the batching work targets. ShortRun error bars are wide by design; use
+  `-- bdn --job medium` before quoting a delta.

--- a/src/Fisher.Benchmarks/Scenarios/ColdStartScenario.cs
+++ b/src/Fisher.Benchmarks/Scenarios/ColdStartScenario.cs
@@ -1,0 +1,63 @@
+using Fisher.TestUtils;
+
+namespace Fisher.Benchmarks.Scenarios;
+
+/// <summary>
+///     Scenario 5: cold-start warm-up — the first unit of work that touches T document types on a
+///     fresh database file, which is what pays the first-use table-ensure migration once per type
+///     (the O(types × objects) migration finding). The second, warm commit of the identical shape is
+///     the contrast that isolates the migration cost from the write cost.
+/// </summary>
+public static class ColdStartScenario
+{
+    public static async Task<ScenarioReport> RunAsync(int types, int rounds)
+    {
+        if (types < 1 || types > ColdDocs.Writers.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(types),
+                $"types must be between 1 and {ColdDocs.Writers.Length}");
+        }
+
+        var cold = new double[rounds];
+        var warm = new double[rounds];
+
+        for (var round = 0; round < rounds; round++)
+        {
+            // A fresh file and a fresh store per round: cold means cold.
+            await using var database = TemporaryDatabase.Create("bench-cold-start");
+            await using var store = Harness.BuildStore(database);
+
+            // The base (event) schema is applied up front, so the measurement below is the
+            // per-document-type on-demand ensure and nothing else.
+            await store.ApplyAllConfiguredChangesToDatabaseAsync();
+
+            cold[round] = await Harness.TimeAsync(() => SaveOneOfEachAsync(store, types));
+            warm[round] = await Harness.TimeAsync(() => SaveOneOfEachAsync(store, types));
+        }
+
+        Array.Sort(cold);
+        Array.Sort(warm);
+        var medianCold = cold[rounds / 2];
+        var medianWarm = warm[rounds / 2];
+
+        return new ScenarioReport($"cold-start ({types} document types, {rounds} rounds)",
+        [
+            new Metric("median first commit (table ensure)", Harness.Ms(medianCold)),
+            new Metric("median second commit (warm)", Harness.Ms(medianWarm)),
+            new Metric("table-ensure overhead", Harness.Ms(medianCold - medianWarm)),
+            new Metric("overhead per type", Harness.Ms((medianCold - medianWarm) / types))
+        ]);
+    }
+
+    private static async Task SaveOneOfEachAsync(DocumentStore store, int types)
+    {
+        await using var session = store.LightweightSession();
+
+        for (var i = 0; i < types; i++)
+        {
+            ColdDocs.Writers[i](session);
+        }
+
+        await session.SaveChangesAsync();
+    }
+}

--- a/src/Fisher.Benchmarks/Scenarios/ConcurrentWritersScenario.cs
+++ b/src/Fisher.Benchmarks/Scenarios/ConcurrentWritersScenario.cs
@@ -1,0 +1,96 @@
+using Fisher.TestUtils;
+
+namespace Fisher.Benchmarks.Scenarios;
+
+/// <summary>
+///     Scenario 4: K parallel writers against one database file — the discriminating scenario for
+///     the write-lock and PRAGMA findings, since SQLite takes one writer per file and every commit
+///     here contends for the same <c>BEGIN IMMEDIATE</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Retries are surfaced through Fisher's own telemetry: the <c>fisher.retry</c> activity
+///         events the Polly pipeline records on the enclosing span (see <see cref="RetryCounter" />).
+///         Two caveats when reading the numbers. First, the wait at <c>BEGIN IMMEDIATE</c> comes from
+///         the connection string's <c>Default Timeout</c> (30s), so a contended commit can simply
+///         wait and succeed with <em>no</em> retry — a low retry count with a high wall clock is
+///         still contention. Second, the retry event only fires when a command-level
+///         SQLITE_BUSY/SQLITE_LOCKED reaches the resilience pipeline.
+///     </para>
+///     <para>
+///         Baseline comparison: the same total work single-writer (K=1) versus K-way parallel says
+///         what the file's one write lock costs; the per-tenant/per-file answer to that cost is
+///         database-per-tenant, which this scenario deliberately does not use.
+///     </para>
+/// </remarks>
+public static class ConcurrentWritersScenario
+{
+    public static async Task<ScenarioReport> RunAsync(int writers, int commitsPerWriter, int docsPerCommit)
+    {
+        await using var database = TemporaryDatabase.Create("bench-concurrent");
+        await using var store = Harness.BuildStore(database);
+        await store.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Prewarm the document table so no writer pays the first-use migration mid-race.
+        await using (var warm = store.LightweightSession())
+        {
+            warm.Store(new BenchDoc { Name = "warm" });
+            await warm.SaveChangesAsync();
+        }
+
+        using var retries = new RetryCounter();
+        var failures = 0;
+
+        var elapsed = await Harness.TimeAsync(async () =>
+        {
+            var tasks = new Task[writers];
+            for (var w = 0; w < writers; w++)
+            {
+                var writer = w;
+                tasks[w] = Task.Run(async () =>
+                {
+                    for (var c = 0; c < commitsPerWriter; c++)
+                    {
+                        try
+                        {
+                            await using var session = store.LightweightSession();
+                            for (var d = 0; d < docsPerCommit; d++)
+                            {
+                                session.Store(new BenchDoc
+                                {
+                                    Name = $"w{writer}-c{c}-d{d}",
+                                    Number = c,
+                                    Timestamp = DateTimeOffset.UtcNow
+                                });
+                            }
+
+                            await session.SaveChangesAsync();
+                        }
+                        catch
+                        {
+                            // A commit that exhausted the resilience pipeline. Counted rather than
+                            // rethrown so one loss under extreme contention doesn't void the run.
+                            Interlocked.Increment(ref failures);
+                        }
+                    }
+                });
+            }
+
+            await Task.WhenAll(tasks);
+        });
+
+        var totalCommits = writers * commitsPerWriter;
+
+        return new ScenarioReport(
+            $"concurrent-writers ({writers} writers x {commitsPerWriter} commits x {docsPerCommit} docs)",
+        [
+            new Metric("total", Harness.Ms(elapsed)),
+            new Metric("commits/sec", Harness.PerSecond(totalCommits, elapsed)),
+            new Metric("docs/sec", Harness.PerSecond(totalCommits * docsPerCommit, elapsed)),
+            new Metric("fisher.retry events", retries.RetryEvents.ToString("n0")),
+            new Metric("commits that retried", retries.RetriedActivities.ToString("n0")),
+            new Metric("max retry attempt", retries.MaxAttempt.ToString("n0")),
+            new Metric("failed commits", failures.ToString("n0"))
+        ]);
+    }
+}

--- a/src/Fisher.Benchmarks/Scenarios/DaemonRebuildScenario.cs
+++ b/src/Fisher.Benchmarks/Scenarios/DaemonRebuildScenario.cs
@@ -1,0 +1,80 @@
+using Fisher.TestUtils;
+using JasperFx.Events.Projections;
+
+namespace Fisher.Benchmarks.Scenarios;
+
+/// <summary>
+///     Scenario 3: the async daemon pushing M events through a single-stream projection — first the
+///     initial catch-up from a standing start, then a full <c>RebuildProjectionAsync</c> over the
+///     same data.
+/// </summary>
+public static class DaemonRebuildScenario
+{
+    private const int EventsPerStream = 10;
+    private const int StreamsPerSeedCommit = 50;
+
+    public static async Task<ScenarioReport> RunAsync(int events)
+    {
+        await using var database = TemporaryDatabase.Create("bench-rebuild");
+        await using var store = Harness.BuildStore(database,
+            options => options.Projections.Snapshot<BenchTally>(SnapshotLifecycle.Async));
+        await store.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streams = Math.Max(1, events / EventsPerStream);
+        var seedMs = await Harness.TimeAsync(() => SeedAsync(store, streams));
+
+        var daemon = await store.BuildProjectionDaemonAsync();
+        try
+        {
+            var catchUpMs = await Harness.TimeAsync(async () =>
+            {
+                await daemon.StartAllAsync();
+                await store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromMinutes(10));
+            });
+
+            var rebuildMs = await Harness.TimeAsync(
+                () => daemon.RebuildProjectionAsync<BenchTally>(CancellationToken.None));
+
+            var totalEvents = streams * EventsPerStream;
+
+            return new ScenarioReport(
+                $"daemon-rebuild ({totalEvents} events, {streams} streams, async Snapshot<BenchTally>)",
+            [
+                new Metric("seed (not daemon time)", Harness.Ms(seedMs)),
+                new Metric("initial catch-up", Harness.Ms(catchUpMs)),
+                new Metric("catch-up events/sec", Harness.PerSecond(totalEvents, catchUpMs)),
+                new Metric("rebuild", Harness.Ms(rebuildMs)),
+                new Metric("rebuild events/sec", Harness.PerSecond(totalEvents, rebuildMs))
+            ]);
+        }
+        finally
+        {
+            await daemon.StopAllAsync();
+            daemon.Dispose();
+        }
+    }
+
+    private static async Task SeedAsync(DocumentStore store, int streams)
+    {
+        var seeded = 0;
+        while (seeded < streams)
+        {
+            await using var session = store.LightweightSession();
+
+            var batch = Math.Min(StreamsPerSeedCommit, streams - seeded);
+            for (var i = 0; i < batch; i++)
+            {
+                var events = new object[EventsPerStream];
+                for (var j = 0; j < EventsPerStream; j++)
+                {
+                    events[j] = j % 2 == 0 ? new BenchCheckIn(j) : new BenchCheckOut(j);
+                }
+
+                session.Events.StartStream<BenchTally>(Guid.NewGuid(), events);
+            }
+
+            await session.SaveChangesAsync();
+            seeded += batch;
+        }
+    }
+}

--- a/src/Fisher.Benchmarks/Scenarios/DocSaveScenario.cs
+++ b/src/Fisher.Benchmarks/Scenarios/DocSaveScenario.cs
@@ -1,0 +1,56 @@
+using Fisher.TestUtils;
+
+namespace Fisher.Benchmarks.Scenarios;
+
+/// <summary>
+///     Scenario 1: N documents queued into one <c>SaveChangesAsync</c>. The harness for the future
+///     write-batching fix — today every queued operation is compiled and executed as its own command
+///     and round trip inside the one <c>BEGIN IMMEDIATE</c> transaction.
+/// </summary>
+public static class DocSaveScenario
+{
+    public static async Task<ScenarioReport> RunAsync(int documents, int rounds)
+    {
+        await using var database = TemporaryDatabase.Create("bench-doc-save");
+        await using var store = Harness.BuildStore(database);
+        await store.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // One warm-up commit so the first measured round is not paying the first-use table ensure —
+        // that cost is the cold-start scenario's subject, not this one's.
+        await SaveBatchAsync(store, 1);
+
+        var timings = new double[rounds];
+        for (var round = 0; round < rounds; round++)
+        {
+            timings[round] = await Harness.TimeAsync(() => SaveBatchAsync(store, documents));
+        }
+
+        Array.Sort(timings);
+        var median = timings[rounds / 2];
+
+        return new ScenarioReport($"doc-save ({documents} docs/commit, {rounds} rounds)",
+        [
+            new Metric("median commit", Harness.Ms(median)),
+            new Metric("fastest commit", Harness.Ms(timings[0])),
+            new Metric("slowest commit", Harness.Ms(timings[^1])),
+            new Metric("docs/sec at median", Harness.PerSecond(documents, median))
+        ]);
+    }
+
+    private static async Task SaveBatchAsync(DocumentStore store, int documents)
+    {
+        await using var session = store.LightweightSession();
+
+        for (var i = 0; i < documents; i++)
+        {
+            session.Store(new BenchDoc
+            {
+                Name = $"doc-{i}",
+                Number = i,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+        }
+
+        await session.SaveChangesAsync();
+    }
+}

--- a/src/Fisher.Benchmarks/Scenarios/EventAppendScenario.cs
+++ b/src/Fisher.Benchmarks/Scenarios/EventAppendScenario.cs
@@ -1,0 +1,86 @@
+using Fisher.TestUtils;
+
+namespace Fisher.Benchmarks.Scenarios;
+
+/// <summary>
+///     Scenario 2: event appends in the two shapes that stress different halves of the append path —
+///     many streams with a few events each (per-stream version reads dominate), and one stream with
+///     many events appended in batches (the trailing sequence read-back and version chain dominate).
+/// </summary>
+public static class EventAppendScenario
+{
+    public static async Task<ScenarioReport> RunManyStreamsAsync(int streams, int eventsPerStream)
+    {
+        await using var database = TemporaryDatabase.Create("bench-append-many");
+        await using var store = Harness.BuildStore(database);
+        await store.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var elapsed = await Harness.TimeAsync(async () =>
+        {
+            for (var i = 0; i < streams; i++)
+            {
+                await using var session = store.LightweightSession();
+                var events = new object[eventsPerStream];
+                for (var j = 0; j < eventsPerStream; j++)
+                {
+                    events[j] = j % 2 == 0 ? new BenchCheckIn(j) : new BenchCheckOut(j);
+                }
+
+                session.Events.StartStream<BenchTally>(Guid.NewGuid(), events);
+                await session.SaveChangesAsync();
+            }
+        });
+
+        var totalEvents = streams * eventsPerStream;
+
+        return new ScenarioReport($"event-append many-streams ({streams} streams x {eventsPerStream} events)",
+        [
+            new Metric("total", Harness.Ms(elapsed)),
+            new Metric("commits/sec", Harness.PerSecond(streams, elapsed)),
+            new Metric("events/sec", Harness.PerSecond(totalEvents, elapsed))
+        ]);
+    }
+
+    public static async Task<ScenarioReport> RunSingleStreamAsync(int events, int eventsPerCommit)
+    {
+        await using var database = TemporaryDatabase.Create("bench-append-single");
+        await using var store = Harness.BuildStore(database);
+        await store.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = Guid.NewGuid();
+
+        // Start the stream outside the measurement so every measured commit is the same shape: an
+        // append to an existing stream, which is the case that reads the current version each time.
+        await using (var seed = store.LightweightSession())
+        {
+            seed.Events.StartStream<BenchTally>(streamId, new BenchCheckIn(0));
+            await seed.SaveChangesAsync();
+        }
+
+        var commits = events / eventsPerCommit;
+
+        var elapsed = await Harness.TimeAsync(async () =>
+        {
+            for (var i = 0; i < commits; i++)
+            {
+                await using var session = store.LightweightSession();
+                var batch = new object[eventsPerCommit];
+                for (var j = 0; j < eventsPerCommit; j++)
+                {
+                    batch[j] = j % 2 == 0 ? new BenchCheckIn(j) : new BenchCheckOut(j);
+                }
+
+                session.Events.Append(streamId, batch);
+                await session.SaveChangesAsync();
+            }
+        });
+
+        return new ScenarioReport(
+            $"event-append single-stream ({events} events, {eventsPerCommit}/commit)",
+        [
+            new Metric("total", Harness.Ms(elapsed)),
+            new Metric("commits/sec", Harness.PerSecond(commits, elapsed)),
+            new Metric("events/sec", Harness.PerSecond(commits * eventsPerCommit, elapsed))
+        ]);
+    }
+}

--- a/src/Fisher.Benchmarks/Scenarios/Harness.cs
+++ b/src/Fisher.Benchmarks/Scenarios/Harness.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+using Fisher.TestUtils;
+using JasperFx;
+
+namespace Fisher.Benchmarks.Scenarios;
+
+/// <summary>One measured line of a scenario's output.</summary>
+public sealed record Metric(string Name, string Value);
+
+/// <summary>What a scenario hands back to the console for the summary table.</summary>
+public sealed record ScenarioReport(string Scenario, IReadOnlyList<Metric> Metrics)
+{
+    public void Print()
+    {
+        Console.WriteLine();
+        Console.WriteLine($"== {Scenario} ==");
+        foreach (var metric in Metrics)
+        {
+            Console.WriteLine($"  {metric.Name,-46} {metric.Value,18}");
+        }
+    }
+}
+
+/// <summary>
+///     Shared plumbing for the timed scenarios: a throwaway database file, a store built the way the
+///     tests build one, and stopwatch helpers.
+/// </summary>
+public static class Harness
+{
+    public static DocumentStore BuildStore(TemporaryDatabase database, Action<StoreOptions>? configure = null)
+        => DocumentStore.For(options =>
+        {
+            options.ConnectionString = database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            configure?.Invoke(options);
+        });
+
+    public static async Task<double> TimeAsync(Func<Task> work)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        await work().ConfigureAwait(false);
+        stopwatch.Stop();
+        return stopwatch.Elapsed.TotalMilliseconds;
+    }
+
+    public static string Ms(double milliseconds) => $"{milliseconds:n1} ms";
+
+    public static string PerSecond(double count, double milliseconds)
+        => milliseconds <= 0 ? "n/a" : $"{count / (milliseconds / 1000d):n0}/s";
+}

--- a/src/Fisher.Benchmarks/Scenarios/RetryCounter.cs
+++ b/src/Fisher.Benchmarks/Scenarios/RetryCounter.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics;
+
+namespace Fisher.Benchmarks.Scenarios;
+
+/// <summary>
+///     Counts Fisher's <c>fisher.retry</c> activity events — the telemetry the resilience pipeline
+///     records when a call waited on the write lock (SQLITE_BUSY / SQLITE_LOCKED) and was retried.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>FisherTracing.RecordRetry</c> only records when <c>Activity.Current</c> exists and has
+///         <c>IsAllDataRequested</c>, so this listener must sample <c>AllDataAndRecorded</c> for the
+///         <c>Fisher</c> source — merely being subscribed is not enough.
+///     </para>
+///     <para>
+///         An <see cref="ActivityListener" /> is process-wide; this one filters to the Fisher source
+///         and is disposed with the scenario, which is fine for a single-purpose console process
+///         (the same reason the tracing tests filter by tag).
+///     </para>
+/// </remarks>
+public sealed class RetryCounter : IDisposable
+{
+    private readonly ActivityListener _listener;
+    private long _retryEvents;
+    private long _retriedActivities;
+    private int _maxAttempt;
+
+    public RetryCounter()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Fisher",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _)
+                => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = OnStopped
+        };
+
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    /// <summary>Total <c>fisher.retry</c> events seen — one per retried attempt.</summary>
+    public long RetryEvents => Interlocked.Read(ref _retryEvents);
+
+    /// <summary>How many spans (commits, batches, …) recorded at least one retry.</summary>
+    public long RetriedActivities => Interlocked.Read(ref _retriedActivities);
+
+    /// <summary>The highest <c>fisher.retry.attempt</c> observed.</summary>
+    public int MaxAttempt => _maxAttempt;
+
+    private void OnStopped(Activity activity)
+    {
+        var sawRetry = false;
+
+        foreach (var activityEvent in activity.Events)
+        {
+            if (activityEvent.Name != "fisher.retry")
+            {
+                continue;
+            }
+
+            sawRetry = true;
+            Interlocked.Increment(ref _retryEvents);
+
+            foreach (var tag in activityEvent.Tags)
+            {
+                if (tag is { Key: "fisher.retry.attempt", Value: int attempt })
+                {
+                    int seen;
+                    while (attempt > (seen = _maxAttempt)
+                           && Interlocked.CompareExchange(ref _maxAttempt, attempt, seen) != seen)
+                    {
+                    }
+                }
+            }
+        }
+
+        if (sawRetry)
+        {
+            Interlocked.Increment(ref _retriedActivities);
+        }
+    }
+
+    public void Dispose() => _listener.Dispose();
+}


### PR DESCRIPTION
Closes #163. Stoat plan `critter-performance-2026-09`, node `fisher-benchmarks` — the prerequisite for the gated write-batching and table-ensure-migration fix nodes, which will be measured against the baseline recorded here.

## What this adds

`src/Fisher.Benchmarks`, a mixed-mode perf harness modeled on Marten's `EventAppenderPerfTester`:

**Timed console scenarios** (`dotnet run -c Release --project src/Fisher.Benchmarks -- all`):

1. `doc-save` — 100/1000 documents through one `SaveChangesAsync` (the write-batching harness: one command + round trip per operation inside `BEGIN IMMEDIATE` today)
2. `event-append` — many streams × few events, and one stream × many events in batched commits
3. `daemon-rebuild` — 10k events through an async `Snapshot<BenchTally>`, initial catch-up and full `RebuildProjectionAsync` timed separately
4. `concurrent-writers` — K parallel writers against one file, wall clock plus Fisher's `fisher.retry` activity events (captured via an `ActivityListener` on the `Fisher` source), with the single-writer contrast for the same total work
5. `cold-start` — first-use table ensure across T document types vs the warm commit of the same shape

**BenchmarkDotNet + MemoryDiagnoser** for the allocation-shaped micro-benchmarks (`-- bdn`): `SaveDocuments` at 100/1000 docs, `AppendToExistingStream`/`StartNewStream` at 1/10 events. ShortRun in-process by default; BDN args pass through for publishable runs. The README explains why the harness is mixed.

Throwaway SQLite files via `TemporaryDatabase`; no docker, no servers. Checked-in defaults finish in a few minutes.

## Baseline (recorded in Results.md)

macOS 26.4.1 arm64, .NET 10.0.1, Release. Highlights:

- doc-save: 3.3 ms @ 100 docs, 23.4 ms @ 1000 docs per commit (near-linear in N — the batching target); ~4.3 KB allocated/doc
- event-append: 3,572 commits/s many-streams; 9,608 events/s single-stream @ 10/commit
- daemon-rebuild 10k events: catch-up 186 ms (~54k events/s), rebuild 110 ms (~91k events/s)
- concurrent-writers: 8 writers took ~1.8x the wall clock of 1 writer for the same work, with **zero** `fisher.retry` events — the contention cost is waiting inside `BEGIN IMMEDIATE` under the busy timeout, not pipeline retries (noted in the scenario docs; both numbers matter for the write-lock findings)
- cold-start: ~3 ms table-ensure per document type (~60 ms for 20 types); warm commit 0.6 ms

Do not merge until the plan's review gate clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)