### PR TITLE
gh-172: register ISystemPart and IDatabaseSource so the JasperFx CLI sees a Fisher store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,9 @@ Working, with tests:
   range of events, its writes committing in the batch's transaction
 - **DI registration** — `AddFisher(...)`, scoped sessions, and hosted services for schema application
   and the async daemon
+- **The command line** — `ISystemPart` and `IDatabaseSource` registered from both `AddFisher` and
+  `AddFisherStore<T>`, so `db-apply` / `db-assert` / `db-patch` / `db-dump`, the `resources` commands
+  and `describe` all see a Fisher store; plus `AssertDatabaseMatchesConfigurationOnStartup()`
 - **Flat-table projections** — `FlatTableProjection`, projecting into a plain relational table
   through declarative column mappings rather than into a document
 - **Soft delete** — `is_deleted` / `deleted_at`, `HardDelete`, `DeleteWhere` / `HardDeleteWhere` /
@@ -2100,6 +2103,63 @@ hosted services. The store is a singleton, sessions are scoped, and the returned
       assemblies in one process in a fixed order — an intermittent under xUnit's parallel collections
       rather than a test. What is Fisher's to get right is read it, buffer it, log it once; detecting
       it is JasperFx's and is tested there.
+
+#### The command-line seam — fisher#172
+
+`AddFisher` registered the store, sessions and its hosted services, and **nothing the JasperFx or
+Weasel command line looks for** — so `dotnet run -- db-apply` failed with *"No Weasel databases were
+registered in this application"*, `resources list` reported an application with no resources, and a
+CI step asserting the deployed schema still matches the code was not expressible at all.
+
+**Two registrations, because the two command families resolve different things**, and registering one
+leaves the other reporting an empty application:
+
+| Surface | Resolves | Fisher supplies |
+|---|---|---|
+| `resources setup/list/check`, `AddResourceSetupOnStartup()`, `describe` | `JasperFx.CommandLine.Descriptions.ISystemPart` | `FisherSystemPart` / `FisherSystemPart<T>` |
+| `db-apply` / `db-assert` / `db-patch` / `db-dump` | `Weasel.Core.Migrations.IDatabaseSource` | `FisherDatabaseSource` |
+
+- **An adapter rather than widening `ITenancy`**, following polecat#501's reasoning. Marten satisfies
+  the Weasel half because its own `ITenancy` *is* an `IDatabaseSource`; Fisher's `ITenancy` is public
+  and implementable outside this repo, so extending it is a breaking change — and it would pull a
+  migration contract into a tenancy abstraction for what is purely a CLI concern. Nothing was needed
+  underneath: `FisherDatabase` already extends Weasel's `SqliteDatabase`.
+- **Both take a factory, never the resolved store.** The `IConfigureFisher` chain has to have run
+  before the tenancy means anything, and that happens on first `IDocumentStore` resolution — so
+  injecting the store would build it while the container is still being assembled.
+- **Both refresh a `DynamicTenancy` first.** A tenant nothing has resolved yet still has a file to
+  migrate, and `db-apply` silently skipping it is the exact failure the whole seam closes. Read
+  through `ITenancy` rather than the store's internal `RefreshTenantsAsync`, because an ancillary
+  store arrives as its marker `DispatchProxy` and is not a `DocumentStore`.
+- **An ancillary store gets its own subject uri** (`fisher://iotherstore`), and that matters more here
+  than on either sibling: a second Fisher store is usually a second *file*, so collapsing the two
+  would hide one from `resources list` outright rather than merely mislabelling a schema.
+- **Neither ancillary registration unwraps the proxy**, unlike the `IEventStore` bridge beside them.
+  Correct rather than an oversight: both reach the store through `IDocumentStore` members (`Tenancy`,
+  `Options`), which a marker interface inherits and the proxy therefore implements — where the tooling
+  interfaces are implemented explicitly and are not on `IDocumentStore` at all.
+
+**`AssertDatabaseMatchesConfigurationOnStartup()`** is the third opt-in, beside
+`ApplyAllDatabaseChangesOnStartup()` and `SeedInitialDataOnStartup()`, over a new
+`IDocumentStore.AssertDatabaseMatchesConfigurationAsync` that spans every tenant database.
+
+- **The two schema opt-ins are refused together, in either order.** Applying the changes at startup
+  makes the assertion a check on the schema that same startup just wrote, so a host asking for both is
+  expressing a contradiction rather than being careful — and accepting it silently would leave
+  somebody believing they had a guard they do not have.
+- **`AutoCreate.None` is deliberately not consulted**, where the migration activator honours it. That
+  setting says the schema is not Fisher's to change and this changes nothing — declining to *verify*
+  because the store was told not to write would make the strictest configuration the one with the
+  fewest guarantees.
+- **A seeder may follow either activator.** What `SeedInitialDataOnStartup` needs is that the tables
+  exist by the time it runs, and an assertion that passed is exactly that claim.
+
+**The tests run the commands rather than asserting on the container**, and that is the point: a
+registration test passes against a source that resolves, enumerates nothing and reports success —
+which is `db-assert` answering "everything matches" about a store it never looked at. They needed a
+`ConsoleWritingCollection`, because `Console.SetOut` is process-wide and `CliJsonCapture` was already
+swapping it; two tests printing JSON objects at once made the existing `event_query_command` capture
+parse somebody else's report. Same family as the process-wide `ActivityListener` lesson in tracing.
 
 **Everything Fisher hands a container now implements `IDisposable` as well as `IAsyncDisposable`** —
 `DocumentStore`, `FisherDatabase`, `FisherSession`, and `IQuerySession` with them. That is not a

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1555 tests green on net9.0 and net10.0**, with no known intermittent failures — 1500 in
+**1571 tests green on net9.0 and net10.0**, with no known intermittent failures — 1516 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 391 of
 them are shared cross-store compliance tests — 322 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1515 tests green on net9.0 and net10.0**, with no known intermittent failures — 1460 in
+**1548 tests green on net9.0 and net10.0**, with no known intermittent failures — 1493 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 391 of
 them are shared cross-store compliance tests — 322 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 40 suites and 391 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,460.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,493.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 40 suites and 391 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,500.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,516.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/src/Fisher.Tests/Configuration/command_line_integration.cs
+++ b/src/Fisher.Tests/Configuration/command_line_integration.cs
@@ -1,0 +1,406 @@
+using JasperFx;
+using JasperFx.CommandLine.Descriptions;
+using JasperFx.Resources;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Weasel.Core.CommandLine;
+using Weasel.Core.Migrations;
+
+namespace Fisher.Tests.Configuration;
+
+/// <summary>
+///     fisher#172 — the command-line seam. A Fisher store was invisible to every JasperFx and Weasel
+///     CLI surface, because <c>AddFisher</c> registered no <see cref="ISystemPart" /> and no
+///     <see cref="IDatabaseSource" />.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Two registrations, not one, because the two families resolve different things.</b>
+///         <c>resources setup / list / check</c> and <c>AddResourceSetupOnStartup()</c> go through
+///         <see cref="ISystemPart" />; <c>db-apply</c> / <c>db-assert</c> / <c>db-patch</c> /
+///         <c>db-dump</c> go through Weasel's <see cref="IDatabaseSource" />. Registering one leaves the
+///         other family reporting an application with no databases in it — which is why several tests
+///         here run the commands rather than asserting on the container.
+///     </para>
+///     <para>
+///         Running them is the point. A registration test passes against a source that resolves,
+///         enumerates nothing and reports success, and that is exactly the failure mode this closes:
+///         <c>db-assert</c> answering "everything matches" about a store it never looked at.
+///     </para>
+/// </remarks>
+[Collection(ConsoleWritingCollection.Name)]
+public class command_line_integration : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("cli");
+    private readonly TemporaryDatabase _second = TemporaryDatabase.Create("cli-second");
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        _database.Dispose();
+        _second.Dispose();
+
+        return ValueTask.CompletedTask;
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private IHostBuilder Builder(bool applyOnStartup = false) =>
+        Host.CreateDefaultBuilder().ConfigureServices(services =>
+        {
+            var expression = services.AddFisher(options =>
+            {
+                options.ConnectionString = _database.ConnectionString;
+                options.AutoCreateSchemaObjects = AutoCreate.All;
+                options.Schema.For<CliTarget>();
+            });
+
+            if (applyOnStartup)
+            {
+                expression.ApplyAllDatabaseChangesOnStartup();
+            }
+        });
+
+    // ---- the registrations themselves ----
+
+    [Fact]
+    public async Task add_fisher_registers_a_system_part_over_the_stores_databases()
+    {
+        using var host = await Builder().StartAsync(Token);
+
+        var part = host.Services.GetServices<ISystemPart>().Single(x => x.SubjectUri.Scheme == "fisher");
+
+        part.SubjectUri.ShouldBe(new Uri("fisher://store"));
+        part.Title.ShouldBe("Fisher");
+
+        var resources = await part.FindResources();
+        var resource = resources.ShouldHaveSingleItem().ShouldBeOfType<DatabaseResource>();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        resource.Database.ShouldBeSameAs(store.Tenancy.Default);
+    }
+
+    [Fact]
+    public async Task add_fisher_registers_a_weasel_database_source()
+    {
+        using var host = await Builder().StartAsync(Token);
+
+        var source = host.Services.GetServices<IDatabaseSource>().ShouldHaveSingleItem();
+        var databases = await source.BuildDatabases();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        databases.ShouldHaveSingleItem().ShouldBeSameAs(store.Tenancy.Default);
+    }
+
+    /// <remarks>
+    ///     Under database-per-tenant the source has to hand back <em>every</em> file, or <c>db-apply</c>
+    ///     migrates one tenant and reports success for the store.
+    /// </remarks>
+    [Fact]
+    public async Task the_database_source_spans_every_tenant_database()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "fisher-cli-tenants-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .ConfigureServices(services => services.AddFisher(options =>
+                {
+                    options.AutoCreateSchemaObjects = AutoCreate.All;
+                    options.MultiTenantedDatabases(x => x.InDirectory(directory).AddTenants("one", "two", "*DEFAULT*"));
+                    options.Schema.For<CliTarget>();
+                })).StartAsync(Token);
+
+            var source = host.Services.GetServices<IDatabaseSource>().ShouldHaveSingleItem();
+            var databases = await source.BuildDatabases();
+
+            databases.Select(x => x.Identifier).OrderBy(x => x, StringComparer.Ordinal)
+                .ShouldBe(["*DEFAULT*", "one", "two"]);
+
+            var usage = await source.DescribeDatabasesAsync(Token);
+            usage.Databases.Count.ShouldBe(3);
+        }
+        finally
+        {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <remarks>
+    ///     An ancillary store is usually a second <em>file</em> here, so collapsing the two onto one
+    ///     subject uri would hide one from <c>resources list</c> outright — a sharper consequence than
+    ///     the same mistake has on either sibling, where a second store is a second schema.
+    /// </remarks>
+    [Fact]
+    public async Task an_ancillary_store_contributes_its_own_part_and_database_source()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddFisher(options =>
+                {
+                    options.ConnectionString = _database.ConnectionString;
+                    options.AutoCreateSchemaObjects = AutoCreate.All;
+                });
+
+                services.AddFisherStore<ICliOtherStore>(options =>
+                {
+                    options.ConnectionString = _second.ConnectionString;
+                    options.AutoCreateSchemaObjects = AutoCreate.All;
+                });
+            }).StartAsync(Token);
+
+        var parts = host.Services.GetServices<ISystemPart>()
+            .Where(x => x.SubjectUri.Scheme == "fisher")
+            .ToArray();
+
+        parts.Select(x => x.SubjectUri.ToString()).OrderBy(x => x, StringComparer.Ordinal).ToArray()
+            .ShouldBe(["fisher://icliotherstore/", "fisher://store/"]);
+
+        var ancillary = parts.Single(x => x.SubjectUri != FisherSystemPartUri);
+        ancillary.Title.ShouldBe("Fisher ICliOtherStore");
+
+        var ancillaryResource = (await ancillary.FindResources()).ShouldHaveSingleItem()
+            .ShouldBeOfType<DatabaseResource>();
+
+        var other = host.Services.GetRequiredService<ICliOtherStore>();
+        ancillaryResource.Database.ShouldBeSameAs(other.Tenancy.Default);
+
+        // And both files reach db-apply, which is the half polecat#501 was actually about.
+        var sources = host.Services.GetServices<IDatabaseSource>().ToArray();
+        sources.Length.ShouldBe(2);
+
+        var all = new List<IDatabase>();
+        foreach (var source in sources)
+        {
+            all.AddRange(await source.BuildDatabases());
+        }
+
+        all.Count.ShouldBe(2);
+    }
+
+    private static Uri FisherSystemPartUri => new("fisher://store");
+
+    // ---- the commands, actually invoked ----
+
+    [Fact]
+    public async Task db_apply_creates_the_schema()
+    {
+        var exitCode = await Builder().RunJasperFxCommands(["db-apply"]);
+
+        exitCode.ShouldBe(0);
+        (await TableExistsAsync("fi_events")).ShouldBeTrue();
+        (await TableExistsAsync("fi_doc_clitarget")).ShouldBeTrue();
+    }
+
+    /// <remarks>
+    ///     The CI shape the whole issue was about: apply the schema in a release step, then have a later
+    ///     step (or the next deploy) prove the deployed database still matches what the code configures.
+    /// </remarks>
+    [Fact]
+    public async Task db_assert_passes_once_the_schema_has_been_applied_and_fails_before()
+    {
+        // Before anything is applied the assertion has to fail, or "matches" means nothing.
+        (await Builder().RunJasperFxCommands(["db-assert"])).ShouldNotBe(0);
+
+        (await Builder().RunJasperFxCommands(["db-apply"])).ShouldBe(0);
+
+        (await Builder().RunJasperFxCommands(["db-assert"])).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task db_patch_writes_the_outstanding_ddl_to_a_file()
+    {
+        var file = Path.Combine(Path.GetTempPath(), "fisher-cli-patch-" + Guid.NewGuid().ToString("N") + ".sql");
+
+        try
+        {
+            var exitCode = await Builder().RunJasperFxCommands(["db-patch", file]);
+
+            exitCode.ShouldBe(0);
+            File.Exists(file).ShouldBeTrue();
+            (await File.ReadAllTextAsync(file, Token)).ShouldContain("fi_events");
+        }
+        finally
+        {
+            if (File.Exists(file)) File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task db_dump_writes_the_whole_creation_script()
+    {
+        var file = Path.Combine(Path.GetTempPath(), "fisher-cli-dump-" + Guid.NewGuid().ToString("N") + ".sql");
+
+        try
+        {
+            var exitCode = await Builder().RunJasperFxCommands(["db-dump", file]);
+
+            exitCode.ShouldBe(0);
+
+            var sql = await File.ReadAllTextAsync(file, Token);
+            sql.ShouldContain("fi_events");
+            sql.ShouldContain("fi_doc_clitarget");
+        }
+        finally
+        {
+            if (File.Exists(file)) File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task describe_reports_the_store()
+    {
+        (await Builder().RunJasperFxCommands(["describe"])).ShouldBe(0);
+    }
+
+    /// <remarks>
+    ///     The idiomatic route: no Fisher-specific call at all, just the host-level resource opt-in,
+    ///     which finds Fisher's databases through <see cref="ISystemPart" />.
+    /// </remarks>
+    [Fact]
+    public async Task add_resource_setup_on_startup_creates_the_schema()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddFisher(options =>
+                {
+                    options.ConnectionString = _database.ConnectionString;
+                    options.AutoCreateSchemaObjects = AutoCreate.All;
+                    options.Schema.For<CliTarget>();
+                });
+
+                services.AddResourceSetupOnStartup();
+            }).StartAsync(Token);
+
+        (await TableExistsAsync("fi_events")).ShouldBeTrue();
+
+        await host.StopAsync(Token);
+    }
+
+    // ---- AssertDatabaseMatchesConfigurationOnStartup ----
+
+    [Fact]
+    public async Task assert_on_startup_stops_the_host_against_an_unapplied_schema()
+    {
+        var builder = Host.CreateDefaultBuilder().ConfigureServices(services =>
+            services.AddFisher(options =>
+                {
+                    options.ConnectionString = _database.ConnectionString;
+                    options.Schema.For<CliTarget>();
+                })
+                .AssertDatabaseMatchesConfigurationOnStartup());
+
+        await Should.ThrowAsync<Exception>(async () =>
+        {
+            using var host = await builder.StartAsync(Token);
+        });
+    }
+
+    [Fact]
+    public async Task assert_on_startup_is_happy_once_the_schema_has_been_applied()
+    {
+        await using (var store = DocumentStore.For(options =>
+                     {
+                         options.ConnectionString = _database.ConnectionString;
+                         options.Schema.For<CliTarget>();
+                     }))
+        {
+            await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+        }
+
+        using var host = await Host.CreateDefaultBuilder().ConfigureServices(services =>
+            services.AddFisher(options =>
+                {
+                    options.ConnectionString = _database.ConnectionString;
+                    options.Schema.For<CliTarget>();
+                })
+                .AssertDatabaseMatchesConfigurationOnStartup()).StartAsync(Token);
+
+        await host.StopAsync(Token);
+    }
+
+    /// <remarks>
+    ///     Both orders, because which call came first must not decide whether the contradiction is
+    ///     reported.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void applying_and_asserting_on_startup_are_alternatives(bool assertFirst)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var expression = services.AddFisher(options => options.ConnectionString = _database.ConnectionString);
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+        {
+            if (assertFirst)
+            {
+                expression.AssertDatabaseMatchesConfigurationOnStartup().ApplyAllDatabaseChangesOnStartup();
+            }
+            else
+            {
+                expression.ApplyAllDatabaseChangesOnStartup().AssertDatabaseMatchesConfigurationOnStartup();
+            }
+        });
+
+        ex.Message.ShouldContain("alternatives");
+    }
+
+    /// <remarks>
+    ///     A seeder needs the tables to exist by the time it runs, and an assertion that passed is
+    ///     exactly that claim — so it satisfies the ordering guard the same way applying does.
+    /// </remarks>
+    [Fact]
+    public void seeding_may_follow_the_assertion_as_well_as_the_migration()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        Should.NotThrow(() => services.AddFisher(options => options.ConnectionString = _database.ConnectionString)
+            .AssertDatabaseMatchesConfigurationOnStartup()
+            .SeedInitialDataOnStartup());
+    }
+
+    [Fact]
+    public async Task an_ancillary_store_can_assert_its_own_schema_on_startup()
+    {
+        var builder = Host.CreateDefaultBuilder().ConfigureServices(services =>
+            services.AddFisherStore<ICliOtherStore>(options =>
+                {
+                    options.ConnectionString = _second.ConnectionString;
+                    options.Schema.For<CliTarget>();
+                })
+                .AssertDatabaseMatchesConfigurationOnStartup());
+
+        await Should.ThrowAsync<Exception>(async () =>
+        {
+            using var host = await builder.StartAsync(Token);
+        });
+    }
+
+    private async Task<bool> TableExistsAsync(string name)
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "select count(*) from sqlite_master where type = 'table' and name = $name";
+        command.Parameters.AddWithValue("$name", name);
+
+        return Convert.ToInt64(await command.ExecuteScalarAsync(Token)) > 0;
+    }
+}
+
+public interface ICliOtherStore : IDocumentStore;
+
+public class CliTarget
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Fisher.Tests/ConsoleWritingCollection.cs
+++ b/src/Fisher.Tests/ConsoleWritingCollection.cs
@@ -1,0 +1,26 @@
+namespace Fisher.Tests;
+
+/// <summary>
+///     Test classes that either capture <see cref="Console.Out" /> or write to it from a JasperFx
+///     command, serialized against each other (fisher#172).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>Console.SetOut</c> is process-wide and xUnit runs collections in parallel, so a class
+///         that swaps stdout to read a command's JSON report will capture whatever any concurrently
+///         running test happened to print. <c>CliJsonCapture.ParseReport</c> already brace-counts from
+///         the first <c>{</c> to survive a stray *line*, but that is not enough against another test
+///         that also prints a JSON object — the capture then parses somebody else's report and the
+///         assertions fail somewhere that has nothing to do with the cause.
+///     </para>
+///     <para>
+///         Same family as the lesson the tracing tests record about a process-wide
+///         <c>ActivityListener</c>: the shared surface is the operating system's, so the only fix is
+///         to stop two tests using it at once.
+///     </para>
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class ConsoleWritingCollection
+{
+    public const string Name = "console";
+}

--- a/src/Fisher.Tests/Events/event_query_command.cs
+++ b/src/Fisher.Tests/Events/event_query_command.cs
@@ -27,6 +27,7 @@ namespace Fisher.Tests.Events;
 ///         <see cref="runAsync" />.
 ///     </para>
 /// </remarks>
+[Collection(ConsoleWritingCollection.Name)]
 public class event_query_command : IAsyncLifetime
 {
     private readonly TemporaryDatabase _database = TemporaryDatabase.Create("cli_event_query");

--- a/src/Fisher.Tests/Events/stream_query_command.cs
+++ b/src/Fisher.Tests/Events/stream_query_command.cs
@@ -17,6 +17,7 @@ namespace Fisher.Tests.Events;
 ///     store discovery, aggregate-type resolution, the queryable translation and the JSON rendering
 ///     meet, including <c>versionsSinceCompaction</c> riding the jasperfx#740 watermark end to end.
 /// </remarks>
+[Collection(ConsoleWritingCollection.Name)]
 public class stream_query_command : IAsyncLifetime
 {
     private readonly TemporaryDatabase _database = TemporaryDatabase.Create("cli_stream_query");

--- a/src/Fisher/DocumentStore.cs
+++ b/src/Fisher/DocumentStore.cs
@@ -301,6 +301,34 @@ public partial class DocumentStore : IDocumentStore
         }
     }
 
+    /// <summary>
+    ///     Throw if any database this store spans does not already match the configured schema, without
+    ///     changing anything (fisher#172).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The read half of <see cref="ApplyAllConfiguredChangesToDatabaseAsync" />, and the same
+    ///         question <c>db-assert</c> asks — so a deployment that applies its schema out of band can
+    ///         verify it, and a host can refuse to start against a database it would silently misread.
+    ///     </para>
+    ///     <para>
+    ///         <b>Every database, not just the default</b>, and reported per database for the same
+    ///         reason the migration is: under database-per-tenant, asserting one file and calling the
+    ///         store verified is the answer most likely to be wrong. Unlike the migration this stops at
+    ///         the first mismatch — there is nothing partial to report, and the caller's next act is to
+    ///         look at the one that failed.
+    ///     </para>
+    /// </remarks>
+    public async Task AssertDatabaseMatchesConfigurationAsync(CancellationToken token = default)
+    {
+        await RefreshTenantsAsync(token).ConfigureAwait(false);
+
+        foreach (var database in Tenancy.AllDatabases())
+        {
+            await database.AssertDatabaseMatchesConfigurationAsync(token).ConfigureAwait(false);
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         GC.SuppressFinalize(this);

--- a/src/Fisher/FisherServiceCollectionExtensions.cs
+++ b/src/Fisher/FisherServiceCollectionExtensions.cs
@@ -80,6 +80,20 @@ public static class FisherServiceCollectionExtensions
         services.AddSingleton<JasperFx.Events.IEventStore>(
             sp => sp.GetRequiredService<DocumentStore>());
 
+        // fisher#172 — the two halves of the command-line seam, and they are genuinely two: the
+        // "resources" commands and AddResourceSetupOnStartup() go through ISystemPart, while Weasel's
+        // db-apply / db-assert / db-patch / db-dump resolve IDatabaseSource. Registering only one
+        // leaves the other family reporting an application with no databases in it. Marten satisfies
+        // both because its ITenancy IS an IDatabaseSource; Fisher's is adapted — see
+        // FisherDatabaseSource for why widening the public interface was the wrong trade.
+        //
+        // Both take a factory rather than the resolved store, because the IConfigureFisher chain has
+        // to run before the tenancy means anything and that happens on first store resolution.
+        services.AddSingleton<JasperFx.CommandLine.Descriptions.ISystemPart>(sp
+            => new FisherSystemPart(sp.GetRequiredService<IDocumentStore>));
+        services.AddSingleton<Weasel.Core.Migrations.IDatabaseSource>(sp
+            => new Storage.FisherDatabaseSource(sp.GetRequiredService<IDocumentStore>));
+
         // TryAdd so an application that registers its own factory — to scope sessions to a tenant read
         // off the request, say — keeps it whichever side of AddFisher the registration lands.
         services.TryAddSingleton<ISessionFactory>(
@@ -159,6 +173,20 @@ public static class FisherServiceCollectionExtensions
         // secondary store carries its own StoreName.
         services.AddSingleton<JasperFx.Events.IEventStore>(sp
             => (JasperFx.Events.IEventStore)UnwrapForTooling(sp.GetRequiredService<T>()));
+
+        // fisher#172 — an ancillary store contributes its own database(s) to both command-line seams,
+        // under a subject uri of its own. That distinction matters more here than on either sibling:
+        // two Fisher stores are usually two *files*, so collapsing them would hide one entirely from
+        // `resources list` and migrate only one under `db-apply`.
+        //
+        // Neither registration unwraps the marker proxy, and that is correct rather than an oversight:
+        // both reach the store through IDocumentStore members (Tenancy, Options), which a marker
+        // interface inherits and the proxy therefore implements — unlike the tooling interfaces above,
+        // which are implemented explicitly and are not on IDocumentStore at all.
+        services.AddSingleton<JasperFx.CommandLine.Descriptions.ISystemPart>(sp
+            => new FisherSystemPart<T>(sp.GetRequiredService<T>));
+        services.AddSingleton<Weasel.Core.Migrations.IDatabaseSource>(sp
+            => new Storage.FisherDatabaseSource(() => sp.GetRequiredService<T>()));
 
         return new FisherStoreConfigurationExpression<T>(services);
     }
@@ -431,6 +459,15 @@ public sealed class FisherStoreConfigurationExpression<T> where T : class, IDocu
         return this;
     }
 
+    /// <inheritdoc cref="FisherConfigurationExpression.AssertDatabaseMatchesConfigurationOnStartup" />
+    public FisherStoreConfigurationExpression<T> AssertDatabaseMatchesConfigurationOnStartup()
+    {
+        _services.AddSingleton<IHostedService>(sp
+            => new FisherSchemaAssertionActivator(sp.GetRequiredService<T>()));
+
+        return this;
+    }
+
     /// <inheritdoc cref="FisherConfigurationExpression.SeedInitialDataOnStartup" />
     public FisherStoreConfigurationExpression<T> SeedInitialDataOnStartup()
     {
@@ -518,7 +555,58 @@ public sealed class FisherConfigurationExpression
     /// </remarks>
     public FisherConfigurationExpression ApplyAllDatabaseChangesOnStartup()
     {
+        // Symmetric with the guard in AssertDatabaseMatchesConfigurationOnStartup, because which of the
+        // two was called first must not decide whether the contradiction is reported.
+        if (_services.Any(x => x.ImplementationType == typeof(FisherSchemaAssertionActivator)))
+        {
+            throw new InvalidOperationException(
+                "AssertDatabaseMatchesConfigurationOnStartup() and ApplyAllDatabaseChangesOnStartup() are "
+                + "alternatives: applying the configured changes at startup makes the assertion a check on "
+                + "the schema this same startup just wrote, which proves nothing. Keep the one that matches "
+                + "how this deployment gets its schema.");
+        }
+
         _services.AddSingleton<IHostedService, FisherSchemaActivator>();
+        return this;
+    }
+
+    /// <summary>
+    ///     Refuse to start the host unless every database this store spans already matches the
+    ///     configured schema (fisher#172).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The counterpart to <see cref="ApplyAllDatabaseChangesOnStartup" /> for a deployment where
+    ///         the schema is applied out of band — by <c>db-apply</c> in a release step, or by a DBA
+    ///         running <c>Advanced.ToDatabaseScript()</c>. Marten ships the same pair, and the reason to
+    ///         want the assertion is that the failure it catches is otherwise silent: a store reading a
+    ///         table whose shape has drifted does not error, it answers wrongly.
+    ///     </para>
+    ///     <para>
+    ///         <b>The two are alternatives, and asking for both is refused by name.</b> Applying changes
+    ///         makes the assertion vacuous — it would verify the schema this very startup just wrote —
+    ///         so a host registering both is expressing a contradiction rather than being careful, and
+    ///         silently accepting it would leave somebody believing they had a guard they do not have.
+    ///     </para>
+    ///     <para>
+    ///         <b>Deliberately not gated on <see cref="AutoCreate.None" />.</b> That setting says
+    ///         "the schema is not yours to change", which is the natural companion but not a
+    ///         prerequisite — and the on-demand document table path honours it separately (fisher#81).
+    ///         This one only ever reads.
+    ///     </para>
+    /// </remarks>
+    public FisherConfigurationExpression AssertDatabaseMatchesConfigurationOnStartup()
+    {
+        if (_services.Any(x => x.ImplementationType == typeof(FisherSchemaActivator)))
+        {
+            throw new InvalidOperationException(
+                "ApplyAllDatabaseChangesOnStartup() and AssertDatabaseMatchesConfigurationOnStartup() are "
+                + "alternatives: applying the configured changes at startup makes the assertion a check on "
+                + "the schema this same startup just wrote, which proves nothing. Keep the one that matches "
+                + "how this deployment gets its schema.");
+        }
+
+        _services.AddSingleton<IHostedService, FisherSchemaAssertionActivator>();
         return this;
     }
 
@@ -540,10 +628,14 @@ public sealed class FisherConfigurationExpression
     /// </remarks>
     public FisherConfigurationExpression SeedInitialDataOnStartup()
     {
-        if (_services.All(x => x.ImplementationType != typeof(FisherSchemaActivator)))
+        // Either schema activator satisfies this: what a seeder needs is that the tables exist by the
+        // time it runs, and an assertion that passed is exactly that claim (fisher#172).
+        if (_services.All(x => x.ImplementationType != typeof(FisherSchemaActivator)
+                && x.ImplementationType != typeof(FisherSchemaAssertionActivator)))
         {
             throw new InvalidOperationException(
-                "Call ApplyAllDatabaseChangesOnStartup() before SeedInitialDataOnStartup(). Hosted "
+                "Call ApplyAllDatabaseChangesOnStartup() (or AssertDatabaseMatchesConfigurationOnStartup()) "
+                + "before SeedInitialDataOnStartup(). Hosted "
                 + "services start in registration order, and a seeder that runs before the schema is "
                 + "applied writes to tables that do not exist yet. If the schema is applied some other "
                 + "way, run the seeders that way too.");
@@ -613,6 +705,35 @@ internal sealed class FisherSchemaActivator : IHostedService
         => _store.Options.AutoCreateSchemaObjects == AutoCreate.None
             ? Task.CompletedTask
             : _store.ApplyAllConfiguredChangesToDatabaseAsync(cancellationToken);
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>
+///     Asserts once, at host start, that every database the store spans already matches the configured
+///     schema — and stops the host if one does not (fisher#172).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b><see cref="AutoCreate.None" /> is not consulted, where
+///         <see cref="FisherSchemaActivator" /> honours it.</b> That is not an inconsistency: the setting
+///         says the schema is not Fisher's to change, and this changes nothing — it reads. Declining to
+///         verify because the store was told not to write would turn the strictest configuration into
+///         the one with the fewest guarantees.
+///     </para>
+///     <para>
+///         The exception propagates rather than being logged, which is the point of the opt-in: a host
+///         that starts against a drifted schema does not fail, it answers wrongly.
+///     </para>
+/// </remarks>
+internal sealed class FisherSchemaAssertionActivator : IHostedService
+{
+    private readonly IDocumentStore _store;
+
+    public FisherSchemaAssertionActivator(IDocumentStore store) => _store = store;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+        => _store.AssertDatabaseMatchesConfigurationAsync(cancellationToken);
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/src/Fisher/FisherSystemPart.cs
+++ b/src/Fisher/FisherSystemPart.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics.CodeAnalysis;
+using Fisher.Internal;
+using JasperFx.CommandLine;
+using JasperFx.CommandLine.Descriptions;
+using JasperFx.Descriptors;
+using JasperFx.Resources;
+using Weasel.Core.CommandLine;
+
+namespace Fisher;
+
+/// <summary>
+///     Exposes a Fisher store's database file(s) to JasperFx's resource model, so
+///     <c>services.AddResourceSetupOnStartup()</c> and the <c>resources</c> / <c>describe</c> CLI
+///     commands see the store with no Fisher-specific call (fisher#172).
+/// </summary>
+/// <remarks>
+///     <para>
+///         Mirrors Marten's <c>MartenSystemPart</c> and Polecat's <c>PolecatSystemPart</c>:
+///         <see cref="FindResources" /> wraps each tenant database in a Weasel
+///         <see cref="DatabaseResource" />, which is what makes "set up the schema" a resource the host
+///         already knows how to provision.
+///     </para>
+///     <para>
+///         <b>The store is resolved lazily rather than injected</b>, because the
+///         <see cref="IConfigureFisher" /> chain has to have run before the tenancy is meaningful and
+///         that only happens on first <see cref="IDocumentStore" /> resolution. Registering the part
+///         eagerly would build the store while the container is still being assembled.
+///     </para>
+/// </remarks>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "WriteToConsole reflects over the store options for the dev-time 'describe' command only; "
+        + "the resource-setup path (FindResources/Setup) is reflection-free. AOT consumers run resource setup, "
+        + "not describe.")]
+[UnconditionalSuppressMessage("Trimming", "IL2046",
+    Justification = "Class-level: override RUC mismatch — the base WriteToConsole does not yet carry "
+        + "RequiresUnreferencedCode. Suppressed locally to match Marten's MartenSystemPart.")]
+internal class FisherSystemPart : SystemPartBase
+{
+    private readonly Func<IDocumentStore> _store;
+
+    public static Uri FisherStoreUri { get; } = new("fisher://store");
+
+    protected FisherSystemPart(Func<IDocumentStore> store, string title, Uri subjectUri) : base(title, subjectUri)
+    {
+        _store = store;
+    }
+
+    public FisherSystemPart(Func<IDocumentStore> store) : this(store, "Fisher", FisherStoreUri)
+    {
+    }
+
+    public override Task WriteToConsole()
+    {
+        var description = OptionsDescription.For(_store());
+        OptionDescriptionWriter.Write(description);
+        return Task.CompletedTask;
+    }
+
+    /// <remarks>
+    ///     A dynamic tenancy is refreshed first, or a store whose tenants come from an
+    ///     <see cref="Storage.ITenantSource" /> would report only the tenants something happened to have
+    ///     resolved already — which on a freshly started host is none of them, and "no resources" reads
+    ///     as a store with nothing to provision rather than as a question that was never asked.
+    /// </remarks>
+    public override async ValueTask<IReadOnlyList<IStatefulResource>> FindResources()
+    {
+        var tenancy = _store().Tenancy;
+
+        // Read through ITenancy rather than the store's own internal RefreshTenantsAsync, because an
+        // ancillary store arrives here as its marker DispatchProxy and is not a DocumentStore.
+        if (tenancy is Storage.DynamicTenancy dynamic)
+        {
+            await dynamic.RefreshAsync().ConfigureAwait(false);
+        }
+
+        return tenancy.AllDatabases()
+            .Select(x => new DatabaseResource(x, SubjectUri))
+            .ToArray();
+    }
+}
+
+/// <summary>
+///     Marker-typed variant of <see cref="FisherSystemPart" /> for an ancillary store registered with
+///     <c>AddFisherStore&lt;T&gt;</c>, so each store contributes its own database(s) to the resource
+///     model under a subject uri of its own.
+/// </summary>
+/// <remarks>
+///     Distinct subject uris matter more here than on either sibling: two Fisher stores are usually two
+///     <em>files</em>, so a shared uri would collapse two genuinely separate databases into one entry.
+/// </remarks>
+internal sealed class FisherSystemPart<T> : FisherSystemPart where T : class, IDocumentStore
+{
+    public FisherSystemPart(Func<T> store)
+        : base(() => store(), $"Fisher {typeof(T).Name}",
+            new Uri("fisher://" + typeof(T).Name.ToLowerInvariant()))
+    {
+    }
+}

--- a/src/Fisher/IDocumentStore.cs
+++ b/src/Fisher/IDocumentStore.cs
@@ -110,6 +110,9 @@ public interface IDocumentStore : IDisposable, IAsyncDisposable,
     /// <inheritdoc cref="DocumentStore.ApplyAllConfiguredChangesToDatabaseAsync" />
     Task ApplyAllConfiguredChangesToDatabaseAsync(CancellationToken token = default);
 
+    /// <inheritdoc cref="DocumentStore.AssertDatabaseMatchesConfigurationAsync" />
+    Task AssertDatabaseMatchesConfigurationAsync(CancellationToken token = default);
+
     /// <inheritdoc cref="DocumentStore.BuildProjectionDaemonAsync" />
     ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(
         string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null);

--- a/src/Fisher/Storage/FisherDatabaseSource.cs
+++ b/src/Fisher/Storage/FisherDatabaseSource.cs
@@ -1,0 +1,84 @@
+using JasperFx.Descriptors;
+using Weasel.Core.Migrations;
+
+namespace Fisher.Storage;
+
+/// <summary>
+///     Adapts Fisher's <see cref="ITenancy" /> to Weasel's <see cref="IDatabaseSource" />, so the
+///     <c>db-apply</c> / <c>db-assert</c> / <c>db-patch</c> / <c>db-dump</c> CLI commands discover a
+///     Fisher store's database file(s) (fisher#172).
+/// </summary>
+/// <remarks>
+///     <para>
+///         Weasel's command line resolves <see cref="IDatabaseSource" /> out of the container
+///         (<c>WeaselInput.FilterDatabases</c>). Marten satisfies that because its own <c>ITenancy</c>
+///         extends <see cref="IDatabaseSource" /> directly; Fisher's does not, and registering nothing
+///         meant every <c>db-*</c> command failed with "No Weasel databases were registered in this
+///         application" — which reads as a misconfigured host rather than as an unsupported command,
+///         and makes a CI "assert the schema matches" step impossible to write.
+///     </para>
+///     <para>
+///         <b>An adapter rather than widening <see cref="ITenancy" />, following Polecat's reasoning
+///         in polecat#501.</b> <see cref="ITenancy" /> is public and implementable outside this repo, so
+///         extending it is a breaking change — and it would pull Weasel's migration contract into
+///         Fisher's tenancy abstraction for what is purely a command-line concern. Nothing new was
+///         needed underneath: <see cref="FisherDatabase" /> already extends Weasel's
+///         <c>SqliteDatabase</c> and is therefore already an <see cref="IDatabase" />.
+///     </para>
+///     <para>
+///         <b>The store is resolved lazily, not injected</b>, for the same reason
+///         <see cref="FisherSystemPart" /> does it: the <see cref="IConfigureFisher" /> chain has to
+///         have run before the tenancy is meaningful, and that only happens on first store resolution.
+///     </para>
+/// </remarks>
+internal sealed class FisherDatabaseSource : IDatabaseSource
+{
+    private readonly Func<IDocumentStore> _store;
+
+    internal FisherDatabaseSource(Func<IDocumentStore> store)
+    {
+        _store = store;
+    }
+
+    private ITenancy Tenancy => _store().Tenancy;
+
+    public DatabaseCardinality Cardinality => Tenancy.Cardinality;
+
+    /// <remarks>
+    ///     A dynamic tenancy is refreshed first — a tenant nothing has resolved yet still has a file to
+    ///     migrate, and <c>db-apply</c> silently skipping it is exactly the failure this whole seam
+    ///     exists to stop.
+    /// </remarks>
+    public async ValueTask<IReadOnlyList<IDatabase>> BuildDatabases()
+    {
+        var tenancy = Tenancy;
+
+        if (tenancy is DynamicTenancy dynamic)
+        {
+            await dynamic.RefreshAsync().ConfigureAwait(false);
+        }
+
+        return tenancy.AllDatabases();
+    }
+
+    public async ValueTask<DatabaseUsage> DescribeDatabasesAsync(CancellationToken token)
+    {
+        var tenancy = Tenancy;
+        var databases = await BuildDatabases().ConfigureAwait(false);
+
+        if (tenancy.Cardinality == DatabaseCardinality.Single)
+        {
+            return new DatabaseUsage
+            {
+                Cardinality = DatabaseCardinality.Single,
+                MainDatabase = databases.Count == 1 ? databases[0].Describe() : tenancy.Default.Describe()
+            };
+        }
+
+        return new DatabaseUsage
+        {
+            Cardinality = tenancy.Cardinality,
+            Databases = databases.Select(x => x.Describe()).ToList()
+        };
+    }
+}


### PR DESCRIPTION
Closes #172. Stoat plan `fisher-marten-parity`, node `cli-integration`.

`AddFisher` registered the store, sessions and its three conditional hosted services, and **nothing the JasperFx or Weasel command line looks for**. `grep -rn "ISystemPart\|IDatabaseSource" src/Fisher` returned nothing. The consequences were not cosmetic:

- `dotnet run -- db-apply` / `db-assert` / `db-patch` / `db-dump` failed with *"No Weasel databases were registered in this application"* — which reads as a misconfigured host rather than an unsupported command.
- `resources list / setup / check` and `services.AddResourceSetupOnStartup()` found no Fisher resource.
- A CI step of "assert the deployed schema still matches what the code configures" was not expressible for a Fisher application at all.

## Two registrations, not one

The two command families resolve different things, and registering one leaves the other reporting an empty application:

| Surface | Resolves | Now supplied by |
|---|---|---|
| `resources setup/list/check`, `AddResourceSetupOnStartup()`, `describe` | `JasperFx.CommandLine.Descriptions.ISystemPart` | `FisherSystemPart` / `FisherSystemPart<T>` |
| `db-apply` / `db-assert` / `db-patch` / `db-dump` | `Weasel.Core.Migrations.IDatabaseSource` | `FisherDatabaseSource` |

Registered from **both** `AddFisher(...)` and `AddFisherStore<T>(...)`, the ancillary case under a subject uri of the marker's own (`fisher://iotherstore`). That distinction matters more here than on either sibling: a second Fisher store is usually a second **file**, so collapsing the two would hide one from `resources list` outright and migrate only one under `db-apply`, rather than merely mislabelling a schema.

### Decisions worth reviewing

- **`FisherDatabaseSource` adapts `ITenancy` rather than widening it**, following polecat#501's reasoning. Marten satisfies the Weasel half because its own `ITenancy` *is* an `IDatabaseSource`; Fisher's is public and implementable outside this repo, so extending it is a breaking change — and it would pull a migration contract into a tenancy abstraction for what is purely a CLI concern. Nothing was needed underneath: `FisherDatabase` already extends Weasel's `SqliteDatabase`.
- **Both take a factory, never the resolved store.** The `IConfigureFisher` chain has to have run before the tenancy means anything, and that only happens on first `IDocumentStore` resolution.
- **Both refresh a `DynamicTenancy` first.** A tenant nothing has resolved yet still has a file to migrate, and `db-apply` skipping it silently is exactly the failure this closes. Read through `ITenancy` rather than the store's internal `RefreshTenantsAsync`, because an ancillary store arrives as its marker `DispatchProxy` and is not a `DocumentStore`.
- **Neither ancillary registration unwraps the proxy**, unlike the `IEventStore` bridge beside them — correct rather than an oversight, since both reach the store only through `IDocumentStore` members a marker interface inherits.

## `AssertDatabaseMatchesConfigurationOnStartup()`

The third opt-in beside `ApplyAllDatabaseChangesOnStartup()` and `SeedInitialDataOnStartup()`, over a new `IDocumentStore.AssertDatabaseMatchesConfigurationAsync` that spans every tenant database.

- **The two schema opt-ins are refused together, in either order.** Applying the changes at startup makes the assertion a check on the schema that same startup just wrote, so a host asking for both is expressing a contradiction rather than being careful — and accepting it silently would leave somebody believing they had a guard they do not have.
- **`AutoCreate.None` is deliberately not consulted**, where the migration activator honours it. That setting says the schema is not Fisher's to change, and this changes nothing — declining to *verify* because the store was told not to *write* would make the strictest configuration the one with the fewest guarantees.
- **A seeder may follow either activator now.** What `SeedInitialDataOnStartup` needs is that the tables exist by the time it runs, and an assertion that passed is exactly that claim.

## Tests

16 new, in `command_line_integration`. **They run the commands rather than asserting on registrations**, and that is the point: a registration test passes against a source that resolves, enumerates nothing and reports success — which is `db-assert` answering "everything matches" about a store it never looked at.

`db-apply` creates the schema; `db-assert` fails before it and passes after; `db-patch` and `db-dump` write real DDL naming `fi_events` and `fi_doc_clitarget`; `describe` exits 0; `AddResourceSetupOnStartup()` provisions the schema with no Fisher-specific call. Plus the database-per-tenant fan-out, the ancillary-store pair, and the startup assertion in both directions.

They needed a new `ConsoleWritingCollection`: `Console.SetOut` is process-wide, `CliJsonCapture` was already swapping it for `event_query_command`, and two tests printing JSON objects at once made that capture parse somebody else's report. Same family as the process-wide `ActivityListener` lesson the tracing tests record.

## Validation

Local, both TFMs, no docker (SQLite only):

- `net10.0` — Fisher.Tests **1516**, Fisher.AspNetCore.Tests **36**, Fisher.EntityFrameworkCore.Tests **19**. 0 failed.
- `net9.0` — same three, same counts. 0 failed.
- `python3 scripts/check_scoreboard.py --tfm net10.0 --configuration Release` → *"Scoreboard agrees with the net10.0 run: 1571 tests, 391 compliance across 40 suites (33 event / 7 document)."*

HANDOFF.md and README.md counts reconciled from that run (1571 total / 1516 in `Fisher.Tests`), after merging `origin/main`, which had moved the baseline to 1555/1500.

GitHub Actions is stalled org-wide, so CI is not a gate on this one; the numbers above are from a real local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)