### PR TITLE
gh-173: AdvancedOperations parity — the daemon escape hatches, projection progress, single-stream rebuild, tenant data wipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,9 @@ Working, with tests:
 - `EventOperations` implements the full `IEventStoreOperations` — see below for which members throw
 - Document storage over Guid, string, int and long ids; numeric ids via Hi-Lo sequences (`fi_hilo`)
 - `EventProjection.storeEntity` — an `EventProjection`'s `Create`/`Project` results are stored inline
-- `DocumentStore.Advanced` — `Clean`, `ResetAllDataAsync`, `ResetHiloSequenceFloorAsync<T>`
+- `DocumentStore.Advanced` — `Clean`, `ResetAllDataAsync`, `ResetHiloSequenceFloorAsync<T>`, the
+  daemon escape hatches (`AdvanceHighWaterMarkToLatestAsync`, `TryCorrectProgressInDatabaseAsync`),
+  the projection progress reads, `RebuildSingleStreamAsync<T>` and `DeleteAllTenantDataAsync`
 - `DocumentStore : IEventStore` — the explorer reads (`GetRecentStreamsAsync`,
   `GetStreamMetadataAsync`) and `TryCreateUsage`; see below
 - **LINQ** — `session.Query<T>()` over `json_extract`: where, ordering, paging, projections, grouping,
@@ -2731,6 +2733,71 @@ the projection scenario harness (fisher#42). Four independent pieces, none large
   projections own, **not every table**: a scenario is entitled to seed documents its projections do not
   produce, and clearing those would make the harness quietly destructive.
   `the_teardown_leaves_unrelated_documents_alone` pins it.
+
+### `Advanced` — the daemon escape hatches, single-stream rebuild and the tenant wipe
+
+fisher#173 — the `AdvancedOperations` members Marten carries and Fisher did not. Four independent
+pieces; two of them are operational escape hatches whose value is that they exist before you need
+them.
+
+- **`AdvanceHighWaterMarkToLatestAsync`** moves the high-water mark straight to `max(seq_id)`, for
+  retrofitting async projections onto a store that has never had any — otherwise the mark climbs from
+  zero, which on a large store is a long read with nothing to show for it. **It advances the mark and
+  not the shards**, which is the half that decides whether it is the right call: a shard with no
+  progression row still starts at zero, so this is for a store whose projections are new *and* whose
+  history is genuinely not wanted. Spans every database, with a tenant-scoped overload that means
+  something only under database-per-tenant — a conjoined store has one global sequence however many
+  tenants write into it.
+- **`TryCorrectProgressInDatabaseAsync`** pulls a progression row that has advanced past the highest
+  sequence back down to it. **Reachable here through an ordinary supported operation, where Marten
+  carries the same method for a PostgreSQL race it believes it has closed**: `seq_id` is
+  `AUTOINCREMENT`, and stream compacting and event masking both delete rows, so removing events from
+  the top of the table lowers `max(seq_id)` below progress already recorded. A shard stranded above
+  the ceiling never advances again and `QueryForNonStaleData` waits on it forever, with nothing saying
+  why.
+  - **Clamped per row, where Marten resets every row wholesale** the moment the high-water row is
+    ahead. That drags a shard genuinely *behind* the head forward, past events it never applied —
+    silently, and on the very store somebody is already repairing.
+    `correcting_leaves_a_shard_that_is_merely_behind_alone` is the discriminating fact.
+- **`AllProjectionProgress` / `ProjectionProgressFor` / `AllAsyncProjectionShardNames`** were a
+  surfacing job rather than new machinery: the first two have been on `FisherDatabase` since the
+  daemon landed, reachable only by casting the store to `IEventStore` and walking `AllDatabases()`. An
+  omitted tenant id spans every database — concatenating for the first, taking the highest for the
+  second — which under database-per-tenant means one shard name appears once per tenant, deliberately:
+  collapsing them would have to pick a winner, and "at 40 for one tenant and 900 for another" is what
+  an operator came to find out.
+- **`RebuildSingleStreamAsync<T>`** live-aggregates one stream and stores the result, for the repair
+  that does not need the daemon.
+  - **A stream that folds to nothing deletes the document, where Marten's throws from inside
+    `Store(null!)`.** That case is not exotic — a `ShouldDelete` that fired, an archived stream, an id
+    with no events — and "no document" is exactly what a real rebuild leaves for such a stream, since
+    teardown clears the rows and the replay never recreates that one. Throwing would make the method
+    unusable on the streams most likely to have gone wrong.
+  - **Refused by name for a type with no Fisher mapping.** A projection registered through
+    `Projections.StorageProviders` (an EF Core entity) is deliberately never mapped, so `Store` would
+    create a `fi_doc_*` table nothing else ever reads — a rebuild that silently wrote to the wrong
+    place.
+- **`DeleteAllTenantDataAsync`**, and the distinction it rests on. **Fisher refuses tenant
+  *deletion*** — deprovisioning here means deleting a *file*, the cheapest deprovisioning of any
+  Critter Stack store and the most irreversible, and Fisher cannot know whether that file is backed up
+  (see "Runtime tenants"). Wiping a tenant's *rows* is a different operation: it destroys nothing a
+  file restore would be needed to recover, it is the only way to erase a conjoined tenant at all, and
+  nothing covered it.
+  - **Under database-per-tenant it clears the tenant's file and keeps it**, so the tenant goes on
+    working and simply has no data. Removing the file stays the operator's act.
+  - **Tag rows go first, through their events.** `fi_event_tag_*` carries no tenant of its own and has
+    a real foreign key to `fi_events(seq_id)`, so the delete is a subselect and it has to precede the
+    events — fisher#6's ordering met again with a tenant predicate on it.
+  - **Progression rows are left alone**, under either tenancy. They describe how far the daemon read,
+    not what a tenant owns, and clearing them would make every shard replay a store that is now empty.
+    That is also why this needs no daemon pause, unlike `ResetAllDataAsync`.
+  - ⚠️ **"Has a `tenant_id` column" is not the question, and reading it as one makes the refusal
+    unreachable.** `fi_events`, `fi_streams` and `fi_dead_letters` carry the column on *every* store —
+    the event tables get it with a default under non-conjoined tenancy, and a dead letter records the
+    failing event's tenant as ordinary data. What the guard asks is what the store was *configured* to
+    slice by: a database per tenant, conjoined events, or at least one `MultiTenanted()` document type,
+    which is the only thing that puts the column on a `fi_doc_*` table. A store with none of those is
+    refused by name rather than reporting a successful erasure of nothing.
 
 ### `Advanced` and cleaning
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1263,7 +1263,10 @@ Each of these is a decision with a reason, not an oversight:
   `MetadataForAsync` reads the column regardless, so the value is reachable even though no member can
   hold it.
 - **Tenants can be deprovisioned but never deleted**, which is the one deliberate limit left in the
-  tenancy story rather than a stage it stops at. Both styles ship: conjoined (one file sliced by a
+  tenancy story rather than a stage it stops at. **`Advanced.DeleteAllTenantDataAsync` is not a
+  softening of that** (fisher#173): wiping a tenant's *rows* destroys nothing a file restore would be
+  needed to recover, and under database-per-tenant it clears the tenant's file and keeps it. Removing
+  the file stays the operator's act. Both styles ship: conjoined (one file sliced by a
   tenant id column, pinned cross-store by `ConjoinedEventTenancyCompliance`), database-per-tenant
   (#47), and tenants that appear, suspend and resume at runtime (#58) — with the daemon routed per
   database, which is what fisher#57 made those `IEventDatabase` parameters carry. Deleting a tenant

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1571 tests green on net9.0 and net10.0**, with no known intermittent failures — 1516 in
+**1593 tests green on net9.0 and net10.0**, with no known intermittent failures — 1538 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 391 of
 them are shared cross-store compliance tests — 322 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 40 suites and 391 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,516.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,538.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/src/Fisher.Tests/Configuration/advanced_daemon_and_tenant_operations.cs
+++ b/src/Fisher.Tests/Configuration/advanced_daemon_and_tenant_operations.cs
@@ -1,0 +1,571 @@
+using Fisher.Linq;
+using Fisher.Tests.Events;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Tags;
+using JasperFx.MultiTenancy;
+using Microsoft.Data.Sqlite;
+
+namespace Fisher.Tests.Configuration;
+
+/// <summary>
+///     fisher#173 — the <c>AdvancedOperations</c> members Marten carries and Fisher did not: the
+///     unstick-the-daemon pair, the projection progress reads, single-stream rebuild, and wiping one
+///     tenant's rows.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Two of these are operational escape hatches whose whole value is that they exist before you
+///         need them, so the tests are about the states they repair rather than about the calls
+///         succeeding: a store whose projections are being retrofitted, and a store whose progression
+///         has been left above the highest sequence there is.
+///     </para>
+/// </remarks>
+public class advanced_daemon_and_tenant_operations : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("advanced-daemon");
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        _database.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private async Task<DocumentStore> StoreAsync(Action<StoreOptions>? extra = null)
+    {
+        var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            extra?.Invoke(options);
+        });
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        return store;
+    }
+
+    private async Task AppendAsync(DocumentStore store, int count, string? tenantId = null)
+    {
+        await using var session = store.LightweightSession(tenantId);
+
+        for (var i = 0; i < count; i++)
+        {
+            session.Events.StartStream(Guid.NewGuid(), new QuestStarted($"Quest {i}"));
+        }
+
+        await session.SaveChangesAsync(Token);
+    }
+
+    // ---- AdvanceHighWaterMarkToLatestAsync ----
+
+    /// <remarks>
+    ///     The retrofit case: a large store that has never run a projection, where the mark climbing
+    ///     from zero is a long read with nothing to show for it.
+    /// </remarks>
+    [Fact]
+    public async Task advancing_the_high_water_mark_puts_it_at_the_highest_sequence()
+    {
+        await using var store = await StoreAsync();
+        await AppendAsync(store, 7);
+
+        (await store.Advanced.ProjectionProgressFor(new ShardName(ShardState.HighWaterMark), token: Token))
+            .ShouldBe(0);
+
+        await store.Advanced.AdvanceHighWaterMarkToLatestAsync(Token);
+
+        (await store.Advanced.ProjectionProgressFor(new ShardName(ShardState.HighWaterMark), token: Token))
+            .ShouldBe(7);
+    }
+
+    /// <remarks>
+    ///     It advances the <em>mark</em>, not the shards — which is the half that decides whether this
+    ///     is the right call for a store. A shard with no row still starts at zero, so a projection
+    ///     registered after this still replays everything unless its own row is moved too.
+    /// </remarks>
+    [Fact]
+    public async Task advancing_the_mark_leaves_the_shards_where_they_were()
+    {
+        await using var store = await StoreAsync(o => o.Projections.Snapshot<TallySnapshot>(SnapshotLifecycle.Async));
+        await AppendAsync(store, 4);
+
+        await store.Advanced.AdvanceHighWaterMarkToLatestAsync(Token);
+
+        var shard = store.Advanced.AllAsyncProjectionShardNames().ShouldHaveSingleItem();
+        (await store.Advanced.ProjectionProgressFor(shard, token: Token)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task advancing_an_empty_store_records_zero_rather_than_failing()
+    {
+        await using var store = await StoreAsync();
+
+        await store.Advanced.AdvanceHighWaterMarkToLatestAsync(Token);
+
+        (await store.Advanced.ProjectionProgressFor(new ShardName(ShardState.HighWaterMark), token: Token))
+            .ShouldBe(0);
+    }
+
+    // ---- TryCorrectProgressInDatabaseAsync ----
+
+    /// <remarks>
+    ///     <b>Reachable on Fisher through a supported operation</b>, where Marten carries the same
+    ///     method for a PostgreSQL race it believes it has closed: <c>seq_id</c> is
+    ///     <c>AUTOINCREMENT</c>, and compacting and masking both delete rows, so removing events from
+    ///     the top lowers <c>max(seq_id)</c> below progress already recorded. Planted with raw SQL here
+    ///     because the state is what matters, not how it arose.
+    /// </remarks>
+    [Fact]
+    public async Task correcting_pulls_a_stranded_row_back_to_the_ceiling()
+    {
+        await using var store = await StoreAsync();
+        await AppendAsync(store, 3);
+
+        await PlantProgressionAsync("HighWaterMark", 99);
+
+        await store.Advanced.TryCorrectProgressInDatabaseAsync(Token);
+
+        (await store.Advanced.ProjectionProgressFor(new ShardName(ShardState.HighWaterMark), token: Token))
+            .ShouldBe(3);
+    }
+
+    /// <remarks>
+    ///     <b>The discriminating fact against Marten's implementation, which resets every row
+    ///     wholesale</b> the moment the high-water row is ahead. That drags a shard genuinely behind the
+    ///     head <em>forward</em>, past events it never applied — silently, and on the very store
+    ///     somebody is repairing. Only the impossible row moves here.
+    /// </remarks>
+    [Fact]
+    public async Task correcting_leaves_a_shard_that_is_merely_behind_alone()
+    {
+        await using var store = await StoreAsync();
+        await AppendAsync(store, 10);
+
+        await PlantProgressionAsync("HighWaterMark", 44);
+        await PlantProgressionAsync("Catching:All", 2);
+
+        await store.Advanced.TryCorrectProgressInDatabaseAsync(Token);
+
+        (await ProgressionAsync("HighWaterMark")).ShouldBe(10);
+        (await ProgressionAsync("Catching:All")).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task correcting_a_healthy_store_changes_nothing()
+    {
+        await using var store = await StoreAsync();
+        await AppendAsync(store, 5);
+        await PlantProgressionAsync("HighWaterMark", 5);
+
+        await store.Advanced.TryCorrectProgressInDatabaseAsync(Token);
+
+        (await ProgressionAsync("HighWaterMark")).ShouldBe(5);
+    }
+
+    // ---- the progression reads ----
+
+    [Fact]
+    public async Task all_projection_progress_reports_every_row()
+    {
+        await using var store = await StoreAsync();
+        await AppendAsync(store, 6);
+
+        await PlantProgressionAsync("HighWaterMark", 6);
+        await PlantProgressionAsync("Catching:All", 4);
+
+        var states = await store.Advanced.AllProjectionProgress(token: Token);
+
+        states.Count.ShouldBe(2);
+        states.Single(x => x.ShardName == "Catching:All").Sequence.ShouldBe(4);
+    }
+
+    /// <remarks>
+    ///     Zero rather than an error for a shard nothing has recorded, which is what the daemon itself
+    ///     reads as "start from the beginning" — a missing row and a row at zero mean the same thing.
+    /// </remarks>
+    [Fact]
+    public async Task progress_for_a_shard_with_no_row_is_zero()
+    {
+        await using var store = await StoreAsync();
+
+        (await store.Advanced.ProjectionProgressFor(new ShardName("Nothing"), token: Token)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task async_shard_names_cover_the_registered_async_projections_only()
+    {
+        await using var store = await StoreAsync(o =>
+        {
+            o.Projections.Snapshot<TallySnapshot>(SnapshotLifecycle.Async);
+            o.Projections.Snapshot<InlineTally>(SnapshotLifecycle.Inline);
+        });
+
+        var names = store.Advanced.AllAsyncProjectionShardNames();
+
+        // Inline has no shard because it has no progress to record.
+        names.ShouldHaveSingleItem().Identity.ShouldContain(nameof(TallySnapshot));
+    }
+
+    // ---- RebuildSingleStreamAsync ----
+
+    [Fact]
+    public async Task rebuilding_one_stream_repairs_its_document()
+    {
+        await using var store = await StoreAsync(o => o.Projections.Snapshot<TallySnapshot>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<TallySnapshot>(streamId, new MemberJoined("a"), new MemberJoined("b"));
+            await session.SaveChangesAsync(Token);
+        }
+
+        // Corrupt the read model out of band, which is the state this method exists to repair.
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new TallySnapshot { Id = streamId, Members = 99 });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await store.Advanced.RebuildSingleStreamAsync<TallySnapshot>(streamId, token: Token);
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<TallySnapshot>(streamId, Token))!.Members.ShouldBe(2);
+    }
+
+    /// <remarks>
+    ///     <b>Where Marten's equivalent throws from inside <c>Store(null!)</c>.</b> A stream that folds
+    ///     to nothing is not exotic — a <c>ShouldDelete</c> that fired, or an id with no events at all —
+    ///     and "no document" is exactly what a real rebuild leaves for such a stream, since teardown
+    ///     clears the rows and the replay never recreates that one.
+    /// </remarks>
+    [Fact]
+    public async Task rebuilding_a_stream_that_folds_to_nothing_removes_the_document()
+    {
+        await using var store = await StoreAsync(o => o.Projections.Snapshot<TallySnapshot>(SnapshotLifecycle.Inline));
+
+        var orphan = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new TallySnapshot { Id = orphan, Members = 5 });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await store.Advanced.RebuildSingleStreamAsync<TallySnapshot>(orphan, token: Token);
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<TallySnapshot>(orphan, Token)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task rebuilding_a_string_identified_stream_works_too()
+    {
+        await using var store = await StoreAsync(o =>
+        {
+            o.Events.StreamIdentity = JasperFx.Events.StreamIdentity.AsString;
+            o.Projections.Snapshot<KeyedTally>(SnapshotLifecycle.Inline);
+        });
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<KeyedTally>("quest-1", new MemberJoined("a"));
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new KeyedTally { Id = "quest-1", Members = 77 });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await store.Advanced.RebuildSingleStreamAsync<KeyedTally>("quest-1", token: Token);
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<KeyedTally>("quest-1", Token))!.Members.ShouldBe(1);
+    }
+
+    /// <remarks>
+    ///     A type registered through <c>Projections.StorageProviders</c> is deliberately never mapped,
+    ///     so <c>Store</c> would create a <c>fi_doc_*</c> table nothing else ever reads — a rebuild that
+    ///     silently wrote to the wrong place. Refused by name rather than half-working.
+    /// </remarks>
+    [Fact]
+    public async Task rebuilding_a_type_with_no_fisher_mapping_is_refused_by_name()
+    {
+        await using var store = await StoreAsync();
+
+        var ex = await Should.ThrowAsync<NotSupportedException>(() =>
+            store.Advanced.RebuildSingleStreamAsync<UnmappedTally>(Guid.NewGuid(), token: Token));
+
+        ex.Message.ShouldContain("StorageProviders");
+        ex.Message.ShouldContain("RebuildProjectionAsync");
+    }
+
+    // ---- DeleteAllTenantDataAsync ----
+
+    private Task<DocumentStore> ConjoinedStoreAsync() => StoreAsync(o =>
+    {
+        o.Events.TenancyStyle = TenancyStyle.Conjoined;
+        o.Schema.For<TenantedNote>().MultiTenanted();
+    });
+
+    /// <remarks>
+    ///     <b>The distinction this method rests on.</b> Fisher refuses tenant <em>deletion</em>, because
+    ///     deprovisioning here means deleting a file it cannot know is backed up. Wiping a conjoined
+    ///     tenant's rows destroys nothing a file restore would be needed to recover, and is the only way
+    ///     to erase such a tenant at all.
+    /// </remarks>
+    [Fact]
+    public async Task deleting_one_conjoined_tenants_data_leaves_the_other_tenant_alone()
+    {
+        await using var store = await ConjoinedStoreAsync();
+
+        await AppendAsync(store, 3, "blue");
+        await AppendAsync(store, 2, "green");
+
+        await using (var session = store.LightweightSession("blue"))
+        {
+            session.Store(new TenantedNote { Id = Guid.NewGuid(), Text = "blue note" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using (var session = store.LightweightSession("green"))
+        {
+            session.Store(new TenantedNote { Id = Guid.NewGuid(), Text = "green note" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await store.Advanced.DeleteAllTenantDataAsync("blue", Token);
+
+        (await CountAsync("fi_events", "blue")).ShouldBe(0);
+        (await CountAsync("fi_streams", "blue")).ShouldBe(0);
+        (await CountAsync("fi_doc_tenantednote", "blue")).ShouldBe(0);
+
+        (await CountAsync("fi_events", "green")).ShouldBe(2);
+        (await CountAsync("fi_streams", "green")).ShouldBe(2);
+        (await CountAsync("fi_doc_tenantednote", "green")).ShouldBe(1);
+    }
+
+    /// <remarks>
+    ///     A tag row carries no tenant of its own and has a real foreign key to <c>fi_events(seq_id)</c>,
+    ///     so it has to be reached through its events and deleted first. Without that this fails with
+    ///     <c>FOREIGN KEY constraint failed</c> — the ordering fisher#6 established for
+    ///     <c>DeleteAllEventDataAsync</c>, met again with a tenant predicate on it.
+    /// </remarks>
+    [Fact]
+    public async Task deleting_a_tenants_data_clears_the_tag_rows_of_its_events_first()
+    {
+        await using var store = await StoreAsync(o =>
+        {
+            o.Events.TenancyStyle = TenancyStyle.Conjoined;
+            o.Events.RegisterTagType<QuestTag>("quest");
+        });
+
+        await using (var session = store.LightweightSession("blue"))
+        {
+            var started = session.Events.BuildEvent(new QuestStarted("blue"));
+            started.WithTag(new QuestTag(Guid.NewGuid()));
+            session.Events.StartStream(Guid.NewGuid(), started);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using (var session = store.LightweightSession("green"))
+        {
+            var started = session.Events.BuildEvent(new QuestStarted("green"));
+            started.WithTag(new QuestTag(Guid.NewGuid()));
+            session.Events.StartStream(Guid.NewGuid(), started);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await store.Advanced.DeleteAllTenantDataAsync("blue", Token);
+
+        (await CountAsync("fi_events", "blue")).ShouldBe(0);
+        (await CountAsync("fi_events", "green")).ShouldBe(1);
+        (await ScalarAsync("select count(*) from fi_event_tag_quest")).ShouldBe(1);
+    }
+
+    /// <remarks>
+    ///     Under database-per-tenant the whole file is the tenant's, so this clears it — and
+    ///     <b>leaves the file, its schema and its pooled connections where they were</b>. Removing the
+    ///     file stays the operator's act, which is the limit Fisher's tenancy story keeps.
+    /// </remarks>
+    [Fact]
+    public async Task deleting_a_tenants_data_under_database_per_tenant_clears_the_file_and_keeps_it()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "fisher-tenant-wipe-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            await using var store = DocumentStore.For(options =>
+            {
+                options.AutoCreateSchemaObjects = AutoCreate.All;
+                options.MultiTenantedDatabases(x => x.InDirectory(directory).AddTenants("one", "two"));
+            });
+
+            await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+            await AppendAsync(store, 3, "one");
+            await AppendAsync(store, 2, "two");
+
+            await store.Advanced.DeleteAllTenantDataAsync("one", Token);
+
+            await using (var session = store.QuerySession("one"))
+            {
+                (await session.Events.QueryEventsAsync(new JasperFx.Events.EventQuery(), Token)).Events
+                    .ShouldBeEmpty();
+            }
+
+            // The file is still there and still works — a store that had deleted it would fail here.
+            await AppendAsync(store, 1, "one");
+
+            await using var after = store.QuerySession("one");
+            (await after.Events.QueryEventsAsync(new JasperFx.Events.EventQuery(), Token)).Events.Count
+                .ShouldBe(1);
+        }
+        finally
+        {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <remarks>
+    ///     Refused rather than silently doing nothing, which would report a successful erasure of a
+    ///     tenant that has no rows because it has no column to have them under — the worst possible
+    ///     answer to a compliance request.
+    /// </remarks>
+    [Fact]
+    public async Task deleting_tenant_data_from_a_store_with_no_tenanted_data_is_refused_by_name()
+    {
+        await using var store = await StoreAsync();
+
+        var ex = await Should.ThrowAsync<NotSupportedException>(() =>
+            store.Advanced.DeleteAllTenantDataAsync("blue", Token));
+
+        ex.Message.ShouldContain("Conjoined");
+        ex.Message.ShouldContain("Advanced.Clean");
+    }
+
+    [Fact]
+    public async Task deleting_an_unknown_tenants_data_under_database_per_tenant_is_refused()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "fisher-tenant-unknown-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            await using var store = DocumentStore.For(options =>
+            {
+                options.AutoCreateSchemaObjects = AutoCreate.All;
+                options.MultiTenantedDatabases(x => x.InDirectory(directory).AddTenants("one"));
+            });
+
+            await Should.ThrowAsync<Storage.UnknownTenantException>(() =>
+                store.Advanced.DeleteAllTenantDataAsync("nobody", Token));
+        }
+        finally
+        {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <remarks>
+    ///     The progression rows describe how far the daemon read, not what a tenant owns — clearing them
+    ///     would make every shard replay a store that is now empty.
+    /// </remarks>
+    [Fact]
+    public async Task deleting_a_tenants_data_leaves_the_progression_rows_alone()
+    {
+        await using var store = await ConjoinedStoreAsync();
+
+        await AppendAsync(store, 2, "blue");
+        await PlantProgressionAsync("HighWaterMark", 2);
+
+        await store.Advanced.DeleteAllTenantDataAsync("blue", Token);
+
+        (await ProgressionAsync("HighWaterMark")).ShouldBe(2);
+    }
+
+    // ---- raw probes ----
+
+    private async Task PlantProgressionAsync(string name, long sequence)
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              insert into fi_event_progression (name, last_seq_id, last_updated)
+                              values ($name, $seq, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+                              on conflict (name) do update set last_seq_id = excluded.last_seq_id;
+                              """;
+        command.Parameters.AddWithValue("$name", name);
+        command.Parameters.AddWithValue("$seq", sequence);
+
+        await command.ExecuteNonQueryAsync(Token);
+    }
+
+    private async Task<long> ProgressionAsync(string name)
+        => await ScalarAsync($"select coalesce((select last_seq_id from fi_event_progression where name = '{name}'), -1)");
+
+    private Task<long> CountAsync(string table, string tenantId)
+        => ScalarAsync($"select count(*) from \"{table}\" where tenant_id = '{tenantId}'");
+
+    private async Task<long> ScalarAsync(string sql)
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        return Convert.ToInt64(await command.ExecuteScalarAsync(Token));
+    }
+}
+
+public class TallySnapshot
+{
+    public Guid Id { get; set; }
+    public int Members { get; set; }
+
+    public void Apply(MemberJoined joined) => Members++;
+}
+
+public class InlineTally
+{
+    public Guid Id { get; set; }
+    public int Members { get; set; }
+
+    public void Apply(MemberJoined joined) => Members++;
+}
+
+public class KeyedTally
+{
+    public string Id { get; set; } = string.Empty;
+    public int Members { get; set; }
+
+    public void Apply(MemberJoined joined) => Members++;
+}
+
+/// <summary>
+///     Never registered as a document type, standing in for a projection whose storage is somewhere
+///     Fisher does not own.
+/// </summary>
+public class UnmappedTally
+{
+    public Guid Id { get; set; }
+}
+
+public readonly record struct QuestTag(Guid Value);
+
+public class TenantedNote
+{
+    public Guid Id { get; set; }
+    public string Text { get; set; } = string.Empty;
+}

--- a/src/Fisher/AdvancedOperations.cs
+++ b/src/Fisher/AdvancedOperations.cs
@@ -1,3 +1,5 @@
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
 using JasperFx.Events.Protected;
 using Weasel.Core.Sequences;
 
@@ -77,6 +79,48 @@ public class AdvancedOperations
                 await daemons.ResumeAsync().ConfigureAwait(false);
             }
         }
+    }
+
+    /// <summary>
+    ///     Delete every row belonging to one tenant, keeping the schema — and, under
+    ///     database-per-tenant, the tenant's file (fisher#173).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>This is not the tenant deletion Fisher refuses, and the difference is the point.</b>
+    ///         Deprovisioning a tenant here means deleting a <em>file</em>: the cheapest deprovisioning
+    ///         of any Critter Stack store and the most irreversible, and Fisher cannot know whether that
+    ///         file is backed up — so <see cref="Storage.ITenantSource" /> suspends or forgets and an
+    ///         operator removes the file themselves. Wiping a tenant's <em>rows</em> is a different
+    ///         operation: it destroys nothing a file restore would be needed to recover, it is the only
+    ///         way to erase a conjoined tenant at all, and nothing covered it.
+    ///     </para>
+    ///     <para>
+    ///         Under conjoined tenancy every table carrying a <c>tenant_id</c> is filtered on it — the
+    ///         event store, the tenanted document types, the natural key lookups and the dead letters —
+    ///         and the DCB tag rows go through their events, since a tag has no tenant of its own.
+    ///         Under database-per-tenant the tenant's whole file is cleared, progression rows excepted:
+    ///         they describe how far the daemon read, not what a tenant owns, and resetting them would
+    ///         make every shard replay a store that is now empty.
+    ///     </para>
+    ///     <para>
+    ///         <b>One transaction per database, and nothing else is paused.</b> Unlike
+    ///         <see cref="ResetAllDataAsync" /> this leaves <c>fi_event_progression</c> alone, so a
+    ///         running daemon is not stranded and does not need pausing.
+    ///     </para>
+    /// </remarks>
+    /// <exception cref="NotSupportedException">
+    ///     The store keeps no tenant-scoped data at all, so there is nothing that could be this tenant's
+    ///     to delete. Refused rather than reporting a successful erasure of nothing.
+    /// </exception>
+    /// <exception cref="Storage.UnknownTenantException">
+    ///     Database-per-tenant, and this store has no database for that tenant.
+    /// </exception>
+    public Task DeleteAllTenantDataAsync(string tenantId, CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        return new Internal.TenantDataCleaner(tenantId, _store).ExecuteAsync(token);
     }
 
     /// <summary>
@@ -341,6 +385,267 @@ public class AdvancedOperations
     /// <inheritdoc cref="ToDatabaseScript" />
     public Task WriteCreationScriptToFileAsync(string path, CancellationToken token = default)
         => _store.Database.WriteCreationScriptToFileAsync(path, token);
+
+    // ---- the daemon's progression: reading it, and the two ways of unsticking it (fisher#173) ----
+
+    /// <summary>
+    ///     Move the high-water mark straight to the highest sequence present, so a daemon starts in
+    ///     catch-up mode instead of replaying a store's whole history. <b>Use with caution.</b>
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>For retrofitting async projections onto a large event store that has never had
+    ///         any.</b> Without this the high-water agent climbs from zero, which on a store with
+    ///         millions of events is a long, entirely pointless read.
+    ///     </para>
+    ///     <para>
+    ///         What it skips is the <em>mark's</em> climb, not the shards'. A registered shard still
+    ///         starts from its own progression row, and a shard with no row still starts at zero — so
+    ///         this is the right call when the projections are new and their history is genuinely not
+    ///         wanted, and the wrong one otherwise.
+    ///     </para>
+    ///     <para>
+    ///         Spans every database the store has, because under database-per-tenant a mark advanced on
+    ///         one file says nothing about the rest. Name a tenant to advance one.
+    ///     </para>
+    /// </remarks>
+    public async Task AdvanceHighWaterMarkToLatestAsync(CancellationToken token = default)
+    {
+        await _store.RefreshTenantsAsync(token).ConfigureAwait(false);
+
+        foreach (var database in _store.Tenancy.AllDatabases())
+        {
+            await DetectorFor(database).AdvanceHighWaterMarkToLatestAsync(token).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc cref="AdvanceHighWaterMarkToLatestAsync(CancellationToken)" />
+    /// <remarks>
+    ///     <b>Under conjoined tenancy every tenant resolves to the one file</b>, which is the honest
+    ///     answer rather than a limitation: the high-water mark is a position in a global sequence, and
+    ///     a conjoined store has exactly one of those however many tenants write into it. The overload
+    ///     is meaningful under database-per-tenant, where a tenant genuinely is a database.
+    /// </remarks>
+    public Task AdvanceHighWaterMarkToLatestAsync(string tenantId, CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        return DetectorFor(_store.Tenancy.DatabaseFor(tenantId)).AdvanceHighWaterMarkToLatestAsync(token);
+    }
+
+    /// <summary>
+    ///     Pull any progression row that has advanced past the highest event sequence back down to it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Reachable on Fisher through an ordinary supported operation, where Marten carries the
+    ///         same method for a database race it believes it has closed.</b> <c>fi_events.seq_id</c> is
+    ///         <c>AUTOINCREMENT</c>, and stream compacting and event masking both delete rows — so
+    ///         removing events from the top of the table lowers <c>max(seq_id)</c> below progress that
+    ///         was already recorded. A shard stranded above the ceiling never advances again and
+    ///         <c>QueryForNonStaleData</c> waits on it forever, with nothing anywhere saying why.
+    ///     </para>
+    ///     <para>
+    ///         <b>Clamped per row, where Marten resets every row wholesale</b> the moment the high-water
+    ///         row is ahead. That would drag a shard genuinely behind the head <em>forward</em>, past
+    ///         events it had not applied — silently, and exactly on the store somebody is already
+    ///         repairing. Only an impossible row is corrected, and only as far as the ceiling.
+    ///     </para>
+    ///     <para>
+    ///         A corrected shard replays from the new ceiling to wherever it thought it was. That is the
+    ///         honest outcome: the events it recorded having processed are no longer there to say
+    ///         otherwise.
+    ///     </para>
+    /// </remarks>
+    public async Task TryCorrectProgressInDatabaseAsync(CancellationToken token = default)
+    {
+        await _store.RefreshTenantsAsync(token).ConfigureAwait(false);
+
+        foreach (var database in _store.Tenancy.AllDatabases())
+        {
+            await DetectorFor(database).TryCorrectProgressInDatabaseAsync(token).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc cref="TryCorrectProgressInDatabaseAsync(CancellationToken)" />
+    public Task TryCorrectProgressInDatabaseAsync(string tenantId, CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        return DetectorFor(_store.Tenancy.DatabaseFor(tenantId)).TryCorrectProgressInDatabaseAsync(token);
+    }
+
+    /// <summary>
+    ///     Where every shard has reached, including the high-water mark's own row.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The read has existed on <c>FisherDatabase</c> since the daemon landed; what was missing
+    ///         was any way to reach it that did not involve casting the store to <c>IEventStore</c> and
+    ///         walking <c>AllDatabases()</c>. Marten and Polecat both surface it here.
+    ///     </para>
+    ///     <para>
+    ///         <b>An omitted tenant id spans every database and concatenates</b>, which under
+    ///         database-per-tenant means the same shard name appears once per tenant — deliberately, and
+    ///         the same shape Marten settled on: collapsing them would have to pick a winner, and
+    ///         "projection X is at 40 for one tenant and 900 for another" is the thing an operator came
+    ///         to find out. Name a tenant for one database's rows.
+    ///     </para>
+    /// </remarks>
+    public async Task<IReadOnlyList<ShardState>> AllProjectionProgress(string? tenantId = null,
+        CancellationToken token = default)
+    {
+        if (tenantId is not null)
+        {
+            return await _store.Tenancy.DatabaseFor(tenantId).AllProjectionProgress(token).ConfigureAwait(false);
+        }
+
+        await _store.RefreshTenantsAsync(token).ConfigureAwait(false);
+
+        var databases = _store.Tenancy.AllDatabases();
+
+        if (databases.Count == 1)
+        {
+            return await databases[0].AllProjectionProgress(token).ConfigureAwait(false);
+        }
+
+        var states = new List<ShardState>();
+
+        foreach (var database in databases)
+        {
+            states.AddRange(await database.AllProjectionProgress(token).ConfigureAwait(false));
+        }
+
+        return states;
+    }
+
+    /// <summary>
+    ///     How far one shard has processed.
+    /// </summary>
+    /// <remarks>
+    ///     An omitted tenant id returns the <em>highest</em> position that shard has reached in any of
+    ///     the store's databases, mirroring Marten. Zero for a shard with no row, which is what the
+    ///     daemon itself reads as "start from the beginning" — a missing row and a row at zero mean the
+    ///     same thing and neither is an error.
+    /// </remarks>
+    public async Task<long> ProjectionProgressFor(ShardName name, string? tenantId = null,
+        CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        if (tenantId is not null)
+        {
+            return await _store.Tenancy.DatabaseFor(tenantId).ProjectionProgressFor(name, token)
+                .ConfigureAwait(false);
+        }
+
+        await _store.RefreshTenantsAsync(token).ConfigureAwait(false);
+
+        var highest = 0L;
+
+        foreach (var database in _store.Tenancy.AllDatabases())
+        {
+            var sequence = await database.ProjectionProgressFor(name, token).ConfigureAwait(false);
+
+            if (sequence > highest)
+            {
+                highest = sequence;
+            }
+        }
+
+        return highest;
+    }
+
+    /// <summary>
+    ///     Every shard name the store's asynchronous projections and subscriptions run under.
+    /// </summary>
+    /// <remarks>
+    ///     The names <see cref="ProjectionProgressFor" /> and the daemon's rebuild overloads are
+    ///     addressed by, so an operator does not have to reconstruct <c>{Name}:{ShardKey}</c> by hand.
+    ///     Asynchronous only — an inline projection has no shard, because it has no progress to record.
+    /// </remarks>
+    public IReadOnlyList<ShardName> AllAsyncProjectionShardNames()
+        => _store.Options.Projections.AllShards().Select(x => x.Name).ToList();
+
+    private Events.Daemon.FisherHighWaterDetector DetectorFor(Storage.FisherDatabase database)
+        => new(database, _store.Options.EventGraph);
+
+    // ---- rebuilding one stream (fisher#173) ----
+
+    /// <summary>
+    ///     Rebuild the projected document of type <typeparamref name="T" /> for a single stream, by
+    ///     live-aggregating it and storing the result.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The repair that does not need the daemon: one stream's read model is wrong, and a full
+    ///         <c>RebuildProjectionAsync</c> would replay every stream the projection owns to fix it.
+    ///     </para>
+    ///     <para>
+    ///         <b>A stream that folds to nothing deletes the document, where Marten's equivalent throws
+    ///         an <see cref="ArgumentNullException" /> from inside <c>Store(null!)</c>.</b> That is not
+    ///         an exotic case — an aggregate whose <c>ShouldDelete</c> fired, or an archived stream, both
+    ///         land there — and "no document" is exactly what a real rebuild leaves behind for such a
+    ///         stream, since teardown clears the rows and the replay never recreates that one. Throwing
+    ///         would make the method unusable on the streams most likely to have gone wrong.
+    ///     </para>
+    ///     <para>
+    ///         <b>Refused by name for a type whose storage is not Fisher's</b> — an EF Core-backed
+    ///         projection registered through <c>Projections.StorageProviders</c> is deliberately never
+    ///         mapped, so <c>Store</c> would create a <c>fi_doc_*</c> table nothing else ever reads.
+    ///         Rebuild those through the daemon.
+    ///     </para>
+    /// </remarks>
+    public Task RebuildSingleStreamAsync<T>(Guid id, string? tenantId = null,
+        CancellationToken token = default) where T : class
+        => RebuildSingleStreamAsync<T>(
+            (session, ct) => session.Events.AggregateStreamAsync<T>(id, token: ct),
+            session => session.Delete<T>(id), tenantId, token);
+
+    /// <inheritdoc cref="RebuildSingleStreamAsync{T}(Guid, string, CancellationToken)" />
+    public Task RebuildSingleStreamAsync<T>(string streamKey, string? tenantId = null,
+        CancellationToken token = default) where T : class
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamKey);
+
+        return RebuildSingleStreamAsync<T>(
+            (session, ct) => session.Events.AggregateStreamAsync<T>(streamKey, token: ct),
+            session => session.Delete<T>(streamKey), tenantId, token);
+    }
+
+    private async Task RebuildSingleStreamAsync<T>(
+        Func<IDocumentSession, CancellationToken, Task<T?>> aggregate, Action<IDocumentSession> deleteById,
+        string? tenantId, CancellationToken token) where T : class
+    {
+        if (!_store.Options.Schema.HasMappingFor(typeof(T)))
+        {
+            throw new NotSupportedException(
+                $"'{typeof(T).Name}' has no Fisher document mapping, so there is no fi_doc_* table for this "
+                + "to write into. A projection registered through Projections.StorageProviders (an EF Core "
+                + "entity, say) deliberately keeps its rows elsewhere — rebuild it through the daemon's "
+                + "RebuildProjectionAsync instead, which routes through the registered storage.");
+        }
+
+        await using var session = _store.LightweightSession(tenantId);
+
+        var document = await aggregate(session, token).ConfigureAwait(false);
+
+        if (document is null)
+        {
+            // Deleted rather than skipped: a real rebuild tears the rows down and replays, so a stream
+            // that folds to nothing leaves no document behind. Skipping would keep whatever the
+            // previous, wrong run wrote — which is the state this method is being called to repair.
+            // Deleted by the stream's own identity, on the same assumption Store makes of the
+            // aggregate it just built: a single-stream aggregate's id is its stream's.
+            deleteById(session);
+        }
+        else
+        {
+            session.Store(document);
+        }
+
+        await session.SaveChangesAsync(token).ConfigureAwait(false);
+    }
 
     /// <summary>
     ///     Run a projection scenario — a given/when/then harness for asserting projected state after a

--- a/src/Fisher/Events/Daemon/FisherHighWaterDetector.cs
+++ b/src/Fisher/Events/Daemon/FisherHighWaterDetector.cs
@@ -165,6 +165,79 @@ internal sealed class FisherHighWaterDetector : IHighWaterDetector
         => _database.FetchHighestEventSequenceNumber(token);
 
     /// <summary>
+    ///     Move the high-water mark straight to the highest sequence in the database, without the
+    ///     daemon having read a single event (fisher#173).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>For retrofitting async projections onto a store that has never had any.</b> A daemon
+    ///         starting against a large existing event store begins at zero and replays everything to
+    ///         reach the head; advancing the mark first means it starts in catch-up mode and processes
+    ///         only what arrives afterwards.
+    ///     </para>
+    ///     <para>
+    ///         <b>Nothing is projected by this, and that is the whole point — so it is also the
+    ///         hazard.</b> Every registered shard still starts from its own progression row, so a shard
+    ///         with no row will still replay from zero; what this skips is the *high-water* agent's
+    ///         climb. Use it on a store whose projections are genuinely new and whose history is
+    ///         genuinely not wanted, which is why Marten's own doc comment says "use with caution".
+    ///     </para>
+    ///     <para>
+    ///         Reads <c>max(seq_id)</c> and writes it. On SQLite that is the honest ceiling with no
+    ///         safe-zone reasoning behind it, for the reason this whole class documents: committed
+    ///         sequences are contiguous.
+    ///     </para>
+    /// </remarks>
+    internal async Task AdvanceHighWaterMarkToLatestAsync(CancellationToken token)
+    {
+        var highest = await _database.FetchHighestEventSequenceNumber(token).ConfigureAwait(false);
+
+        await MarkAsync(highest, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Pull any progression row that has somehow advanced past the highest event sequence back down
+    ///     to it (fisher#173).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>This is more reachable on Fisher than the Marten method it mirrors, and for a reason
+    ///         that is Fisher's own.</b> Marten carries it for a PostgreSQL shutdown race it believes it
+    ///         has since closed. Here the state arises from an ordinary, supported operation: stream
+    ///         compacting and <c>DeleteEventsOperation</c> remove rows, and <c>seq_id</c> is
+    ///         <c>AUTOINCREMENT</c>, so deleting from the top of the table lowers <c>max(seq_id)</c>
+    ///         below progress that was already recorded. A shard left above the ceiling never advances
+    ///         again, and <c>QueryForNonStaleData</c> waits on it forever.
+    ///     </para>
+    ///     <para>
+    ///         <b>Every row, not only the high-water one, and clamped per row rather than reset
+    ///         wholesale.</b> Marten's version resets every row to the highest sequence the moment the
+    ///         high-water row is ahead; that drags shards genuinely behind the head *forward*, skipping
+    ///         events they had not applied. Only a row that is impossible is corrected here, and only as
+    ///         far as the ceiling.
+    ///     </para>
+    ///     <para>
+    ///         A corrected shard will replay the range between the new ceiling and where it thought it
+    ///         was — which is the honest outcome, since the events it recorded having processed are no
+    ///         longer there to say otherwise.
+    ///     </para>
+    /// </remarks>
+    internal async Task TryCorrectProgressInDatabaseAsync(CancellationToken token)
+    {
+        await using var connection = await _database.OpenConnectionAsync(token).ConfigureAwait(false);
+        await using var command = connection.CreateCommand();
+
+        command.CommandText = $"""
+                               update {_events.ProgressionTableName}
+                                  set last_seq_id = (select coalesce(max(seq_id), 0) from {_events.EventsTableName}),
+                                      last_updated = {SqliteTimestamp.NowExpression}
+                                where last_seq_id > (select coalesce(max(seq_id), 0) from {_events.EventsTableName});
+                               """;
+
+        await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+    }
+
+    /// <summary>
     ///     The progression row the mark lives in, sharing <c>fi_event_progression</c> with the shards.
     /// </summary>
     private static ShardName HighWaterShard => new(ShardState.HighWaterMark);

--- a/src/Fisher/Internal/TenantDataCleaner.cs
+++ b/src/Fisher/Internal/TenantDataCleaner.cs
@@ -1,0 +1,228 @@
+using Fisher.Storage;
+using Microsoft.Data.Sqlite;
+
+namespace Fisher.Internal;
+
+/// <summary>
+///     Delete one tenant's rows, leaving every other tenant's alone and leaving the schema — and, under
+///     database-per-tenant, the tenant's file — where they were (fisher#173).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>This is not the tenant deletion Fisher refuses, and the distinction is the whole reason it
+///         can exist.</b> Deprovisioning a tenant here means deleting a <em>file</em> — the cheapest
+///         deprovisioning of any Critter Stack store and the most irreversible, and Fisher cannot know
+///         whether that file is backed up — so the tenancy API suspends or forgets and an operator
+///         removes the file themselves. Wiping a tenant's <em>rows</em> out of a shared conjoined file
+///         is a different operation: it destroys nothing an operator would have to restore a file to
+///         recover, it is the only way to erase a conjoined tenant at all, and it was covered by
+///         nothing.
+///     </para>
+///     <para>
+///         <b>Under database-per-tenant it clears the tenant's file rather than deleting it</b>, which
+///         is the same operation reached from the other side. The file, its schema and its pooled
+///         connections survive, so the tenant goes on working and simply has no data; removing the file
+///         stays the operator's act.
+///     </para>
+/// </remarks>
+internal sealed class TenantDataCleaner
+{
+    private readonly DocumentStore _store;
+    private readonly string _tenantId;
+
+    internal TenantDataCleaner(string tenantId, DocumentStore store)
+    {
+        _tenantId = tenantId;
+        _store = store;
+    }
+
+    private string Prefix => FisherTableNaming.PrefixFor(_store.Options.DatabaseSchemaName);
+
+    internal async Task ExecuteAsync(CancellationToken token)
+    {
+        // Resolves through the tenancy, so an unknown or suspended tenant is refused by name here
+        // exactly as it would be by a session — a wipe that silently landed on the default tenant's
+        // file is the one outcome database-per-tenant exists to make impossible.
+        var database = _store.Tenancy.DatabaseFor(_tenantId);
+
+        var events = _store.Options.EventGraph;
+
+        // Tag rows carry no tenant of their own and have a real foreign key to fi_events(seq_id), so
+        // they are reached through their events and have to go first — the ordering fisher#6
+        // established for DeleteAllEventDataAsync, now with a tenant predicate on the subselect.
+        var tagTables = events.TagTypes.Select(events.TagTableName).ToArray();
+
+        await _store.Options.ResiliencePipeline.ExecuteAsync(async ct =>
+        {
+            await using var connection = await database.OpenConnectionAsync(ct).ConfigureAwait(false);
+
+            var tables = (await ReadTableNamesAsync(connection, ct).ConfigureAwait(false))
+                .Where(x => x.StartsWith(Prefix, StringComparison.Ordinal))
+                .ToList();
+
+            var tenanted = new List<string>();
+
+            foreach (var table in tables)
+            {
+                if (await HasTenantColumnAsync(connection, table, ct).ConfigureAwait(false))
+                {
+                    tenanted.Add(table);
+                }
+            }
+
+            // **"Has a tenant_id column" is not the question, and reading it as one would make this
+            // refusal unreachable.** fi_events, fi_streams and fi_dead_letters carry the column on
+            // every store, tenanted or not — the event tables get it with a default under
+            // non-conjoined tenancy (see StreamsTable), and a dead letter records the failing event's
+            // tenant as ordinary data. So the question is what the store was *configured* to slice by:
+            // a database per tenant, conjoined events, or at least one MultiTenanted() document type,
+            // which is the only case that puts the column on a fi_doc_* table.
+            var tenantedByConfiguration =
+                _store.Tenancy.Cardinality != JasperFx.Descriptors.DatabaseCardinality.Single
+                || events.TenancyStyle == JasperFx.MultiTenancy.TenancyStyle.Conjoined
+                || tenanted.Any(x => x.StartsWith(Prefix + "doc_", StringComparison.Ordinal));
+
+            // Refused rather than silently doing nothing, which would report a successful erasure of a
+            // tenant that has no rows because the store has no notion of tenants at all — the worst
+            // possible answer to a compliance request.
+            if (!tenantedByConfiguration)
+            {
+                throw new NotSupportedException(
+                    $"This store keeps no tenant-scoped data, so there is nothing that could be '{_tenantId}'s' "
+                    + "to delete. Conjoined tenancy (Events.TenancyStyle = TenancyStyle.Conjoined, and "
+                    + "Schema.For<T>().MultiTenanted()) is what puts a tenant_id column on the tables; "
+                    + "database-per-tenant (MultiTenantedDatabases(...)) gives each tenant a file of its own. "
+                    + "Under neither, Advanced.Clean is the operation you want.");
+            }
+
+            var ordered = await OrderByForeignKeys(connection, tenanted, ct).ConfigureAwait(false);
+            var existing = new HashSet<string>(tables, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var tagTable in tagTables.Select(Unquoted).Where(existing.Contains))
+            {
+                await ExecuteAsync(connection,
+                    $"""
+                     delete from "{tagTable}"
+                      where seq_id in (select seq_id from {events.EventsTableName} where tenant_id = $tenant)
+                     """, ct).ConfigureAwait(false);
+            }
+
+            foreach (var table in ordered)
+            {
+                await ExecuteAsync(connection, $"delete from \"{table}\" where tenant_id = $tenant", ct)
+                    .ConfigureAwait(false);
+            }
+
+            // Under database-per-tenant the whole file is this tenant's, so anything that carries no
+            // tenant column is still this tenant's data — the natural key lookups and the progression
+            // rows in particular. Leaving the lookups would make the duplicate guard fire on streams
+            // that are gone, which is precisely what DeleteAllEventDataAsync clears them for.
+            if (_store.Tenancy.Cardinality != JasperFx.Descriptors.DatabaseCardinality.Single)
+            {
+                foreach (var table in tables.Except(ordered, StringComparer.OrdinalIgnoreCase)
+                             .Where(x => !x.Equals(events.ProgressionTableName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    await ExecuteAsync(connection, $"delete from \"{table}\"", ct).ConfigureAwait(false);
+                }
+            }
+        }, token).ConfigureAwait(false);
+    }
+
+    /// <remarks>
+    ///     The names come back from <c>EventGraph</c> already quoted for embedding in SQL; matching them
+    ///     against <c>sqlite_master</c> needs the bare form.
+    /// </remarks>
+    private static string Unquoted(string name) => name.Trim('"');
+
+    private async Task ExecuteAsync(SqliteConnection connection, string sql, CancellationToken token)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("$tenant", _tenantId);
+
+        await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+    }
+
+    private static async Task<bool> HasTenantColumnAsync(SqliteConnection connection, string table,
+        CancellationToken token)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"select count(*) from pragma_table_info('{table.Replace("'", "''")}') "
+            + "where name = 'tenant_id'";
+
+        return Convert.ToInt64(await command.ExecuteScalarAsync(token).ConfigureAwait(false)) > 0;
+    }
+
+    private static async Task<List<string>> ReadTableNamesAsync(SqliteConnection connection,
+        CancellationToken token)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = "select name from sqlite_master where type = 'table'";
+
+        var names = new List<string>();
+
+        await using var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            names.Add(reader.GetString(0));
+        }
+
+        return names;
+    }
+
+    /// <inheritdoc cref="FisherDocumentCleaner" />
+    /// <remarks>
+    ///     Children first, read from <c>pragma_foreign_key_list</c> — the same pass
+    ///     <c>DeleteAllDocumentsAsync</c> uses, and for the same reason: Weasel's default profile
+    ///     enforces foreign keys on every connection Fisher opens, so an unordered sweep over document
+    ///     tables that reference each other (fisher#38) fails roughly half the time.
+    /// </remarks>
+    private static async Task<List<string>> OrderByForeignKeys(SqliteConnection connection,
+        List<string> tables, CancellationToken token)
+    {
+        var references = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var table in tables)
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"select \"table\" from pragma_foreign_key_list('{table.Replace("'", "''")}')";
+
+            var parents = new List<string>();
+
+            await using var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
+            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                parents.Add(reader.GetString(0));
+            }
+
+            references[table] = parents;
+        }
+
+        var ordered = new List<string>();
+        var done = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var visiting = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void Visit(string table)
+        {
+            if (!done.Add(table) || !visiting.Add(table))
+            {
+                return;
+            }
+
+            foreach (var child in tables.Where(x => references[x].Contains(table, StringComparer.OrdinalIgnoreCase)))
+            {
+                Visit(child);
+            }
+
+            visiting.Remove(table);
+            ordered.Add(table);
+        }
+
+        foreach (var table in tables)
+        {
+            Visit(table);
+        }
+
+        return ordered;
+    }
+}


### PR DESCRIPTION
Closes #173. Stoat plan `fisher-marten-parity`, node `advanced-operations`.

Four independent additions to `DocumentStore.Advanced`, filling the holes against Marten's `AdvancedOperations`. Two are operational escape hatches whose whole value is that they exist before you need them, so the tests are about the states they repair rather than about the calls succeeding.

## 1. The unstick-the-daemon pair

**`AdvanceHighWaterMarkToLatestAsync`** moves the high-water mark straight to `max(seq_id)`, for retrofitting async projections onto a store that has never had any — otherwise the mark climbs from zero, which on a large store is a long read with nothing to show for it. There was no way to do this on Fisher at all.

It advances the **mark and not the shards**, and that is the half that decides whether it is the right call for a store: a shard with no progression row still starts at zero, so this is for a store whose projections are new *and* whose history is genuinely not wanted. `advancing_the_mark_leaves_the_shards_where_they_were` pins it so the caveat is a fact rather than a doc comment.

**`TryCorrectProgressInDatabaseAsync`** pulls a progression row that has advanced past the highest event sequence back down to it.

- **This is more reachable on Fisher than on Marten, and through an ordinary supported operation.** Marten carries the method for a PostgreSQL shutdown race it believes it has closed. Here `fi_events.seq_id` is `AUTOINCREMENT` and stream compacting and event masking both *delete rows* — so removing events from the top of the table lowers `max(seq_id)` below progress already recorded. A shard stranded above the ceiling never advances again and `QueryForNonStaleData` waits on it forever, with nothing anywhere saying why.
- **Clamped per row, where Marten resets every row wholesale** the moment the high-water row is ahead. That would drag a shard genuinely *behind* the head **forward**, past events it had not applied — silently, and on the very store somebody is already repairing. `correcting_leaves_a_shard_that_is_merely_behind_alone` is the discriminating fact.

Both span every database, with tenant-scoped overloads that mean something under database-per-tenant; under conjoined tenancy every tenant resolves to the one file, which is honest rather than a limitation — a conjoined store has one global sequence however many tenants write into it.

## 2. The progression reads, surfaced

`AllProjectionProgress` / `ProjectionProgressFor` / `AllAsyncProjectionShardNames`. **A surfacing job, not new machinery**: the first two have been on `FisherDatabase` since the daemon landed, reachable only by casting the store to `IEventStore` and walking `AllDatabases()`.

An omitted tenant id spans every database — concatenating for the first, taking the highest for the second — so under database-per-tenant one shard name appears once per tenant. Deliberate, and the shape Marten settled on: collapsing them would have to pick a winner, and "projection X is at 40 for one tenant and 900 for another" is the thing an operator came to find out.

## 3. `RebuildSingleStreamAsync<T>`

Live-aggregates one stream and stores the result — the repair that does not need the daemon, where a full `RebuildProjectionAsync` would replay every stream the projection owns.

- **A stream that folds to nothing deletes the document, where Marten's throws an `ArgumentNullException` from inside `Store(null!)`.** That case is not exotic — a `ShouldDelete` that fired, an archived stream, an id with no events — and "no document" is exactly what a real rebuild leaves for such a stream, since teardown clears the rows and the replay never recreates that one. Throwing would make the method unusable on the streams most likely to have gone wrong.
- **Refused by name for a type with no Fisher mapping.** A projection registered through `Projections.StorageProviders` (an EF Core entity) is deliberately never mapped, so `Store` would create a `fi_doc_*` table nothing else ever reads — a rebuild that silently wrote to the wrong place.

## 4. `DeleteAllTenantDataAsync` — and what it is *not*

**Fisher deliberately refuses tenant deletion**, and this does not soften that. Deprovisioning a tenant here means deleting a **file**: the cheapest deprovisioning of any Critter Stack store and the most irreversible, and Fisher cannot know whether that file is backed up — so the tenancy API suspends or forgets and an operator removes the file themselves (HANDOFF.md, "Runtime tenants").

Wiping a tenant's **rows** is a different operation. It destroys nothing a file restore would be needed to recover, it is the only way to erase a conjoined tenant at all, and nothing covered it. Under database-per-tenant it **clears the tenant's file and keeps it** — the file, its schema and its pooled connections survive, so the tenant goes on working and simply has no data.

- **Tag rows go first, through their events.** `fi_event_tag_*` carries no tenant of its own and has a real foreign key to `fi_events(seq_id)`, so the delete is a subselect and has to precede the events — fisher#6's ordering met again with a tenant predicate on it.
- **Progression rows are left alone.** They describe how far the daemon read, not what a tenant owns; clearing them would make every shard replay a store that is now empty. That is also why this needs no daemon pause, unlike `ResetAllDataAsync`.
- ⚠️ **"Has a `tenant_id` column" is not the question, and reading it as one makes the refusal unreachable.** `fi_events`, `fi_streams` and `fi_dead_letters` carry the column on **every** store — the event tables get it with a default under non-conjoined tenancy, and a dead letter records the failing event's tenant as ordinary data. The guard asks what the store was *configured* to slice by: a database per tenant, conjoined events, or at least one `MultiTenanted()` document type, which is the only thing that puts the column on a `fi_doc_*` table. A store with none of those is refused by name rather than reporting a successful erasure of nothing. (This was caught by the test, not by inspection — the first implementation counted columns and never refused.)

## Refusals

Nothing was refused as unimplementable on SQLite. Where a Marten shape did not port, it is documented above and refused loudly rather than no-op'd: the unmapped type on `RebuildSingleStreamAsync`, the untenanted store on `DeleteAllTenantDataAsync`, and an unknown tenant under database-per-tenant (which reaches `ITenancy.DatabaseFor` and gets `UnknownTenantException` as any session would).

Marten's partition-management members (`ApplyRollingPartitionsAsync`, `AddMartenManagedTenantsAsync`, `AddTenantToShardAsync`) are **not** ported and are not gaps: SQLite has no table partitioning and no sharded tenancy, and `StorePolicies` already records partitioning as permanently out of scope rather than pending.

## Tests

19 new, in `advanced_daemon_and_tenant_operations`.

## Validation

Local, both TFMs, no docker (SQLite only):

- `net10.0` — Fisher.Tests **1538**, Fisher.AspNetCore.Tests **36**, Fisher.EntityFrameworkCore.Tests **19**. 0 failed.
- `net9.0` — same three, same counts. 0 failed.
- `python3 scripts/check_scoreboard.py --tfm net10.0 --configuration Release` → *"Scoreboard agrees with the net10.0 run: 1593 tests, 391 compliance across 40 suites (33 event / 7 document)."*

HANDOFF.md and README.md counts reconciled from that run, after merging `origin/main` (which had moved to 1571/1516).

GitHub Actions is stalled org-wide, so CI is not a gate on this one; the numbers above are from a real local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)