### PR TITLE
gh-174: apply only the new type's delta in the first-use table ensure

### DIFF
--- a/src/Fisher.Benchmarks/Results.md
+++ b/src/Fisher.Benchmarks/Results.md
@@ -124,3 +124,49 @@ Notes:
   saved and ~27 KB per single-event append commit — consistent with the per-operation
   command-building the batching work targets. ShortRun error bars are wide by design; use
   `-- bdn --job medium` before quoting a delta.
+
+---
+
+## Per-type table-ensure delta (2026-09-05, fisher#174)
+
+`EnsureDocumentTableAsync` stopped running `ApplyAllConfiguredChangesToDatabaseAsync` per cache miss
+and now diffs only the newly-registered type's own schema objects. Measured on a different machine
+from the baseline block above (a little faster overall), so the baseline was re-run here rather than
+taken from that block — treat the before/after pair, not the absolutes.
+
+```
+Fisher.Benchmarks — 2026-09-05 19:32 -05:00
+  OS:        macOS 26.4.1 (Arm64)
+  .NET:      .NET 10.0.1
+  CPUs:      18
+  Config:    Release
+```
+
+```
+== cold-start (20 document types, 5 rounds) ==
+                                     before      after
+  median first commit (table ensure)  47.9 ms     6.2 ms
+  median second commit (warm)          0.5 ms     0.5 ms
+  table-ensure overhead               47.3 ms     5.7 ms     8.3x
+  overhead per type                    2.4 ms     0.3 ms
+
+== cold-start (32 document types, 5 rounds) ==
+                                     before      after
+  median first commit (table ensure) 110.0 ms     6.1 ms
+  median second commit (warm)          0.8 ms     0.8 ms
+  table-ensure overhead              109.2 ms     5.4 ms    20.2x
+  overhead per type                    3.4 ms     0.2 ms
+```
+
+Notes:
+
+- **The shape changed, not just the constant.** Before, 1.6x the types cost 2.3x the warm-up
+  (47.3 ms → 109.2 ms) — the superlinear curve an O(types × objects) diff predicts, since migration
+  #k re-introspects every object from 1..k−1. After, 32 types cost the same as 20 (5.4 ms vs
+  5.7 ms, inside the run-to-run noise): the remaining cost is per-type and flat, so the number to
+  quote for a larger store is "no worse", not "20x again".
+- **The warm commit is unmoved** in both configurations, which is the control: this changes what the
+  first use of a type pays and nothing about the steady state.
+- Not re-run: `doc-save`, `event-append`, `daemon-rebuild`, `concurrent-writers` and the BDN
+  micro-benchmarks. None of them reaches the first-use ensure more than once per type, and the
+  scenario that does is the one above.

--- a/src/Fisher.Tests/Schema/first_use_table_ensure.cs
+++ b/src/Fisher.Tests/Schema/first_use_table_ensure.cs
@@ -1,0 +1,160 @@
+using Fisher.Linq;
+using JasperFx;
+using Microsoft.Data.Sqlite;
+
+namespace Fisher.Tests.Schema;
+
+/// <summary>
+///     The first write or read of a document type provisions that type's table and only that type's
+///     table (fisher#174).
+/// </summary>
+/// <remarks>
+///     <para>
+///         This used to run <c>ApplyAllConfiguredChangesToDatabaseAsync</c> — a whole-database
+///         migration — per type, so warming up T types re-introspected every object the store knows
+///         about T times over. The delta is the fix; these tests pin its two observable consequences,
+///         since a per-type migration and a whole-configuration one are indistinguishable from any
+///         single type's point of view once both have run.
+///     </para>
+/// </remarks>
+public class first_use_table_ensure : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("first-use-ensure");
+    private DocumentStore _store = null!;
+
+    public ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
+
+            // Registered, so both are in the store's configuration from the start — which is what
+            // makes "only the one that was used" a statement about the migration rather than about
+            // which mappings happen to exist.
+            options.Schema.For<FirstEnsured>();
+            options.Schema.For<SecondEnsured>();
+            options.Schema.For<ConcurrentlyEnsured>();
+        });
+
+        // Deliberately no ApplyAllConfiguredChangesToDatabaseAsync: every table below is created by
+        // the first use of its own type, which is the path under test.
+        return default;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private async Task<HashSet<string>> DocumentTableNamesAsync()
+    {
+        await using var conn = new SqliteConnection(_database.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using var command = conn.CreateCommand();
+        command.CommandText =
+            "select name from sqlite_master where type = 'table' and name like 'fi=_doc=_%' escape '='";
+
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var reader = await command.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        while (await reader.ReadAsync(TestContext.Current.CancellationToken))
+        {
+            names.Add(reader.GetString(0));
+        }
+
+        return names;
+    }
+
+    /// <remarks>
+    ///     The delta itself. A whole-configuration migration would have created every mapped type's
+    ///     table as a side effect of the first one being written, which is the O(types × objects)
+    ///     shape — so "only this one is here" is the assertion that tells the two apart.
+    /// </remarks>
+    [Fact]
+    public async Task ensuring_one_type_creates_that_types_table_and_no_other()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new FirstEnsured { Id = "one" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var tables = await DocumentTableNamesAsync();
+
+        tables.ShouldContain("fi_doc_firstensured");
+        tables.ShouldNotContain("fi_doc_secondensured");
+    }
+
+    /// <remarks>
+    ///     And the second type still provisions itself on its own first use, which is what makes the
+    ///     narrowing above safe rather than merely smaller.
+    /// </remarks>
+    [Fact]
+    public async Task a_later_type_still_provisions_itself()
+    {
+        await using (var first = _store.LightweightSession())
+        {
+            first.Store(new FirstEnsured { Id = "one" });
+            await first.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var second = _store.LightweightSession())
+        {
+            second.Store(new SecondEnsured { Id = "two" });
+            await second.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var tables = await DocumentTableNamesAsync();
+
+        tables.ShouldContain("fi_doc_firstensured");
+        tables.ShouldContain("fi_doc_secondensured");
+    }
+
+    /// <remarks>
+    ///     <para>
+    ///         Concurrent first use of one type has to coalesce. The cache used to hold the types
+    ///         themselves, so <c>HashSet.Add</c> returning false was read as "already ensured" when it
+    ///         meant "somebody else is ensuring it right now" — and the loser went straight on to
+    ///         write against a table that did not exist yet, surfacing as <c>no such table</c>.
+    ///     </para>
+    ///     <para>
+    ///         Racy by nature, so it is run over several fresh types to widen the window rather than
+    ///         relying on one draw. It passes intermittently against the old shape rather than always
+    ///         failing, which is exactly why the coalescing is not left to be inferred from the cache.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task concurrent_first_use_of_one_type_does_not_race()
+    {
+        var writes = Enumerable.Range(0, 8).Select(async i =>
+        {
+            await using var session = _store.LightweightSession();
+            session.Store(new ConcurrentlyEnsured { Id = $"racer-{i}" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        });
+
+        await Task.WhenAll(writes);
+
+        await using var query = _store.QuerySession();
+        var all = await query.Query<ConcurrentlyEnsured>().ToListAsync(TestContext.Current.CancellationToken);
+
+        all.Count.ShouldBe(8);
+    }
+}
+
+public class FirstEnsured
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class SecondEnsured
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class ConcurrentlyEnsured
+{
+    public string Id { get; set; } = string.Empty;
+}

--- a/src/Fisher/Storage/FisherDatabase.cs
+++ b/src/Fisher/Storage/FisherDatabase.cs
@@ -1,8 +1,10 @@
+using System.Collections.Concurrent;
 using System.Data.Common;
 using Fisher.Events;
 using Fisher.Events.Schema;
 using Fisher.Storage.Sequences;
 using Microsoft.Data.Sqlite;
+using Weasel.Core;
 using Weasel.Core.Migrations;
 using Weasel.Sqlite;
 
@@ -207,7 +209,7 @@ public partial class FisherDatabase : SqliteDatabase, Weasel.Storage.IStorageDat
         }
     }
 
-    private readonly HashSet<Type> _ensuredDocumentTables = new();
+    private readonly ConcurrentDictionary<Type, Task> _ensuredDocumentTables = new();
     private ClosedShape.DocumentProviderRegistry? _providers;
     private SequenceFactory? _sequences;
 
@@ -243,42 +245,138 @@ public partial class FisherDatabase : SqliteDatabase, Weasel.Storage.IStorageDat
     ///         would make the second call through this path silently succeed, and the failure would then
     ///         surface as <c>no such table</c> from wherever the caller went next.
     ///     </para>
+    ///     <para>
+    ///         <b>Only this type's own schema objects are diffed, not the whole configuration</b>
+    ///         (fisher#174). This used to call <c>ApplyAllConfiguredChangesToDatabaseAsync</c>, which
+    ///         re-introspects every object the store knows about — so warming up T document types ran T
+    ///         whole-database migrations, and migration #k already contained every object from 1..k−1.
+    ///         Measured at ~2.4 ms per type for 20 types and ~3.4 ms for 32, the superlinear shape that
+    ///         O(T × objects) predicts, and paid on the read path as well as the write one since
+    ///         fisher#74 — a cold application that only <em>queries</em> thirty types paid all of it.
+    ///         Polecat's <c>DocumentTableEnsurer</c> already handed one <c>DocumentTable</c> to
+    ///         <c>SchemaMigration.DetermineAsync</c>; this is the same, and still goes through Weasel's
+    ///         migration path rather than emitting DDL beside it.
+    ///     </para>
+    ///     <para>
+    ///         <b>The cache holds the in-flight task, not just the type</b>, so a second caller for the
+    ///         same type waits for the first one's migration instead of returning as though it were
+    ///         done. The old <c>HashSet.Add</c> returning false was read as "already ensured" when it in
+    ///         fact meant "somebody else is ensuring it right now" — so under a parallel cold start the
+    ///         second caller went straight on to write against a table that did not exist yet. That is
+    ///         a narrow race (both callers have to miss within one migration) and it fails as
+    ///         <c>no such table</c>, a long way from here.
+    ///     </para>
     /// </remarks>
-    internal async Task EnsureDocumentTableAsync(Type documentType, CancellationToken token)
+    internal Task EnsureDocumentTableAsync(Type documentType, CancellationToken token)
     {
-        lock (_ensuredDocumentTables)
+        // The overwhelmingly common case, and worth keeping allocation-free: the type was ensured by
+        // an earlier unit of work and there is nothing to await.
+        if (_ensuredDocumentTables.TryGetValue(documentType, out var ensured) && ensured.IsCompletedSuccessfully)
         {
-            if (!_ensuredDocumentTables.Add(documentType))
+            return Task.CompletedTask;
+        }
+
+        return ensureDocumentTableAsync(documentType, token);
+    }
+
+    private async Task ensureDocumentTableAsync(Type documentType, CancellationToken token)
+    {
+        while (true)
+        {
+            token.ThrowIfCancellationRequested();
+
+            if (_ensuredDocumentTables.TryGetValue(documentType, out var inflight))
             {
+                if (inflight.IsCompletedSuccessfully)
+                {
+                    return;
+                }
+
+                try
+                {
+                    // WaitAsync so that this caller's own cancellation is honoured while it waits on
+                    // somebody else's migration — the migration itself runs on whichever token started
+                    // it, and abandoning the wait must not abandon the work.
+                    await inflight.WaitAsync(token).ConfigureAwait(false);
+                    return;
+                }
+                catch (OperationCanceledException) when (!token.IsCancellationRequested)
+                {
+                    // The caller that owned the migration was cancelled and this one was not, so its
+                    // cancellation is not an answer to our question. Drop the dead entry if it is
+                    // somehow still there and take the work on ourselves.
+                    _ensuredDocumentTables.TryRemove(new KeyValuePair<Type, Task>(documentType, inflight));
+                    continue;
+                }
+            }
+
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!_ensuredDocumentTables.TryAdd(documentType, completion.Task))
+            {
+                // Lost the race to another caller; go round and wait on theirs.
+                continue;
+            }
+
+            try
+            {
+                await applyDocumentSchemaAsync(documentType, token).ConfigureAwait(false);
+                completion.SetResult();
                 return;
             }
-        }
-
-        try
-        {
-            // Registering the mapping is what puts the table into BuildFeatureSchemas; applying the
-            // whole configuration then creates it. Heavier than emitting one CREATE TABLE, but it goes
-            // through the same migration path as every other Fisher table instead of beside it.
-            var mapping = _options.Schema.MappingFor(documentType);
-
-            if (AutoCreate == JasperFx.AutoCreate.None)
+            catch (Exception e)
             {
-                await AssertDocumentTableExistsAsync(documentType, mapping.TableName.Name, token)
-                    .ConfigureAwait(false);
-                return;
-            }
+                // Uncached before the waiters are released, so the next caller through here retries
+                // rather than finding a faulted entry to trip over.
+                _ensuredDocumentTables.TryRemove(new KeyValuePair<Type, Task>(documentType, completion.Task));
+                completion.SetException(e);
 
-            await ApplyAllConfiguredChangesToDatabaseAsync(ct: token).ConfigureAwait(false);
+                // Reading Exception marks the fault observed: a migration that nobody happened to be
+                // waiting on must not surface later as an unobserved task exception.
+                _ = completion.Task.Exception;
+
+                throw;
+            }
         }
-        catch
+    }
+
+    /// <summary>
+    ///     Apply the schema objects one document type needs, and only those.
+    /// </summary>
+    private async Task applyDocumentSchemaAsync(Type documentType, CancellationToken token)
+    {
+        // Asking for the mapping is what creates it for a type nothing has registered, which is the
+        // case this whole path exists for.
+        var mapping = _options.Schema.MappingFor(documentType);
+
+        if (AutoCreate == JasperFx.AutoCreate.None)
         {
-            lock (_ensuredDocumentTables)
-            {
-                _ensuredDocumentTables.Remove(documentType);
-            }
-
-            throw;
+            await AssertDocumentTableExistsAsync(documentType, mapping.TableName.Name, token)
+                .ConfigureAwait(false);
+            return;
         }
+
+        var objects = new List<ISchemaObject> { mapping.BuildTable() };
+
+        // The same condition BuildFeatureSchemas uses to include the Hi-Lo feature. HiloSequence
+        // creates the table for itself — an id is assigned at Store, long before any commit-time
+        // schema work — so this is only here to keep the set of objects this path creates the same as
+        // the set the full migration would have created for the type.
+        if (mapping.IdType == typeof(int) || mapping.IdType == typeof(long))
+        {
+            objects.Add(new HiloTable(_options.DatabaseSchemaName));
+        }
+
+        await using var conn = await OpenConnectionAsync(token).ConfigureAwait(false);
+
+        var migration = await SchemaMigration
+            .DetermineAsync(conn, Migrator, token, objects.ToArray()).ConfigureAwait(false);
+
+        if (migration.Difference == SchemaPatchDifference.None)
+        {
+            return;
+        }
+
+        await Migrator.ApplyAllAsync(conn, migration, AutoCreate, ct: token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -316,10 +414,7 @@ public partial class FisherDatabase : SqliteDatabase, Weasel.Storage.IStorageDat
     /// </remarks>
     internal void ForgetEnsuredTables()
     {
-        lock (_ensuredDocumentTables)
-        {
-            _ensuredDocumentTables.Clear();
-        }
+        _ensuredDocumentTables.Clear();
     }
 
     internal Weasel.Storage.IProviderGraph Providers


### PR DESCRIPTION
Closes #174. Stoat plan `critter-performance-2026-09`, node `fisher-table-ensure-delta`.

`EnsureDocumentTableAsync` memoized per document type but ran `ApplyAllConfiguredChangesToDatabaseAsync` — a **whole-database** migration — on every cache miss. Warming up T types therefore ran T full-configuration migrations, and migration #k re-introspected every object from 1..k−1. Since #74 the read path reaches it too, so a cold application that only *queries* thirty document types paid all of it before answering anything.

## What changed

- **The delta, not the whole configuration.** The type's own `DocumentTable` goes to `SchemaMigration.DetermineAsync` and that migration is applied — the shape Polecat's `DocumentTableEnsurer` already had. The Hi-Lo table is included on the same condition `BuildFeatureSchemas` uses for the Hi-Lo feature, so the set of objects this path creates for a type is unchanged; `HiloSequence` still creates that table for itself, as it always did.
- **Concurrent first use of one type coalesces.** The cache now holds the in-flight `Task` rather than the type. `HashSet.Add` returning false was being read as "already ensured" when it actually meant "somebody else is ensuring it right now" — so under a parallel cold start the losing caller went straight on to write against a table that did not exist yet, surfacing as `no such table` a long way from here.
- Everything the old path guaranteed is kept: the `AutoCreate.None` check-and-decline (#81), un-caching a type whose ensure failed so the next caller retries, and `ForgetEnsuredTables` for `CompletelyRemoveAllAsync`.

## Numbers

`cold-start` scenario in `src/Fisher.Benchmarks` (Apple Silicon, .NET 10.0.1, Release, 5 rounds). Recorded in `Results.md`; the baseline was re-run on this machine rather than taken from the #169 block, which was recorded on a slower one.

| | before | after | |
|---|---|---|---|
| 20 types — table-ensure overhead | 47.3 ms | **5.7 ms** | 8.3x |
| 20 types — per type | 2.4 ms | 0.3 ms | |
| 32 types — table-ensure overhead | 109.2 ms | **5.4 ms** | 20.2x |
| 32 types — per type | 3.4 ms | 0.2 ms | |

**The curve flattened as well as dropping**, which is the part worth quoting: before, 1.6x the types cost 2.3x the warm-up — the O(types × objects) shape. After, 32 types cost what 20 do, inside the run-to-run noise. The warm second commit is unmoved in both configurations, which is the control.

## Tests

Three new tests in `src/Fisher.Tests/Schema/first_use_table_ensure.cs`. The discriminating one is `ensuring_one_type_creates_that_types_table_and_no_other` — a whole-configuration migration creates every registered type's table as a side effect of the first write, so "only this one is here" is what tells the two apart. **Verified load-bearing by reverting the production change**: it fails with `should not contain "fi_doc_secondensured" but was actually ["fi_doc_concurrentlyensured", "fi_doc_secondensured", "fi_doc_firstensured"]`.

Full suite green on both TFMs, no test weakened: **1503 / 36 / 19** passed (`Fisher.Tests`, `Fisher.AspNetCore.Tests`, `Fisher.EntityFrameworkCore.Tests`) on net10.0 and net9.0 alike, run locally against SQLite with no docker. `origin/main` merged first, so #170's child-collection LINQ work is included in that run. The compliance scoreboard is unmoved — these three are Fisher-local tests, not compliance suites, and `check_scoreboard.py` only reads the compliance counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
