### PR TITLE
Fix the net9.0 CI leg broken by the benchmarks project

### DIFF
--- a/.github/workflows/fisher.yml
+++ b/.github/workflows/fisher.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Restore
         run: dotnet restore fisher.slnx
 
+      # Built without -f: Fisher.Benchmarks is deliberately net10.0-only (a perf harness is run,
+      # not shipped), and a solution-wide `-f net9.0` fails on it with NETSDK1005. Building every
+      # target framework here costs a little time and keeps the test steps below, which invoke the
+      # per-framework MTP executables out of bin/Release/<tfm>/, working unchanged.
       - name: Build
-        run: dotnet build fisher.slnx -c Release -f ${{ matrix.tfm }} --no-restore
+        run: dotnet build fisher.slnx -c Release --no-restore
 
       # No database service. Fisher is SQLite-backed and the suites create throwaway database files
       # under the runner's temp directory, so there is nothing to spin up or wait for.


### PR DESCRIPTION
`Fisher.Benchmarks` (from #169) is deliberately net10.0-only, but `.github/workflows/fisher.yml` builds `fisher.slnx -c Release -f \${{ matrix.tfm }}`, so the **net9.0 job now fails with NETSDK1005** on a clean checkout of main. Found by the merge-train agent while landing #170; reproduced locally before and after.

Fix: drop `-f` from the build step. The test steps already run the per-framework MTP executables out of `bin/Release/<tfm>/`, so they are unchanged; the cost is that each matrix job builds both target frameworks.

Verified locally on this branch: the old command still reproduces NETSDK1005, the new one builds the solution with 0 errors.

Local runs are the gate per the September policy; org Actions runners are stalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)