### PR TITLE
gh-166: child-collection LINQ support over json_each

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1515 tests green on net9.0 and net10.0**, with no known intermittent failures — 1460 in
+**1555 tests green on net9.0 and net10.0**, with no known intermittent failures — 1500 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 391 of
 them are shared cross-store compliance tests — 322 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 40 suites and 391 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,460.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,500.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/documents/querying/linq/operators.md
+++ b/docs/documents/querying/linq/operators.md
@@ -27,15 +27,61 @@
 
 ## Collections
 
+A member that is a collection — a `List<T>`, an array, anything `IEnumerable<T>`-shaped except
+strings, byte arrays and dictionaries — is stored as a JSON array and queried through a correlated
+sub-query over SQLite's `json_each` table-valued function:
+
 ```cs
+// scalar elements — string, number, Guid, enum
 .Where(x => x.Tags.Contains("urgent"))
+// exists (select 1 from json_each(data, '$.tags') as each_1
+//         where each_1.key is not null and each_1.value = @p0)
+
+.Where(x => x.Tags.Any())                       // holds anything at all
+.Where(x => x.Tags.Count() > 2)                 // also .Count property and array .Length
+.Where(x => x.Stops.Count(s => s.Days < 5) == 2)
+
+// child objects — member predicates on the element
+.Where(x => x.Stops.Any(s => s.Port == "Oslo"))
+.Where(x => x.Stops.Any(s => s.Days > 5 && s.Resupplied))
+.Where(x => x.Stops.Any(s => s.Cargo.Contains("fuel")))   // nests, with a fresh alias per depth
+.Where(x => x.Stops.All(s => s.Days < 5))
+
+// membership the other way round — a value set, not a collection member
 .Where(x => names.Contains(x.Name))          // in (…)
 .Where(x => x.Name.IsOneOf("a", "b", "c"))   // the same, from the other direction
 .Where(x => x.Name.In(allowed))
+
 .Where(x => x.Tags.IsEmpty())
-.Where(x => x.Tags.Any())
-.Where(x => x.Tags.Count() > 2)
 ```
+
+Element values go through the same conversion as a document member of the same type, so an enum
+element honours `EnumStorage` and the serializer's naming policy, a Guid element matches its
+lowercase canonical text, and a bool element matches the stored 1/0.
+
+**The degenerate shapes are handled honestly.** An absent member, an empty array and a member stored
+as JSON `null` all hold no elements: `Any()` is false, `Contains` matches nothing, `Count()`
+compares as zero (where in-memory LINQ over a null collection would throw), and `All(...)` is
+vacuously true, matching `Enumerable.All` over an empty sequence. The `key is not null` guard in the
+generated SQL is what keeps a null member from matching — `json_each` over JSON `null` yields one
+phantom row, and that row is the only one whose `key` is NULL.
+
+**Refused rather than mis-translated**, each with a `BadLinqExpressionException` naming the problem:
+
+- A predicate referencing anything outside the element's own scope — the outer document
+  (`x.Stops.Any(s => s.Port == x.Name)`), or an enclosing lambda's element. Compare against locals
+  or constants instead.
+- A member access on a scalar element (`x.Tags.Any(t => t.Length > 3)`) — the elements are plain
+  values with no members to extract.
+- A bare element comparison (`x.Tags.Any(t => t == "urgent")`) — use `Contains`.
+- `Contains` against another document member, and `Contains` over child-object elements — use
+  `Any(c => …)` with a predicate on the element's members.
+
+::: tip
+Predicates inside `Any`/`All`/`Count` follow **SQL null semantics**, consistently with the rest of
+the provider: an element for which the predicate is NULL (say a null `Port` compared with `!=`) has
+not satisfied it, so it fails `All` and is not counted — where C# would call `null != "Oslo"` true.
+:::
 
 ::: tip
 `IsEmpty()` has to test null **as well as** length. `json_extract` yields SQL NULL for an absent key
@@ -150,4 +196,6 @@ rather than through a slow query:
 - A second `Select`
 - After a join: keyset paging, JSON reads, and `Select` / `GroupBy` / `Distinct` / `DistinctBy`
 - Ordering or range-comparing a string-stored enum
+- Inside a collection predicate: outer-scope references, member access on scalar elements, and bare
+  element comparisons — see [Collections](#collections)
 - A soft-delete or tenancy operator against a type that has no such column

--- a/src/Fisher.Tests/Linq/child_collections.cs
+++ b/src/Fisher.Tests/Linq/child_collections.cs
@@ -1,0 +1,427 @@
+using System.Linq.Expressions;
+using Fisher.Linq;
+using Fisher.Linq.Members;
+using Fisher.Linq.Parsing;
+using JasperFx;
+using Weasel.Core;
+
+namespace Fisher.Tests.Linq;
+
+public class Expedition
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = "";
+    public List<string> Tags { get; set; } = [];
+    public int[] Depths { get; set; } = [];
+    public List<Grade> Grades { get; set; } = [];
+    public List<Guid> CrewIds { get; set; } = [];
+    public List<Stop> Stops { get; set; } = [];
+}
+
+public class Stop
+{
+    public string Port { get; set; } = "";
+    public int Days { get; set; }
+    public bool Resupplied { get; set; }
+    public List<string> Cargo { get; set; } = [];
+}
+
+/// <summary>
+///     Child-collection predicates over <c>json_each</c>: <c>Contains</c>, <c>Any</c>, <c>All</c> and
+///     <c>Count</c> comparisons, asserted both as generated SQL and by running against documents the
+///     store actually wrote.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The seeded set deliberately includes the three degenerate storage shapes: a populated
+///         collection, an empty one, and a member stored as JSON <b>null</b>. The null one is the case
+///         that silently corrupts a naive translation — <c>json_each</c> over a null member yields one
+///         phantom row where an absent key yields zero — so almost every executed assertion here is
+///         discriminating against exactly that.
+///     </para>
+///     <para>
+///         The refusal tests are as load-bearing as the happy paths. Fisher's house rule is refuse
+///         rather than silently mis-translate, and each refused shape below is one that would
+///         otherwise produce plausible SQL reading the wrong JSON.
+///     </para>
+/// </remarks>
+public class child_collections : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("children");
+    private DocumentStore _store = null!;
+    private readonly Guid _shackletonId = Guid.NewGuid();
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<Expedition>();
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using var session = _store.LightweightSession();
+        session.Store(new Expedition
+        {
+            Id = Guid.NewGuid(), Name = "Endurance",
+            Tags = ["urgent", "cold"],
+            Depths = [10, 250],
+            Grades = [Grade.HighDistinction],
+            CrewIds = [_shackletonId],
+            Stops =
+            [
+                new Stop { Port = "Oslo", Days = 3, Resupplied = true, Cargo = ["fuel"] },
+                new Stop { Port = "Reykjavik", Days = 1, Resupplied = false, Cargo = [] }
+            ]
+        });
+        session.Store(new Expedition
+        {
+            Id = Guid.NewGuid(), Name = "Beagle",
+            Tags = ["survey", null!],
+            Depths = [5],
+            Grades = [Grade.Pass],
+            Stops =
+            [
+                new Stop { Port = "Plymouth", Days = 10, Resupplied = true, Cargo = ["specimens", "fuel"] },
+                // A null Port: the element for which a string predicate is NULL rather than
+                // true or false — the three-valued-logic shape the All() tests discriminate on.
+                new Stop { Port = null!, Days = 0, Resupplied = true, Cargo = [] }
+            ]
+        });
+        session.Store(new Expedition
+        {
+            Id = Guid.NewGuid(), Name = "Fram",
+            Tags = null!,      // stored as JSON null — the phantom-row shape
+            Depths = [],       // stored as an empty array
+            Grades = [],
+            Stops = null!      // JSON null again, for the child-object operators
+        });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private string SqlFor(Expression<Func<Expedition, bool>> predicate)
+    {
+        var factory = new MemberFactory(_store.Options, _store.Options.Schema.For<Expedition>().Mapping);
+        var builder = new Weasel.Sqlite.CommandBuilder();
+        new WhereClauseParser(factory).Parse(predicate.Body).Apply(builder);
+        return builder.Compile().CommandText;
+    }
+
+    private async Task<List<string>> NamesMatchingAsync(Expression<Func<Expedition, bool>> predicate)
+    {
+        var mapping = _store.Options.Schema.For<Expedition>().Mapping;
+        var factory = new MemberFactory(_store.Options, mapping);
+
+        var builder = new Weasel.Sqlite.CommandBuilder();
+        builder.Append($"select json_extract(data, '$.name') from {mapping.QuotedTableName} where ");
+        new WhereClauseParser(factory).Parse(predicate.Body).Apply(builder);
+
+        await using var connection = await _store.Database.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        var command = builder.Compile();
+        command.Connection = connection;
+
+        var names = new List<string>();
+        await using var reader = await command.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        while (await reader.ReadAsync(TestContext.Current.CancellationToken))
+        {
+            names.Add(reader.GetString(0));
+        }
+
+        names.Sort(StringComparer.Ordinal);
+        return names;
+    }
+
+    [Fact]
+    public async Task contains_on_a_scalar_collection_is_a_correlated_exists()
+    {
+        SqlFor(x => x.Tags.Contains("urgent")).ShouldBe(
+            "exists (select 1 from json_each(data, '$.tags') as each_1 "
+            + "where each_1.key is not null and each_1.value = @p0)");
+
+        (await NamesMatchingAsync(x => x.Tags.Contains("urgent"))).ShouldBe(["Endurance"]);
+    }
+
+    /// <summary>
+    ///     An array member reaches the static <c>Enumerable.Contains</c> form rather than the
+    ///     instance one, and translates the same way.
+    /// </summary>
+    [Fact]
+    public async Task contains_on_an_int_array()
+    {
+        (await NamesMatchingAsync(x => x.Depths.Contains(250))).ShouldBe(["Endurance"]);
+        (await NamesMatchingAsync(x => x.Depths.Contains(99))).ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     Guid elements go through the element member's conversion, matching the lowercase canonical
+    ///     text System.Text.Json wrote — the same trap every other Guid comparison has to dodge.
+    /// </summary>
+    [Fact]
+    public async Task contains_converts_guid_elements_to_their_stored_text()
+    {
+        (await NamesMatchingAsync(x => x.CrewIds.Contains(_shackletonId))).ShouldBe(["Endurance"]);
+    }
+
+    /// <summary>
+    ///     Under the default <c>EnumStorage.AsInteger</c> the elements are JSON numbers.
+    /// </summary>
+    [Fact]
+    public async Task contains_on_an_enum_collection_stored_as_integers()
+    {
+        (await NamesMatchingAsync(x => x.Grades.Contains(Grade.HighDistinction))).ShouldBe(["Endurance"]);
+        (await NamesMatchingAsync(x => x.Grades.Contains(Grade.Pass))).ShouldBe(["Beagle"]);
+    }
+
+    /// <summary>
+    ///     Under <c>AsString</c> the stored element is the member's <em>name through the naming
+    ///     policy</em> — "highDistinction", not "HighDistinction" — so this test fails against any
+    ///     translation that does not route the value through <see cref="EnumMember" />'s conversion.
+    /// </summary>
+    [Fact]
+    public async Task contains_on_an_enum_collection_stored_as_strings()
+    {
+        using var database = TemporaryDatabase.Create("children_enum");
+        await using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.ConfigureSerialization(EnumStorage.AsString);
+            options.Schema.For<Expedition>();
+        });
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        await using var session = store.LightweightSession();
+        session.Store(new Expedition { Id = Guid.NewGuid(), Name = "Terror", Grades = [Grade.HighDistinction] });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var matches = await session.Query<Expedition>()
+            .Where(x => x.Grades.Contains(Grade.HighDistinction))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        matches.Select(x => x.Name).ShouldBe(["Terror"]);
+    }
+
+    /// <summary>
+    ///     A member stored as JSON null contains nothing — including null. The discriminating half is
+    ///     Beagle, whose array genuinely holds a null element and must still match, which is exactly
+    ///     what the <c>key is not null</c> guard has to let through while blocking Fram's phantom row.
+    /// </summary>
+    [Fact]
+    public async Task contains_null_matches_a_null_element_but_not_a_null_collection()
+    {
+        (await NamesMatchingAsync(x => x.Tags.Contains(null!))).ShouldBe(["Beagle"]);
+    }
+
+    [Fact]
+    public async Task bare_any_asks_whether_the_collection_holds_anything()
+    {
+        SqlFor(x => x.Tags.Any()).ShouldBe(
+            "exists (select 1 from json_each(data, '$.tags') as each_1 where each_1.key is not null)");
+
+        // Fram's null Tags and empty Depths are both "nothing there".
+        (await NamesMatchingAsync(x => x.Tags.Any())).ShouldBe(["Beagle", "Endurance"]);
+        (await NamesMatchingAsync(x => x.Depths.Any())).ShouldBe(["Beagle", "Endurance"]);
+        (await NamesMatchingAsync(x => !x.Tags.Any())).ShouldBe(["Fram"]);
+    }
+
+    [Fact]
+    public async Task count_comparisons_use_a_count_subquery()
+    {
+        SqlFor(x => x.Tags.Count() > 1).ShouldBe(
+            "(select count(*) from json_each(data, '$.tags') as each_1 "
+            + "where each_1.key is not null) > @p0");
+
+        (await NamesMatchingAsync(x => x.Tags.Count() > 1)).ShouldBe(["Beagle", "Endurance"]);
+        (await NamesMatchingAsync(x => x.Tags.Count() == 2)).ShouldBe(["Beagle", "Endurance"]);
+    }
+
+    [Fact]
+    public async Task a_reversed_count_comparison_reverses_the_operator()
+    {
+        (await NamesMatchingAsync(x => 1 < x.Tags.Count())).ShouldBe(["Beagle", "Endurance"]);
+    }
+
+    /// <summary>
+    ///     The <c>List.Count</c> property and an array's <c>Length</c> are the same question asked
+    ///     without the method call, and translate identically. String <c>Length</c> keeps its own
+    ///     <c>length()</c> translation.
+    /// </summary>
+    [Fact]
+    public async Task the_count_property_and_array_length_translate_like_count()
+    {
+        (await NamesMatchingAsync(x => x.Tags.Count > 1)).ShouldBe(["Beagle", "Endurance"]);
+        (await NamesMatchingAsync(x => x.Depths.Length == 2)).ShouldBe(["Endurance"]);
+
+        SqlFor(x => x.Name.Length == 5).ShouldBe("length(json_extract(data, '$.name')) = @p0");
+    }
+
+    /// <summary>
+    ///     An absent member and one stored as JSON null both count as zero — the same honest reading
+    ///     <c>IsEmpty()</c> documents — where in-memory LINQ over a null collection would throw. The
+    ///     phantom <c>json_each</c> row must not make a null collection count 1.
+    /// </summary>
+    [Fact]
+    public async Task a_null_or_empty_collection_counts_as_zero()
+    {
+        (await NamesMatchingAsync(x => x.Tags.Count() == 0)).ShouldBe(["Fram"]);
+        (await NamesMatchingAsync(x => x.Depths.Count() == 0)).ShouldBe(["Fram"]);
+    }
+
+    [Fact]
+    public async Task count_with_a_predicate_counts_matching_elements_only()
+    {
+        (await NamesMatchingAsync(x => x.Stops.Count(s => s.Resupplied) == 1)).ShouldBe(["Endurance"]);
+        (await NamesMatchingAsync(x => x.Stops.Count(s => s.Resupplied) == 2)).ShouldBe(["Beagle"]);
+        (await NamesMatchingAsync(x => x.Stops.Count(s => s.Days < 5) == 2)).ShouldBe(["Endurance"]);
+    }
+
+    [Fact]
+    public async Task any_with_a_child_predicate_extracts_from_the_element()
+    {
+        SqlFor(x => x.Stops.Any(s => s.Port == "Oslo")).ShouldBe(
+            "exists (select 1 from json_each(data, '$.stops') as each_1 "
+            + "where each_1.key is not null and json_extract(each_1.value, '$.port') = @p0)");
+
+        (await NamesMatchingAsync(x => x.Stops.Any(s => s.Port == "Oslo"))).ShouldBe(["Endurance"]);
+        (await NamesMatchingAsync(x => x.Stops.Any(s => s.Days > 5))).ShouldBe(["Beagle"]);
+        (await NamesMatchingAsync(x => x.Stops.Any(s => s.Resupplied))).ShouldBe(["Beagle", "Endurance"]);
+        (await NamesMatchingAsync(x => x.Stops.Any(s => s.Port == "Oslo" && s.Days == 3)))
+            .ShouldBe(["Endurance"]);
+    }
+
+    /// <summary>
+    ///     A collection predicate inside a collection predicate gets a fresh <c>json_each</c> alias
+    ///     one depth down, so the two do not collide.
+    /// </summary>
+    [Fact]
+    public async Task a_nested_collection_predicate_aliases_one_depth_deeper()
+    {
+        SqlFor(x => x.Stops.Any(s => s.Cargo.Contains("fuel"))).ShouldBe(
+            "exists (select 1 from json_each(data, '$.stops') as each_1 "
+            + "where each_1.key is not null and "
+            + "exists (select 1 from json_each(each_1.value, '$.cargo') as each_2 "
+            + "where each_2.key is not null and each_2.value = @p0))");
+
+        (await NamesMatchingAsync(x => x.Stops.Any(s => s.Cargo.Contains("fuel"))))
+            .ShouldBe(["Beagle", "Endurance"]);
+        (await NamesMatchingAsync(x => x.Stops.Any(s => s.Cargo.Contains("specimens"))))
+            .ShouldBe(["Beagle"]);
+    }
+
+    /// <summary>
+    ///     <c>All</c> is vacuously true over an empty, absent or null collection — the same answer
+    ///     <c>Enumerable.All</c> gives an empty sequence — which is why Fram appears in both results.
+    /// </summary>
+    [Fact]
+    public async Task all_is_a_negated_exists_and_vacuously_true_when_empty()
+    {
+        (await NamesMatchingAsync(x => x.Stops.All(s => s.Days < 5))).ShouldBe(["Endurance", "Fram"]);
+        (await NamesMatchingAsync(x => x.Stops.All(s => s.Resupplied))).ShouldBe(["Beagle", "Fram"]);
+    }
+
+    /// <summary>
+    ///     SQL three-valued logic must not let an element slip past <c>All</c>: an element for which
+    ///     the predicate is NULL has not <em>satisfied</em> it. Beagle's null-Port stop is that shape
+    ///     — <c>NULL != 'Oslo'</c> is NULL, and a naive <c>not exists (… not (p))</c> would read that
+    ///     as passing.
+    /// </summary>
+    /// <remarks>
+    ///     This follows SQL null semantics rather than the CLR's, deliberately and consistently with
+    ///     the rest of the provider: a document whose <c>Name</c> is null does not match
+    ///     <c>x.Name != "Oslo"</c> either. In-memory LINQ would say Beagle passes, because C#'s
+    ///     <c>null != "Oslo"</c> is true.
+    /// </remarks>
+    [Fact]
+    public async Task an_element_the_predicate_cannot_decide_fails_all()
+    {
+        (await NamesMatchingAsync(x => x.Stops.All(s => s.Port != "Oslo"))).ShouldBe(["Fram"]);
+    }
+
+    /// <summary>
+    ///     The previously-advertised docs examples, end to end through the real query provider.
+    /// </summary>
+    [Fact]
+    public async Task the_documented_collection_examples_work_through_the_provider()
+    {
+        await using var session = _store.QuerySession();
+
+        (await session.Query<Expedition>().Where(x => x.Tags.Contains("urgent"))
+                .ToListAsync(TestContext.Current.CancellationToken))
+            .Select(x => x.Name).ShouldBe(["Endurance"]);
+
+        (await session.Query<Expedition>().Where(x => x.Tags.Any())
+                .CountAsync(TestContext.Current.CancellationToken)).ShouldBe(2);
+
+        (await session.Query<Expedition>().Where(x => x.Tags.Count() > 2)
+                .ToListAsync(TestContext.Current.CancellationToken)).ShouldBeEmpty();
+
+        (await session.Query<Expedition>().Where(x => x.Stops.Any(s => s.Days > 5))
+                .ToListAsync(TestContext.Current.CancellationToken))
+            .Select(x => x.Name).ShouldBe(["Beagle"]);
+    }
+
+    [Fact]
+    public void a_predicate_referencing_the_outer_document_is_refused()
+    {
+        var ex = Should.Throw<BadLinqExpressionException>(
+            () => SqlFor(x => x.Stops.Any(s => s.Port == x.Name)));
+
+        ex.Message.ShouldContain("outside the collection element's scope");
+    }
+
+    [Fact]
+    public void a_member_access_on_a_scalar_element_is_refused()
+    {
+        var ex = Should.Throw<BadLinqExpressionException>(
+            () => SqlFor(x => x.Tags.Any(t => t.Length > 3)));
+
+        ex.Message.ShouldContain("no members to extract");
+    }
+
+    /// <summary>
+    ///     A bare-element predicate (<c>t =&gt; t == "urgent"</c>) is not translated yet;
+    ///     <c>Contains</c> is the spelling for an element equality test. Refused rather than
+    ///     mis-translated.
+    /// </summary>
+    [Fact]
+    public void a_bare_element_comparison_is_refused()
+    {
+        Should.Throw<BadLinqExpressionException>(() => SqlFor(x => x.Tags.Any(t => t == "urgent")));
+    }
+
+    [Fact]
+    public void contains_comparing_against_another_document_member_is_refused()
+    {
+        var ex = Should.Throw<BadLinqExpressionException>(() => SqlFor(x => x.Tags.Contains(x.Name)));
+
+        ex.Message.ShouldContain("not another document member");
+    }
+
+    [Fact]
+    public void contains_over_complex_elements_is_refused_toward_any()
+    {
+        var oslo = new Stop { Port = "Oslo" };
+
+        var ex = Should.Throw<BadLinqExpressionException>(() => SqlFor(x => x.Stops.Contains(oslo)));
+
+        ex.Message.ShouldContain("Any(c => ");
+    }
+
+    /// <summary>
+    ///     <c>IsEmpty()</c> keeps its own translation — the null-inclusive json_array_length form —
+    ///     untouched by any of this.
+    /// </summary>
+    [Fact]
+    public async Task is_empty_still_answers_the_null_inclusive_question()
+    {
+        (await NamesMatchingAsync(x => x.Tags.IsEmpty())).ShouldBe(["Fram"]);
+    }
+}

--- a/src/Fisher/Linq/Members/CollectionMember.cs
+++ b/src/Fisher/Linq/Members/CollectionMember.cs
@@ -1,0 +1,209 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Fisher.Linq.Parsing;
+
+namespace Fisher.Linq.Members;
+
+/// <summary>
+///     A document member that is a collection — a JSON array in storage — and knows how to unroll
+///     itself through SQLite's <c>json_each</c> table-valued function.
+/// </summary>
+/// <remarks>
+///     <para>
+///         It is still a <see cref="QueryableMember" /> with the ordinary <c>json_extract</c> locator,
+///         which is what <c>IsEmpty()</c> and a null test read, so nothing that resolved a collection
+///         member before this type existed behaves differently. What is added is the correlated
+///         sub-query surface: <see cref="JsonEachSource" /> and <see cref="Alias" /> are what
+///         <c>Contains</c> / <c>Any</c> / <c>All</c> / <c>Count</c> compose their
+///         <c>exists (select 1 from json_each(data, '$.tags') as each_1 where …)</c> from.
+///     </para>
+///     <para>
+///         <b>The <c>key is not null</c> guard the sub-query fragments carry is load-bearing, not
+///         defensive.</b> <c>json_each</c> over a member whose stored value is JSON <c>null</c> —
+///         which is what System.Text.Json writes for a null collection property — returns <em>one</em>
+///         row holding that null, where an absent key returns zero and an empty array returns zero.
+///         Verified against SQLite 3.51. Without the guard, <c>Contains(null)</c> and any predicate
+///         satisfied by NULL (<c>c =&gt; c.Port == null</c>) would match a document whose collection is
+///         null — a false positive with nothing anywhere to signal it. The guard works because that
+///         one row is the only <c>json_each</c> row whose <c>key</c> is NULL: an array element's key is
+///         its index, even for a null element.
+///     </para>
+///     <para>
+///         Aliases are numbered by nesting depth (<c>each_1</c>, <c>each_2</c>, …) so a collection
+///         predicate inside an <c>Any</c> gets a fresh alias. Two sub-queries at the same depth never
+///         collide, because each is its own <c>exists (…)</c> scope.
+///     </para>
+/// </remarks>
+internal class CollectionMember : QueryableMember
+{
+    private readonly MemberFactory _parent;
+
+    public CollectionMember(MemberFactory parent, string dataExpression, string jsonPath,
+        Type memberType, Type elementType, int depth)
+        : base($"json_extract({dataExpression}, '{jsonPath}')", memberType)
+    {
+        _parent = parent;
+        ElementType = elementType;
+        Depth = depth;
+        Alias = $"each_{depth}";
+        JsonEachSource = $"json_each({dataExpression}, '{jsonPath}')";
+    }
+
+    public Type ElementType { get; }
+
+    /// <summary>The <c>json_each(…)</c> call a correlated sub-query selects from.</summary>
+    public string JsonEachSource { get; }
+
+    /// <summary>The alias the sub-query gives its <c>json_each</c> — <c>each_1</c> at the top level.</summary>
+    public string Alias { get; }
+
+    internal int Depth { get; }
+
+    /// <summary>
+    ///     Whether the elements are scalars a <c>Contains</c> can compare directly. A complex element
+    ///     has no single stored form to compare against — <c>Any(c =&gt; …)</c> is the operator for it.
+    /// </summary>
+    public bool HasScalarElements => IsScalarType(ElementType);
+
+    /// <summary>
+    ///     The element as a queryable member over <c>each_N.value</c> — same typing rules as a
+    ///     document member of the same CLR type, so an enum element honours the store's
+    ///     <c>EnumStorage</c> and a Guid element compares as lowercase canonical text. Null for a
+    ///     complex element type.
+    /// </summary>
+    public IQueryableMember? ElementMember
+        => HasScalarElements ? _parent.CreateScalarMember($"{Alias}.value", ElementType) : null;
+
+    /// <summary>
+    ///     A resolver for the members of one element, scoped to the given lambda parameter — what an
+    ///     <c>Any(c =&gt; …)</c> predicate's member accesses resolve through.
+    /// </summary>
+    public IMemberResolver CreateElementResolver(ParameterExpression parameter)
+        => new ElementMemberResolver(
+            _parent.CreateElementFactory($"{Alias}.value", Depth), parameter, ElementType);
+
+    /// <summary>
+    ///     Whether the CLR type is stored as a JSON array of elements worth unrolling, and which
+    ///     element type. Deliberately narrower than "implements IEnumerable": a string is characters,
+    ///     a byte array serializes as a base64 string, and a dictionary serializes as a JSON object.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+        Justification = "Reflects over a document member's interfaces to classify it as a collection. Document types and their property graph are preserved at the LINQ registration boundary on the caller side, per the AOT publishing guide.")]
+    public static bool TryGetElementType(Type type, out Type elementType)
+    {
+        elementType = typeof(object);
+
+        if (type == typeof(string) || type == typeof(byte[]))
+        {
+            return false;
+        }
+
+        if (typeof(IDictionary).IsAssignableFrom(type) || ImplementsDictionaryInterface(type))
+        {
+            return false;
+        }
+
+        if (type.IsArray && type.GetArrayRank() == 1)
+        {
+            elementType = type.GetElementType()!;
+            return true;
+        }
+
+        var enumerable = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+            ? type
+            : type.GetInterfaces().FirstOrDefault(i =>
+                i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        if (enumerable == null)
+        {
+            return false;
+        }
+
+        elementType = enumerable.GetGenericArguments()[0];
+        return true;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+        Justification = "Same classification reflection as TryGetElementType; see its justification.")]
+    private static bool ImplementsDictionaryInterface(Type type)
+        => type.GetInterfaces().Any(i => i.IsGenericType
+                                         && (i.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                                             || i.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)));
+
+    /// <summary>
+    ///     Whether elements of this type are stored as single JSON scalars rather than objects.
+    /// </summary>
+    public static bool IsScalarType(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+        return underlying.IsPrimitive
+               || underlying.IsEnum
+               || underlying == typeof(string)
+               || underlying == typeof(decimal)
+               || underlying == typeof(Guid)
+               || underlying == typeof(DateTime)
+               || underlying == typeof(DateTimeOffset)
+               || underlying == typeof(DateOnly)
+               || underlying == typeof(TimeOnly)
+               || underlying == typeof(TimeSpan);
+    }
+}
+
+/// <summary>
+///     Resolves member accesses inside an <c>Any</c>/<c>All</c>/<c>Count</c> predicate against one
+///     collection element, refusing anything that is not the element's own member.
+/// </summary>
+/// <remarks>
+///     Both refusals exist because the alternative is wrong SQL rather than an error. A chain rooted
+///     at the <em>outer</em> document's parameter would otherwise resolve against the element and read
+///     the wrong JSON; a member access on a <em>scalar</em> element (<c>t.Length</c>) would build a
+///     JSON path (<c>$.length</c>) into a value that is not an object and match nothing.
+/// </remarks>
+internal sealed class ElementMemberResolver : IMemberResolver
+{
+    private readonly MemberFactory _inner;
+    private readonly ParameterExpression _parameter;
+    private readonly Type _elementType;
+
+    public ElementMemberResolver(MemberFactory inner, ParameterExpression parameter, Type elementType)
+    {
+        _inner = inner;
+        _parameter = parameter;
+        _elementType = elementType;
+    }
+
+    public IQueryableMember ResolveMember(MemberExpression expression)
+    {
+        var root = RootParameterOf(expression);
+        if (!ReferenceEquals(root, _parameter))
+        {
+            throw new BadLinqExpressionException(
+                $"The predicate member '{expression}' does not belong to the collection element "
+                + $"'{_parameter.Name}'. Inside Any/All/Count over a child collection, only the "
+                + "element's own members can be translated to SQL.");
+        }
+
+        if (CollectionMember.IsScalarType(_elementType))
+        {
+            throw new BadLinqExpressionException(
+                $"Cannot translate the member access '{expression}' inside a collection predicate: "
+                + $"the elements are stored as plain {_elementType.Name} values with no members to "
+                + "extract. Use Contains(value) for an equality test against the elements.");
+        }
+
+        return _inner.ResolveMember(expression);
+    }
+
+    private static ParameterExpression? RootParameterOf(MemberExpression expression)
+    {
+        Expression? current = expression;
+        while (current is MemberExpression member)
+        {
+            current = member.Expression;
+        }
+
+        return current as ParameterExpression;
+    }
+}

--- a/src/Fisher/Linq/Members/MemberFactory.cs
+++ b/src/Fisher/Linq/Members/MemberFactory.cs
@@ -39,6 +39,8 @@ internal class MemberFactory : IMemberResolver
     private readonly DocumentMapping? _mapping;
     private readonly bool _hasIdentityColumn;
     private readonly string _qualifier;
+    private readonly string _dataExpression;
+    private readonly int _collectionDepth;
 
     /// <param name="options">The store's options — serializer naming policy and enum storage.</param>
     /// <param name="mapping">The document the members belong to.</param>
@@ -82,6 +84,8 @@ internal class MemberFactory : IMemberResolver
         _mapping = mapping;
         _hasIdentityColumn = hasIdentityColumn;
         _qualifier = tableAlias is null ? "" : tableAlias + ".";
+        _dataExpression = _qualifier + "data";
+        _collectionDepth = 0;
         _enumStorage = options.Serializer.EnumStorage;
 
         if (options.Serializer is Serializer serializer)
@@ -98,6 +102,31 @@ internal class MemberFactory : IMemberResolver
             _namingPolicy = JsonNamingPolicy.CamelCase;
         }
     }
+
+    /// <summary>
+    ///     A factory resolving members of a collection <em>element</em> rather than of the document —
+    ///     the JSON value a <c>json_each</c> row exposes as <c>each_N.value</c>.
+    /// </summary>
+    /// <remarks>
+    ///     No mapping and no identity column, for the same reasons the event-body constructor has
+    ///     neither: an element type has no identity row and no duplicated fields. The depth is what
+    ///     keeps nested <c>json_each</c> aliases distinct — a collection member resolved by this
+    ///     factory aliases itself one level deeper.
+    /// </remarks>
+    private MemberFactory(MemberFactory parent, string dataExpression, int collectionDepth)
+    {
+        _mapping = null;
+        _hasIdentityColumn = false;
+        _qualifier = "";
+        _dataExpression = dataExpression;
+        _collectionDepth = collectionDepth;
+        _enumStorage = parent._enumStorage;
+        _serializerOptions = parent._serializerOptions;
+        _namingPolicy = parent._namingPolicy;
+    }
+
+    internal MemberFactory CreateElementFactory(string dataExpression, int collectionDepth)
+        => new(this, dataExpression, collectionDepth);
 
     public IQueryableMember ResolveMember(MemberExpression expression)
     {
@@ -157,7 +186,26 @@ internal class MemberFactory : IMemberResolver
 
     private IQueryableMember CreateMember(string jsonPath, Type memberType)
     {
-        var locator = $"json_extract({_qualifier}data, '{jsonPath}')";
+        // A collection member keeps the same json_extract locator every scalar member has — that is
+        // what IsEmpty() and a null test read — and additionally knows how to unroll itself through
+        // json_each for Contains / Any / All / Count. Detected by CLR shape, because the JSON shape
+        // (an array) follows from it.
+        if (CollectionMember.TryGetElementType(memberType, out var elementType))
+        {
+            return new CollectionMember(this, _dataExpression, jsonPath, memberType, elementType,
+                _collectionDepth + 1);
+        }
+
+        return CreateScalarMember($"json_extract({_dataExpression}, '{jsonPath}')", memberType);
+    }
+
+    /// <summary>
+    ///     The scalar member switch, factored out of <see cref="CreateMember" /> so a collection's
+    ///     element member — whose locator is <c>each_N.value</c> rather than a <c>json_extract</c> —
+    ///     goes through exactly the same typing rules as a document member of the same CLR type.
+    /// </summary>
+    internal IQueryableMember CreateScalarMember(string locator, Type memberType)
+    {
         var underlying = Nullable.GetUnderlyingType(memberType) ?? memberType;
 
         if (underlying.IsEnum)

--- a/src/Fisher/Linq/Parsing/Methods/ChildCollectionMethods.cs
+++ b/src/Fisher/Linq/Parsing/Methods/ChildCollectionMethods.cs
@@ -1,0 +1,335 @@
+using System.Linq.Expressions;
+using Fisher.Linq.Members;
+using Fisher.Linq.SqlGeneration;
+using Weasel.Core.SqlGeneration;
+
+namespace Fisher.Linq.Parsing.Methods;
+
+/// <summary>
+///     Shared shape tests and helpers for the collection sub-query parsers. Everything here is about
+///     recognising "a document member that is a collection" from the expression tree alone, before any
+///     member resolution happens.
+/// </summary>
+internal static class ChildCollections
+{
+    /// <summary>
+    ///     Whether the expression is a member chain rooted at the query parameter whose CLR type is a
+    ///     collection Fisher stores as a JSON array.
+    /// </summary>
+    public static bool IsCollectionDocumentMember(Expression expression)
+        => StripConversions(expression) is MemberExpression member
+           && IsDocumentMember(member)
+           && CollectionMember.TryGetElementType(member.Type, out _);
+
+    public static bool IsDocumentMember(Expression expression)
+    {
+        var current = StripConversions(expression) as MemberExpression;
+        while (current != null)
+        {
+            if (current.Expression is ParameterExpression)
+            {
+                return true;
+            }
+
+            current = current.Expression as MemberExpression;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Resolves the collection member behind an already shape-matched expression, refusing by name
+    ///     when resolution lands on something that cannot be unrolled — a duplicated column being the
+    ///     one way a collection-shaped member resolves to a non-collection.
+    /// </summary>
+    public static CollectionMember ResolveCollection(IMemberResolver memberFactory,
+        Expression expression, string operatorName)
+    {
+        var member = memberFactory.ResolveMember((MemberExpression)StripConversions(expression));
+
+        if (member is not CollectionMember collection)
+        {
+            throw new BadLinqExpressionException(
+                $"Cannot translate {operatorName}() over the member '{expression}': it does not "
+                + "resolve to a JSON array Fisher can unroll with json_each.");
+        }
+
+        return collection;
+    }
+
+    /// <summary>
+    ///     The lambda argument of an <c>Any</c>/<c>All</c>/<c>Count</c> call, unwrapped from the
+    ///     <c>Quote</c> node expression trees arrive in.
+    /// </summary>
+    public static LambdaExpression LambdaOf(Expression expression)
+    {
+        while (expression is UnaryExpression { NodeType: ExpressionType.Quote or ExpressionType.Convert } unary)
+        {
+            expression = unary.Operand;
+        }
+
+        return (LambdaExpression)expression;
+    }
+
+    /// <summary>
+    ///     Parses an element predicate into the fragment the sub-query's WHERE carries, after refusing
+    ///     any reference that escapes the element's scope.
+    /// </summary>
+    public static ISqlFragment ParseElementPredicate(CollectionMember collection, LambdaExpression lambda,
+        string operatorName)
+    {
+        var parameter = lambda.Parameters[0];
+        OuterReferenceGuard.AssertScoped(lambda.Body, parameter, operatorName);
+
+        var resolver = collection.CreateElementResolver(parameter);
+        return new WhereClauseParser(resolver).Parse(lambda.Body);
+    }
+
+    public static Expression StripConversions(Expression expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case UnaryExpression { NodeType: ExpressionType.Convert } unary:
+                    expression = unary.Operand;
+                    continue;
+
+                // The implicit array-to-span conversion the compiler inserts for
+                // MemoryExtensions overloads — same unwrapping EnumerableContains does.
+                case MethodCallExpression { Method.Name: "op_Implicit" or "op_Explicit" } conversion
+                    when conversion.Arguments.Count == 1:
+                    expression = conversion.Arguments[0];
+                    continue;
+
+                case MethodCallExpression { Method.Name: "AsSpan" or "AsMemory" } asSpan:
+                    expression = asSpan.Object ?? asSpan.Arguments[0];
+                    continue;
+
+                default:
+                    return expression;
+            }
+        }
+    }
+}
+
+/// <summary>
+///     Refuses a collection predicate that references anything other than the lambda's own element —
+///     the outer document, or a captured element of an enclosing lambda.
+/// </summary>
+/// <remarks>
+///     A whole-tree walk rather than a check at member-resolution time, because an escaped reference on
+///     the <em>value</em> side of a comparison never reaches the resolver — it goes through closure
+///     evaluation, which would throw an unhelpful "variable 'x' of type … is not defined" from deep in
+///     expression compilation. Refusing up front names the actual problem. The correlated-EXISTS shape
+///     could support outer <em>member</em> references one day; today they are refused rather than
+///     mis-scoped.
+/// </remarks>
+internal sealed class OuterReferenceGuard : ExpressionVisitor
+{
+    private readonly HashSet<ParameterExpression> _inScope;
+    private readonly string _operatorName;
+
+    private OuterReferenceGuard(ParameterExpression parameter, string operatorName)
+    {
+        _inScope = [parameter];
+        _operatorName = operatorName;
+    }
+
+    public static void AssertScoped(Expression body, ParameterExpression parameter, string operatorName)
+        => new OuterReferenceGuard(parameter, operatorName).Visit(body);
+
+    protected override Expression VisitLambda<T>(Expression<T> node)
+    {
+        foreach (var parameter in node.Parameters)
+        {
+            _inScope.Add(parameter);
+        }
+
+        var result = base.VisitLambda(node);
+
+        foreach (var parameter in node.Parameters)
+        {
+            _inScope.Remove(parameter);
+        }
+
+        return result;
+    }
+
+    protected override Expression VisitParameter(ParameterExpression node)
+    {
+        if (!_inScope.Contains(node))
+        {
+            throw new BadLinqExpressionException(
+                $"The {_operatorName}() predicate references '{node.Name}', which is outside the "
+                + "collection element's scope. Only the element's own members can be used inside a "
+                + "collection predicate; compare against locals or constants instead.");
+        }
+
+        return base.VisitParameter(node);
+    }
+}
+
+/// <summary>
+///     <c>x.Tags.Contains(value)</c> → <c>exists (select 1 from json_each(data, '$.tags') as each_1
+///     where each_1.key is not null and each_1.value = @p0)</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The mirror image of <see cref="EnumerableContains" />: there the collection is an evaluated
+///         value and the member is the needle; here the collection is the document member and the
+///         needle is a value. Registered first of the two and claims every <c>Contains</c> whose
+///         receiver is a collection-typed document member, so that the member-vs-member shape
+///         (<c>x.Tags.Contains(x.Name)</c>) gets a refusal that names the problem instead of
+///         <see cref="EnumerableContains" />'s complaint about evaluating the source.
+///     </para>
+///     <para>
+///         The value goes through the <em>element member's</em> conversion — built by the same switch
+///         as any document member of that type — which is what keeps an enum honouring the store's
+///         <c>EnumStorage</c> and naming policy, a Guid matching its lowercase canonical text, and a
+///         bool matching the stored 1/0.
+///     </para>
+/// </remarks>
+internal sealed class CollectionContains : IMethodCallParser
+{
+    public bool Matches(MethodCallExpression expression)
+    {
+        if (expression.Method.Name != "Contains")
+        {
+            return false;
+        }
+
+        // Instance form on a collection — x.Tags.Contains(value). A string receiver belongs to
+        // StringContains.
+        if (expression.Object != null && expression.Arguments.Count == 1)
+        {
+            return expression.Method.DeclaringType != typeof(string)
+                   && ChildCollections.IsCollectionDocumentMember(expression.Object);
+        }
+
+        // Static form — Enumerable.Contains(x.Tags, value), or the span overload for an array member.
+        return expression.Object == null
+               && expression.Arguments.Count == 2
+               && ChildCollections.IsCollectionDocumentMember(expression.Arguments[0]);
+    }
+
+    public ISqlFragment Parse(IMemberResolver memberFactory, MethodCallExpression expression)
+    {
+        var receiver = expression.Object ?? expression.Arguments[0];
+        var needle = expression.Object == null ? expression.Arguments[1] : expression.Arguments[0];
+
+        if (ChildCollections.IsDocumentMember(needle))
+        {
+            throw new BadLinqExpressionException(
+                $"Cannot translate '{expression}': Contains() over a collection member needs a value "
+                + "that can be evaluated when the query is built, not another document member.");
+        }
+
+        var collection = ChildCollections.ResolveCollection(memberFactory, receiver, "Contains");
+
+        var element = collection.ElementMember
+                      ?? throw new BadLinqExpressionException(
+                          $"Cannot translate '{expression}': Contains() over a collection of "
+                          + $"{collection.ElementType.Name} elements has no single stored value to "
+                          + "compare. Use Any(c => …) with a predicate on the element's members.");
+
+        var value = element.ConvertValue(WhereClauseParser.ExtractValue(needle));
+
+        ISqlFragment where = value is null
+            ? new WhereFragment($"{element.RawLocator} is null")
+            : new ComparisonFilter(element.TypedLocator, "=", value);
+
+        return new ExistsSubQueryFilter(collection.JsonEachSource, collection.Alias, where);
+    }
+}
+
+/// <summary>
+///     <c>x.Children.Any()</c> and <c>x.Children.Any(c =&gt; …)</c> as correlated existence tests.
+/// </summary>
+/// <remarks>
+///     Both forms answer false for an absent member and for one stored as JSON null — no elements is no
+///     elements, however the nothing is spelled. The predicate form resolves the lambda's member
+///     accesses against the <c>json_each</c> element (<c>json_extract(each_1.value, '$.port')</c>),
+///     with everything outside the element's scope refused by <see cref="OuterReferenceGuard" />.
+/// </remarks>
+internal sealed class CollectionAny : IMethodCallParser
+{
+    public bool Matches(MethodCallExpression expression)
+        => expression.Method.Name == "Any"
+           && expression.Object == null
+           && expression.Arguments.Count is 1 or 2
+           && ChildCollections.IsCollectionDocumentMember(expression.Arguments[0]);
+
+    public ISqlFragment Parse(IMemberResolver memberFactory, MethodCallExpression expression)
+    {
+        var collection = ChildCollections.ResolveCollection(memberFactory, expression.Arguments[0], "Any");
+
+        if (expression.Arguments.Count == 1)
+        {
+            return new ExistsSubQueryFilter(collection.JsonEachSource, collection.Alias, null);
+        }
+
+        var lambda = ChildCollections.LambdaOf(expression.Arguments[1]);
+        var where = ChildCollections.ParseElementPredicate(collection, lambda, "Any");
+
+        return new ExistsSubQueryFilter(collection.JsonEachSource, collection.Alias, where);
+    }
+}
+
+/// <summary>
+///     <c>x.Children.All(c =&gt; …)</c> → <c>not exists (… where … and not (predicate))</c>.
+/// </summary>
+/// <remarks>
+///     The double negation is the standard relational spelling of a universal quantifier, and it gives
+///     the empty, absent and null collections the same vacuous truth <c>Enumerable.All</c> gives an
+///     empty sequence. One SQL subtlety: a predicate that evaluates to NULL for some element (say a
+///     null <c>Port</c> compared to a string) is <em>not true</em> for that element, and
+///     <c>not (NULL)</c> is NULL rather than true — so the negated arm wraps the predicate in a
+///     <c>coalesce</c>-free <c>is not true</c>-equivalent by testing <c>not (p)</c> alongside
+///     <c>(p) is null</c>.
+/// </remarks>
+internal sealed class CollectionAll : IMethodCallParser
+{
+    public bool Matches(MethodCallExpression expression)
+        => expression.Method.Name == "All"
+           && expression.Object == null
+           && expression.Arguments.Count == 2
+           && ChildCollections.IsCollectionDocumentMember(expression.Arguments[0]);
+
+    public ISqlFragment Parse(IMemberResolver memberFactory, MethodCallExpression expression)
+    {
+        var collection = ChildCollections.ResolveCollection(memberFactory, expression.Arguments[0], "All");
+
+        var lambda = ChildCollections.LambdaOf(expression.Arguments[1]);
+        var predicate = ChildCollections.ParseElementPredicate(collection, lambda, "All");
+
+        // "some element fails the predicate" must catch the element for which the predicate is NULL —
+        // in SQL that element neither passes nor fails, but All() means every element *passes*.
+        var fails = new FailsPredicateFragment(predicate);
+
+        return new ExistsSubQueryFilter(collection.JsonEachSource, collection.Alias, fails, negated: true);
+    }
+
+    /// <summary>
+    ///     <c>((p) is null or not (p))</c> — true exactly when the element does not satisfy the
+    ///     predicate, including when SQL three-valued logic makes the predicate NULL.
+    /// </summary>
+    private sealed class FailsPredicateFragment : ISqlFragment
+    {
+        private readonly ISqlFragment _predicate;
+
+        public FailsPredicateFragment(ISqlFragment predicate)
+        {
+            _predicate = predicate;
+        }
+
+        public void Apply(Weasel.Core.ICommandBuilder builder)
+        {
+            builder.Append("((");
+            _predicate.Apply(builder);
+            builder.Append(") is null or not (");
+            _predicate.Apply(builder);
+            builder.Append("))");
+        }
+    }
+}

--- a/src/Fisher/Linq/Parsing/Methods/MethodCallParserRegistry.cs
+++ b/src/Fisher/Linq/Parsing/Methods/MethodCallParserRegistry.cs
@@ -24,7 +24,13 @@ internal static class MethodCallParserRegistry
         new StringToUpper(),
         new StringTrim(),
         new IsOneOf(),
+        // Before EnumerableContains: a Contains whose receiver is a collection-typed document member
+        // belongs to the json_each sub-query, whichever shape its argument takes — including the
+        // member-vs-member shape, which gets a refusal naming the actual problem.
+        new CollectionContains(),
         new EnumerableContains(),
+        new CollectionAny(),
+        new CollectionAll(),
         new IsEmpty(),
         new ObjectEquals()
     ];

--- a/src/Fisher/Linq/Parsing/WhereClauseParser.cs
+++ b/src/Fisher/Linq/Parsing/WhereClauseParser.cs
@@ -133,6 +133,13 @@ internal class WhereClauseParser
             return lengthFragment!;
         }
 
+        // x.Tags.Count() > 2 / x.Tags.Count > 2 / x.Depths.Length > 2, either way round
+        if (TryParseCollectionCount(binary.Left, binary.Right, op, out var countFragment)
+            || TryParseCollectionCount(binary.Right, binary.Left, ReverseOperator(op), out countFragment))
+        {
+            return countFragment!;
+        }
+
         if (TryResolveMemberAndValue(binary.Left, binary.Right, out var member, out var value))
         {
             return BuildComparisonFilter(member!, value, op);
@@ -303,6 +310,62 @@ internal class WhereClauseParser
             Found = true;
             return node;
         }
+    }
+
+    /// <summary>
+    ///     <c>x.Tags.Count() &gt; 2</c> — also the <c>List.Count</c> property, an array's
+    ///     <c>Length</c>, and the filtered <c>Count(c =&gt; …)</c> overload — compared as a
+    ///     <c>count(*)</c> sub-query over <c>json_each</c>.
+    /// </summary>
+    /// <remarks>
+    ///     An absent member and one stored as JSON null both count as zero — the same "the key is not
+    ///     there is an honest empty" reading <c>IsEmpty()</c> documents — where in-memory LINQ over a
+    ///     null collection would throw. String <c>Length</c> is not claimed here (the element-type test
+    ///     rejects strings), so it keeps its <c>length()</c> translation.
+    /// </remarks>
+    private bool TryParseCollectionCount(Expression memberSide, Expression valueSide, string op,
+        out ISqlFragment? fragment)
+    {
+        fragment = null;
+
+        var stripped = StripConvert(memberSide);
+        Expression? collectionExpr = null;
+        LambdaExpression? filter = null;
+
+        if (stripped is MethodCallExpression { Method.Name: "Count", Object: null } call
+            && call.Method.DeclaringType == typeof(Enumerable)
+            && call.Arguments.Count is 1 or 2)
+        {
+            collectionExpr = call.Arguments[0];
+            filter = call.Arguments.Count == 2 ? Methods.ChildCollections.LambdaOf(call.Arguments[1]) : null;
+        }
+        else if (stripped is MemberExpression { Member.Name: "Count" or "Length" } property
+                 && property.Expression is MemberExpression inner)
+        {
+            collectionExpr = inner;
+        }
+        // An array's Length is not a member access in an expression tree — the compiler emits a
+        // dedicated ArrayLength unary node.
+        else if (stripped is UnaryExpression { NodeType: ExpressionType.ArrayLength } arrayLength)
+        {
+            collectionExpr = arrayLength.Operand;
+        }
+
+        if (collectionExpr == null
+            || !Methods.ChildCollections.IsCollectionDocumentMember(collectionExpr))
+        {
+            return false;
+        }
+
+        var collection = Methods.ChildCollections.ResolveCollection(_memberFactory, collectionExpr, "Count");
+
+        var where = filter == null
+            ? null
+            : Methods.ChildCollections.ParseElementPredicate(collection, filter, "Count");
+
+        fragment = new CollectionCountFilter(collection.JsonEachSource, collection.Alias, where, op,
+            ExtractValue(valueSide)!);
+        return true;
     }
 
     private bool TryParseModulo(BinaryExpression binary, string op, out ISqlFragment? fragment)

--- a/src/Fisher/Linq/SqlGeneration/ExistsSubQueryFilter.cs
+++ b/src/Fisher/Linq/SqlGeneration/ExistsSubQueryFilter.cs
@@ -1,0 +1,112 @@
+using Weasel.Core;
+using Weasel.Core.SqlGeneration;
+
+namespace Fisher.Linq.SqlGeneration;
+
+/// <summary>
+///     A correlated existence test over a collection member —
+///     <c>exists (select 1 from json_each(data, '$.tags') as each_1 where each_1.key is not null and (…))</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The shape behind <c>Contains</c>, <c>Any(predicate)</c> and — negated twice — <c>All</c>:
+///         <c>All(p)</c> renders as <c>not exists (… where not (p))</c>, which is also why an empty or
+///         absent collection satisfies <c>All</c> (vacuous truth, matching <c>Enumerable.All</c> over an
+///         empty sequence).
+///     </para>
+///     <para>
+///         The <c>key is not null</c> guard is not decoration: <c>json_each</c> over a member stored as
+///         JSON <c>null</c> yields one row holding that null, and without the guard any predicate a NULL
+///         satisfies — <c>Contains(null)</c>, <c>c =&gt; c.Port == null</c>, or <c>All</c>'s negated arm
+///         — would silently match a document whose collection is null. Array element rows always carry
+///         their index as <c>key</c>, so the guard removes exactly that one phantom row. See
+///         <see cref="Members.CollectionMember" />.
+///     </para>
+/// </remarks>
+internal class ExistsSubQueryFilter : ISqlFragment
+{
+    private readonly string _source;
+    private readonly string _alias;
+    private readonly ISqlFragment? _where;
+    private readonly bool _negated;
+
+    /// <param name="where">The element predicate, or null for a bare <c>Any()</c>.</param>
+    public ExistsSubQueryFilter(string source, string alias, ISqlFragment? where, bool negated = false)
+    {
+        _source = source;
+        _alias = alias;
+        _where = where;
+        _negated = negated;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append(_negated ? "not exists (select 1 from " : "exists (select 1 from ");
+        builder.Append(_source);
+        builder.Append(" as ");
+        builder.Append(_alias);
+        builder.Append(" where ");
+        builder.Append(_alias);
+        builder.Append(".key is not null");
+
+        if (_where != null)
+        {
+            builder.Append(" and ");
+            _where.Apply(builder);
+        }
+
+        builder.Append(')');
+    }
+}
+
+/// <summary>
+///     A comparison against how many elements a collection member holds, optionally filtered —
+///     <c>(select count(*) from json_each(data, '$.tags') as each_1 where each_1.key is not null) &gt; @p0</c>.
+/// </summary>
+/// <remarks>
+///     <c>count(*)</c> over <c>json_each</c> rather than <c>json_array_length</c>, for two reasons that
+///     both concern the degenerate cases. An absent key gives <c>json_each</c> zero rows where
+///     <c>json_array_length</c> gives NULL — and "the key is not there" counting as zero elements is
+///     the same honest answer <c>IsEmpty()</c> already gives. And a member stored as JSON <c>null</c>
+///     gives one phantom row, which the same <c>key is not null</c> guard as
+///     <see cref="ExistsSubQueryFilter" /> removes; without it a null collection would count 1.
+/// </remarks>
+internal class CollectionCountFilter : ISqlFragment
+{
+    private readonly string _source;
+    private readonly string _alias;
+    private readonly ISqlFragment? _where;
+    private readonly string _op;
+    private readonly object _value;
+
+    public CollectionCountFilter(string source, string alias, ISqlFragment? where, string op, object value)
+    {
+        _source = source;
+        _alias = alias;
+        _where = where;
+        _op = op;
+        _value = value;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append("(select count(*) from ");
+        builder.Append(_source);
+        builder.Append(" as ");
+        builder.Append(_alias);
+        builder.Append(" where ");
+        builder.Append(_alias);
+        builder.Append(".key is not null");
+
+        if (_where != null)
+        {
+            builder.Append(" and ");
+            _where.Apply(builder);
+        }
+
+        builder.Append(") ");
+        builder.Append(_op);
+        builder.Append(' ');
+        builder.AppendParameter(_value);
+    }
+}


### PR DESCRIPTION
Closes #166. Stoat plan `fisher-marten-parity`, node `child-collection-linq`.

## What this adds

The full child-collection predicate family, as correlated sub-queries over SQLite's `json_each` — the SQLite spelling of the correlated-EXISTS strategy Marten's collection filters moved to:

| Shape | SQL |
|---|---|
| `x.Tags.Contains(value)` (string/number/Guid/enum, both `EnumStorage` modes) | `exists (select 1 from json_each(data, '$.tags') as each_1 where each_1.key is not null and each_1.value = @p0)` |
| `x.Tags.Any()` | bare `exists` with just the guard |
| `x.Stops.Any(s => <predicate>)` | element members via `json_extract(each_1.value, '$.port')`; nested collection predicates alias one depth deeper (`each_2`) |
| `x.Stops.All(s => <predicate>)` | `not exists (… and ((p) is null or not (p)))` |
| `x.Tags.Count() > n`, `.Count`, array `.Length`, `Count(predicate)` | `(select count(*) from json_each(…) as each_1 where each_1.key is not null) > @p0` |

**All four scoped shapes landed** — nothing deferred; `All(predicate)` (the stretch item) is included.

## The load-bearing subtlety

`json_each` over a member stored as JSON `null` (what STJ writes for a null collection property) yields **one phantom row**, where an absent key yields zero — verified against SQLite 3.51. The `key is not null` guard in every sub-query is what keeps `Contains(null)` and NULL-satisfied predicates (`s => s.Port == null`) from matching a null collection. Absent, empty and null members all honestly hold no elements: `Any()` false, `Count()` zero, `All()` vacuously true.

`All()` additionally handles three-valued logic: an element whose predicate evaluates to NULL has not *satisfied* it, so it fails `All` — SQL null semantics, consistent with how the provider already treats `!= value` against null members.

## Refusals (house rule: never mis-translate)

Each throws `BadLinqExpressionException` naming the problem and the alternative:

- Outer-scope references inside a collection predicate (`x.Stops.Any(s => s.Port == x.Name)`) — a whole-tree `ExpressionVisitor` guard, so a value-side escape refuses cleanly instead of dying inside expression compilation
- Member access on scalar elements (`t => t.Length > 3`)
- Bare element comparisons (`t => t == "urgent"`) — `Contains` is the spelling
- `Contains` against another document member; `Contains` over complex elements → pointed at `Any(c => …)`

## Docs bug fixed

`docs/documents/querying/linq/operators.md` advertised `Contains`/`Any()`/`Count() > 2` while none worked. The Collections section now documents the whole supported family, the degenerate-shape semantics, the SQL-null-semantics caveat, and the refusal list.

## Tests

23 new tests in `src/Fisher.Tests/Linq/child_collections.cs`: SQL-shape assertions, executed row assertions against seeded data deliberately including the populated/empty/JSON-null shapes, enum-storage variants (AsInteger + AsString through the naming policy), nested `Any`+`Contains`, three-valued-logic discrimination, all five refusal messages, and the previously-throwing docs examples end-to-end through the provider.

Full suite: **1476 passed / 0 failed on both TFMs** (plus AspNetCore 36×2, EFCore 19×2).

## Expected merge overlap

Open PRs #160 and #162 are based on the same `origin/main`. #162 touches `WhereClauseParser.cs` and `MemberFactory.cs`; this PR's edits there are additive (a new try-parse block + method in `ParseComparison`, a data-expression field and element-factory constructor in `MemberFactory`), so conflicts should be small and mechanical. `MethodCallParserRegistry.cs` gains four registrations, also additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)