### PR TITLE
Protected-data audit: regression armour for masking and compaction, plus a tombstone FK ordering fix

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1609 tests green on net9.0 and net10.0**, with no known intermittent failures — 1554 in
+**1629 tests green on net9.0 and net10.0**, with no known intermittent failures — 1574 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 391 of
 them are shared cross-store compliance tests — 322 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 

--- a/src/Fisher.Tests/Events/cross_tenant_protected_operations.cs
+++ b/src/Fisher.Tests/Events/cross_tenant_protected_operations.cs
@@ -1,0 +1,217 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Protected;
+using JasperFx.MultiTenancy;
+using Microsoft.Data.Sqlite;
+
+namespace Fisher.Tests.Events;
+
+public record HolderRegistered(string Holder);
+
+/// <summary>
+///     polecat#546 item 2 / marten#5234 — the destructive event operations must not reach past the
+///     tenant the read was scoped to.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Polecat's exact bug is structurally unreachable in Fisher, and the first test is what
+///         says so.</b> In Polecat, <c>Events.UseTenantPartitionedEvents</c> gives each tenant its own
+///         <c>pc_events_sequence_{ordinal}</c>, so <c>seq_id = 1</c> exists once per tenant; a
+///         <c>WHERE seq_id = @p</c> with no tenant predicate therefore matched rows in tenants the
+///         caller never named. Fisher has no partitioned-events mode: <c>fi_events.seq_id</c> is a
+///         single <c>INTEGER PRIMARY KEY AUTOINCREMENT</c> shared by every tenant in the file, so a
+///         sequence identifies exactly one row and the escape has nowhere to go. Under
+///         database-per-tenant the tenants are not even in the same file.
+///     </para>
+///     <para>
+///         That makes <c>seq_id</c> uniqueness a load-bearing precondition rather than an
+///         implementation detail, so <see cref="the_two_tenants_events_draw_from_one_shared_sequence" />
+///         asserts it directly. If Fisher ever adopts per-tenant sequencing, that test goes red before
+///         the isolation tests below start silently proving nothing.
+///     </para>
+///     <para>
+///         The isolation tests still earn their place: the guarantee they pin is that the <em>read</em>
+///         half is tenant-scoped. A <c>FetchStreamAsync</c> or <c>QueryEventsAsync</c> that leaked
+///         across tenants would hand the calling tenant another tenant's sequences, and every write
+///         downstream would then be correctly aimed at the wrong rows. Both tenants use the <b>same
+///         stream id</b>, which is legal under conjoined tenancy — identity there is
+///         <c>(tenant_id, id)</c> — and is the shape that discriminates hardest.
+///     </para>
+///     <para>
+///         Every assertion checks both directions, per the discipline in
+///         <c>Documents.cross_tenant_writes</c>: a store that leaks still answers correctly for the
+///         tenant that owns the data.
+///     </para>
+/// </remarks>
+public class cross_tenant_protected_operations : IAsyncLifetime
+{
+    private const string Alpha = "alpha";
+    private const string Beta = "beta";
+
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("cross-tenant-protected");
+    private DocumentStore _store = null!;
+
+    /// <summary>One stream id, two tenants — the strongest shape available under conjoined tenancy.</summary>
+    private readonly Guid _sharedStreamId = Guid.NewGuid();
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+
+            options.Events.AddEventType(typeof(CoinsEarned));
+            options.Events.AddEventType(typeof(CoinsSpent));
+            options.Events.AddEventType(typeof(HolderRegistered));
+
+            options.Events.AddMaskingRuleForProtectedInformation<HolderRegistered>(
+                x => x with { Holder = "REDACTED" });
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    ///     The precondition the whole verdict rests on: one AUTOINCREMENT sequence for the file, so no
+    ///     two tenants' events ever share a <c>seq_id</c> and a bare <c>where seq_id = ?</c> cannot
+    ///     cross a tenant boundary.
+    /// </summary>
+    [Fact]
+    public async Task the_two_tenants_events_draw_from_one_shared_sequence()
+    {
+        await StartAsync(Alpha, new CoinsEarned(100), new CoinsSpent(30));
+        await StartAsync(Beta, new CoinsEarned(7), new CoinsSpent(2));
+
+        var alpha = await SequencesAsync(Alpha);
+        var beta = await SequencesAsync(Beta);
+
+        alpha.Count.ShouldBe(2);
+        beta.Count.ShouldBe(2);
+
+        // Disjoint, not merely different — a per-tenant sequence would give both tenants 1 and 2.
+        alpha.Intersect(beta).ShouldBeEmpty();
+    }
+
+    // ---- masking ----
+
+    [Fact]
+    public async Task masking_one_tenant_must_not_rewrite_another_tenants_events()
+    {
+        await StartAsync(Alpha, new HolderRegistered("Frodo"));
+        await StartAsync(Beta, new HolderRegistered("Samwise"));
+
+        await _store.Advanced.ApplyEventDataMaskingAsync(
+            x => x.ForTenant(Alpha).IncludeStream(_sharedStreamId), Token);
+
+        // The tenant that asked was served...
+        (await HolderAsync(Alpha)).ShouldBe("REDACTED");
+
+        // ...and the one that did not ask still has its own data, unmasked and not replaced by alpha's.
+        (await HolderAsync(Beta)).ShouldBe("Samwise");
+    }
+
+    /// <summary>
+    ///     The cross-stream selector, which is the one translated to SQL and therefore the one that
+    ///     could span tenants if its predicate lost the tenant column.
+    /// </summary>
+    [Fact]
+    public async Task an_include_events_batch_masks_only_the_calling_tenant()
+    {
+        await StartAsync(Alpha, new HolderRegistered("Frodo"));
+        await StartAsync(Beta, new HolderRegistered("Samwise"));
+
+        await _store.Advanced.ApplyEventDataMaskingAsync(
+            x => x.ForTenant(Beta).IncludeEvents(e => e.EventTypeName == "holder_registered"), Token);
+
+        (await HolderAsync(Beta)).ShouldBe("REDACTED");
+        (await HolderAsync(Alpha)).ShouldBe("Frodo");
+    }
+
+    // ---- compaction ----
+
+    [Fact]
+    public async Task compacting_one_tenants_stream_must_not_delete_another_tenants_events()
+    {
+        await StartAsync(Alpha, new CoinsEarned(100), new CoinsSpent(30), new CoinsEarned(5));
+        await StartAsync(Beta, new CoinsEarned(7), new CoinsSpent(2), new CoinsEarned(1));
+
+        await using (var session = _store.LightweightSession(Alpha))
+        {
+            await session.Events.CompactStreamAsync<Purse>(_sharedStreamId);
+        }
+
+        // Alpha collapsed to its snapshot...
+        var alpha = await EventsAsync(Alpha);
+        alpha.ShouldHaveSingleItem().Data.ShouldBeOfType<Compacted<Purse>>().Snapshot.Balance.ShouldBe(75);
+
+        // ...and beta still has all three of its own events, none of them alpha's snapshot.
+        var beta = await EventsAsync(Beta);
+        beta.Count.ShouldBe(3);
+        beta.ShouldAllBe(x => x.Data is CoinsEarned || x.Data is CoinsSpent);
+    }
+
+    /// <summary>
+    ///     The compaction watermark is written to <c>fi_streams</c>, where identity really is
+    ///     <c>(tenant_id, id)</c> and the two tenants' rows collide on <c>id</c> alone.
+    /// </summary>
+    [Fact]
+    public async Task the_compaction_watermark_lands_on_the_calling_tenants_stream_only()
+    {
+        await StartAsync(Alpha, new CoinsEarned(100), new CoinsSpent(30));
+        await StartAsync(Beta, new CoinsEarned(7), new CoinsSpent(2));
+
+        await using (var session = _store.LightweightSession(Alpha))
+        {
+            await session.Events.CompactStreamAsync<Purse>(_sharedStreamId);
+        }
+
+        (await CompactedVersionAsync(Alpha)).ShouldBe(2);
+        (await CompactedVersionAsync(Beta)).ShouldBe(0);
+    }
+
+    // ---- helpers ----
+
+    private async Task StartAsync(string tenantId, params object[] events)
+    {
+        await using var session = _store.LightweightSession(tenantId);
+        session.Events.StartStream<Purse>(_sharedStreamId, events);
+        await session.SaveChangesAsync(Token);
+    }
+
+    private async Task<IReadOnlyList<IEvent>> EventsAsync(string tenantId)
+    {
+        await using var session = _store.LightweightSession(tenantId);
+        return await session.Events.FetchStreamAsync(_sharedStreamId, token: Token);
+    }
+
+    private async Task<string> HolderAsync(string tenantId)
+        => ((HolderRegistered)(await EventsAsync(tenantId))[0].Data).Holder;
+
+    private async Task<List<long>> SequencesAsync(string tenantId)
+        => (await EventsAsync(tenantId)).Select(x => x.Sequence).ToList();
+
+    private async Task<long> CompactedVersionAsync(string tenantId)
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "select compacted_version from fi_streams where id = $id and tenant_id = $tenant";
+        command.Parameters.AddWithValue("$id", _sharedStreamId.ToString());
+        command.Parameters.AddWithValue("$tenant", tenantId);
+
+        var raw = await command.ExecuteScalarAsync(Token);
+        return raw is null or DBNull ? 0 : Convert.ToInt64(raw);
+    }
+}

--- a/src/Fisher.Tests/Events/destructive_event_operation_sweep.cs
+++ b/src/Fisher.Tests/Events/destructive_event_operation_sweep.cs
@@ -1,0 +1,150 @@
+using Fisher.Tests.Schema;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using JasperFx.MultiTenancy;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>
+///     polecat#546 item 4 — the rest of the destructive event surface, checked the same way as the
+///     compaction and masking operations: every statement that deletes or overwrites a row is asked to
+///     prove its predicates reach exactly the stream and tenant that was named.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>ArchiveStream</c> and <c>TombstoneStream</c> live outside
+///         <c>Fisher.Events.Protected</c>, but they are the two other operations that write across
+///         whole streams, and <c>TombstoneStream</c> is the only one that hard-deletes
+///         <c>fi_events</c> rows outside compaction. Their predicates are
+///         <c>id/stream_id = @id and tenant_id = @tenant_id</c> unconditionally — not gated on
+///         <c>TenancyStyle.Conjoined</c>, which is safe because a single-tenant store still writes the
+///         default tenant into the column.
+///     </para>
+///     <para>
+///         <b>The tag-ordering test is the one with teeth.</b> <c>fi_event_tag_*</c> carries a real,
+///         enforced foreign key to <c>fi_events(seq_id)</c>, so any statement deleting events has to
+///         delete tag rows first — a lesson <c>DeleteEventsOperation</c> and
+///         <c>DeleteAllEventDataAsync</c> both record in their remarks. Tombstoning is the third
+///         operation in that family and had no test saying it learned it.
+///     </para>
+/// </remarks>
+public class destructive_event_operation_sweep : IAsyncLifetime
+{
+    private const string Alpha = "alpha";
+    private const string Beta = "beta";
+
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("destructive-sweep");
+    private readonly TerritoryId _shire = new(Guid.NewGuid());
+
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+            options.Events.RegisterTagType<TerritoryId>("territory");
+            options.Events.AddEventType(typeof(CoinsEarned));
+            options.Events.AddEventType(typeof(CoinsSpent));
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    ///     The enforced foreign key from the tag table to <c>fi_events(seq_id)</c> means the tag rows
+    ///     have to go first, exactly as they do in <c>DeleteEventsOperation</c>.
+    /// </summary>
+    [Fact]
+    public async Task tombstoning_a_tagged_stream_clears_its_tag_rows_too()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession(Alpha))
+        {
+            var @event = session.Events.BuildEvent(new CoinsEarned(100));
+            @event.WithTag(_shire);
+            session.Events.StartStream<Purse>(streamId, @event);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using (var session = _store.LightweightSession(Alpha))
+        {
+            session.Events.TombstoneStream(streamId);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = _store.LightweightSession(Alpha);
+
+        (await query.Events.FetchStreamAsync(streamId, token: Token)).ShouldBeEmpty();
+
+        // The tag row cannot outlive the event it points at — the foreign key would not allow it, and
+        // a tag query answering for a deleted event is the failure this asserts against.
+        (await query.Events.QueryByTagsAsync(new EventTagQuery().Or<TerritoryId>(_shire), Token))
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task tombstoning_one_tenants_stream_leaves_the_other_tenants_alone()
+    {
+        var streamId = Guid.NewGuid();
+
+        await StartAsync(Alpha, streamId, new CoinsEarned(100), new CoinsSpent(30));
+        await StartAsync(Beta, streamId, new CoinsEarned(7), new CoinsSpent(2));
+
+        await using (var session = _store.LightweightSession(Alpha))
+        {
+            session.Events.TombstoneStream(streamId);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var alpha = _store.LightweightSession(Alpha);
+        await using var beta = _store.LightweightSession(Beta);
+
+        (await alpha.Events.FetchStreamAsync(streamId, token: Token)).ShouldBeEmpty();
+        (await beta.Events.FetchStreamAsync(streamId, token: Token)).Count.ShouldBe(2);
+
+        // The streams row went with it for alpha, and stayed for beta.
+        (await alpha.Events.FetchStreamStateAsync(streamId, Token)).ShouldBeNull();
+        (await beta.Events.FetchStreamStateAsync(streamId, Token)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task archiving_one_tenants_stream_leaves_the_other_tenants_alone()
+    {
+        var streamId = Guid.NewGuid();
+
+        await StartAsync(Alpha, streamId, new CoinsEarned(100));
+        await StartAsync(Beta, streamId, new CoinsEarned(7));
+
+        await using (var session = _store.LightweightSession(Alpha))
+        {
+            session.Events.ArchiveStream(streamId);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var alpha = _store.LightweightSession(Alpha);
+        await using var beta = _store.LightweightSession(Beta);
+
+        (await alpha.Events.FetchStreamStateAsync(streamId, Token))!.IsArchived.ShouldBeTrue();
+        (await beta.Events.FetchStreamStateAsync(streamId, Token))!.IsArchived.ShouldBeFalse();
+    }
+
+    private async Task StartAsync(string tenantId, Guid streamId, params object[] events)
+    {
+        await using var session = _store.LightweightSession(tenantId);
+        session.Events.StartStream<Purse>(streamId, events);
+        await session.SaveChangesAsync(Token);
+    }
+}

--- a/src/Fisher.Tests/Events/masking_rule_application.cs
+++ b/src/Fisher.Tests/Events/masking_rule_application.cs
@@ -1,0 +1,195 @@
+using JasperFx;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>Two independent pieces of protected information on one class body.</summary>
+public class ApplicantScreened : IPersonalData
+{
+    public string Name { get; set; } = string.Empty;
+    public string NationalId { get; set; } = string.Empty;
+}
+
+/// <summary>The record shape, so the <c>Func</c> overload is exercised the same way.</summary>
+public record ReferenceChecked(string Referee, string Phone) : IPersonalData;
+
+/// <summary>
+///     marten#5199 / polecat#422 — <b>every</b> matching masking rule has to run, not just the first
+///     one that matches.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Marten's bug was a <c>||</c> where a <c>|</c> was meant: the first rule that returned true
+///         short-circuited the rest, so an event covered by two rules had only one of them applied and
+///         the batch still reported success. The half-masked event is the worst possible outcome for a
+///         right-to-erasure feature — it looks done.
+///     </para>
+///     <para>
+///         <b>These tests are deliberately not about rule reach.</b>
+///         <c>masking_event_data.an_action_rule_against_an_interface_reaches_every_implementor</c>
+///         already covers an interface rule and a concrete rule together, and a store that keyed its
+///         rules by event type would pass that test — an interface and a class are two different keys.
+///         The discriminating shape is <b>two rules registered against the same type</b>, which a
+///         type-keyed registry collapses to one and a short-circuiting apply loop runs once. Every test
+///         here therefore asserts two separate transformations landed on one event body.
+///     </para>
+/// </remarks>
+public class masking_rule_application : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("masking-rules");
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        _database.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    ///     Two <c>Action</c> rules on the same concrete type, each erasing a different member. A
+    ///     registry keyed by event type keeps only one of them; an apply loop that stops at the first
+    ///     match runs only one of them. Either way one member survives, and the test says which.
+    /// </summary>
+    [Fact]
+    public async Task both_rules_registered_against_the_same_type_are_applied()
+    {
+        await using var store = StoreFor("same_type", options =>
+        {
+            options.Events.AddMaskingRuleForProtectedInformation<ApplicantScreened>(x => x.Name = "REDACTED");
+            options.Events.AddMaskingRuleForProtectedInformation<ApplicantScreened>(
+                x => x.NationalId = "REDACTED");
+        });
+
+        var masked = await MaskAsync<ApplicantScreened>(store,
+            new ApplicantScreened { Name = "Frodo", NationalId = "SH-1234" });
+
+        masked.Name.ShouldBe("REDACTED");
+        masked.NationalId.ShouldBe("REDACTED");
+    }
+
+    /// <summary>
+    ///     The mirror of the test above with the registrations swapped. A short-circuiting loop passes
+    ///     one order and fails the other, so pinning only one order pins nothing.
+    /// </summary>
+    [Fact]
+    public async Task both_rules_are_applied_regardless_of_registration_order()
+    {
+        await using var store = StoreFor("same_type_reversed", options =>
+        {
+            options.Events.AddMaskingRuleForProtectedInformation<ApplicantScreened>(
+                x => x.NationalId = "REDACTED");
+            options.Events.AddMaskingRuleForProtectedInformation<ApplicantScreened>(x => x.Name = "REDACTED");
+        });
+
+        var masked = await MaskAsync<ApplicantScreened>(store,
+            new ApplicantScreened { Name = "Frodo", NationalId = "SH-1234" });
+
+        masked.Name.ShouldBe("REDACTED");
+        masked.NationalId.ShouldBe("REDACTED");
+    }
+
+    /// <summary>
+    ///     The same, through the <c>Func</c> overload — the one a record needs. Each rule replaces the
+    ///     body, so the second has to see the first one's replacement rather than the original.
+    /// </summary>
+    [Fact]
+    public async Task two_func_rules_on_one_record_type_compose()
+    {
+        await using var store = StoreFor("func_pair", options =>
+        {
+            options.Events.AddMaskingRuleForProtectedInformation<ReferenceChecked>(
+                x => x with { Referee = "REDACTED" });
+            options.Events.AddMaskingRuleForProtectedInformation<ReferenceChecked>(
+                x => x with { Phone = "REDACTED" });
+        });
+
+        var masked = await MaskAsync<ReferenceChecked>(store, new ReferenceChecked("Gandalf", "555-0100"));
+
+        masked.Referee.ShouldBe("REDACTED");
+        masked.Phone.ShouldBe("REDACTED");
+    }
+
+    /// <summary>
+    ///     An interface rule and a concrete rule, both asserted by their effect on the body rather than
+    ///     by a counter. This is the shape a type-keyed registry passes, which is exactly why it is not
+    ///     the only test here.
+    /// </summary>
+    [Fact]
+    public async Task an_interface_rule_and_a_concrete_rule_both_apply()
+    {
+        await using var store = StoreFor("interface_and_concrete", options =>
+        {
+            options.Events.AddMaskingRuleForProtectedInformation<IPersonalData>(x =>
+            {
+                if (x is ApplicantScreened applicant)
+                {
+                    applicant.NationalId = "REDACTED";
+                }
+            });
+
+            options.Events.AddMaskingRuleForProtectedInformation<ApplicantScreened>(x => x.Name = "REDACTED");
+        });
+
+        var masked = await MaskAsync<ApplicantScreened>(store,
+            new ApplicantScreened { Name = "Frodo", NationalId = "SH-1234" });
+
+        masked.Name.ShouldBe("REDACTED");
+        masked.NationalId.ShouldBe("REDACTED");
+    }
+
+    /// <summary>
+    ///     Three rules, so a fix that merely un-short-circuits the second one still has something to
+    ///     fail on.
+    /// </summary>
+    [Fact]
+    public async Task a_third_matching_rule_runs_too()
+    {
+        await using var store = StoreFor("three_rules", options =>
+        {
+            options.Events.AddMaskingRuleForProtectedInformation<ApplicantScreened>(x => x.Name = "A");
+            options.Events.AddMaskingRuleForProtectedInformation<ApplicantScreened>(x => x.Name += "B");
+            options.Events.AddMaskingRuleForProtectedInformation<ApplicantScreened>(x => x.Name += "C");
+        });
+
+        var masked = await MaskAsync<ApplicantScreened>(store,
+            new ApplicantScreened { Name = "Frodo", NationalId = "SH-1234" });
+
+        masked.Name.ShouldBe("ABC");
+    }
+
+    // ---- helpers ----
+
+    private DocumentStore StoreFor(string schema, Action<StoreOptions> configure)
+        => DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.DatabaseSchemaName = schema;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.AddEventType(typeof(ApplicantScreened));
+            options.Events.AddEventType(typeof(ReferenceChecked));
+
+            configure(options);
+        });
+
+    private async Task<T> MaskAsync<T>(DocumentStore store, object @event)
+    {
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, @event);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await store.Advanced.ApplyEventDataMaskingAsync(x => x.IncludeStream(streamId), Token);
+
+        await using var query = store.LightweightSession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: Token);
+
+        return (T)events.ShouldHaveSingleItem().Data;
+    }
+}

--- a/src/Fisher.Tests/Events/stream_compacting_identity_and_scope.cs
+++ b/src/Fisher.Tests/Events/stream_compacting_identity_and_scope.cs
@@ -1,0 +1,221 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Protected;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>
+///     <see cref="Purse" />'s twin for a string-identified store — a single stream aggregate takes its
+///     identity from the stream, so the two have to agree on the type.
+/// </summary>
+public class Satchel
+{
+    public string Id { get; set; } = string.Empty;
+    public int Balance { get; set; }
+
+    public void Apply(CoinsEarned earned) => Balance += earned.Amount;
+
+    public void Apply(CoinsSpent spent) => Balance -= spent.Amount;
+}
+
+/// <summary>
+///     polecat#546 item 3 / marten#5244 — compaction must refuse an overload that disagrees with the
+///     store's stream identity rather than silently compacting nothing, and must never reach a stream
+///     other than the one it was given.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Polecat's <c>StreamCompactingExecution</c> branched on the store's configured
+///         <c>StreamIdentity</c> and never checked which overload the caller had used. The Guid
+///         overload against a string-identified store took the AsString branch, read a null
+///         <c>StreamKey</c>, matched no stream, and <b>returned successfully having compacted
+///         nothing</b> — indistinguishable from a completed compaction. Fisher's <c>FetchAsync</c>
+///         branches the same way, so the same mistake would produce the same silence; what stops it is
+///         the <c>AssertGuidIdentity</c>/<c>AssertStringIdentity</c> pair on the entry points, and
+///         these tests are what hold that pair in place.
+///     </para>
+///     <para>
+///         The untyped <c>IEventStore</c> overloads are covered too. They reach the assertion by
+///         delegation — through <c>FetchStreamStateAsync</c> — which is a real guarantee but an
+///         indirect one, and indirect guarantees are the ones that quietly disappear during a
+///         refactor.
+///     </para>
+///     <para>
+///         The last two tests cover the within-tenant half of the scoping question that
+///         <see cref="cross_tenant_protected_operations" /> answers across tenants: compacting stream A
+///         must leave stream B alone, both its events and its compaction watermark.
+///     </para>
+/// </remarks>
+public class stream_compacting_identity_and_scope : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("compact-identity");
+
+    private DocumentStore _guidStore = null!;
+    private DocumentStore _stringStore = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _guidStore = StoreFor("guids", StreamIdentity.AsGuid);
+        _stringStore = StoreFor("keys", StreamIdentity.AsString);
+
+        await _guidStore.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+        await _stringStore.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _guidStore.DisposeAsync();
+        await _stringStore.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    // ---- identity mismatch on the typed overloads ----
+
+    /// <summary>
+    ///     Polecat's exact defect: this combination silently compacted nothing there.
+    /// </summary>
+    [Fact]
+    public async Task the_guid_overload_is_refused_by_a_string_identified_store()
+    {
+        await using var session = _stringStore.LightweightSession();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            session.Events.CompactStreamAsync<Satchel>(Guid.NewGuid()));
+
+        ex.Message.ShouldContain("StreamIdentity.AsString");
+        ex.Message.ShouldContain("string stream key overloads");
+    }
+
+    /// <summary>
+    ///     The mirror. In Polecat this threw "Nullable object must have a value", which names nothing
+    ///     the caller can act on.
+    /// </summary>
+    [Fact]
+    public async Task the_string_overload_is_refused_by_a_guid_identified_store()
+    {
+        await using var session = _guidStore.LightweightSession();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            session.Events.CompactStreamAsync<Purse>("some-key"));
+
+        ex.Message.ShouldContain("StreamIdentity.AsGuid");
+        ex.Message.ShouldContain("Guid stream id overloads");
+    }
+
+    // ---- identity mismatch on the untyped tooling entry point ----
+
+    [Fact]
+    public async Task the_untyped_guid_entry_point_is_refused_by_a_string_identified_store()
+    {
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            ((IEventStore)_stringStore).CompactStreamAsync(Guid.NewGuid(), Token));
+
+        ex.Message.ShouldContain("StreamIdentity.AsString");
+    }
+
+    [Fact]
+    public async Task the_untyped_string_entry_point_is_refused_by_a_guid_identified_store()
+    {
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            ((IEventStore)_guidStore).CompactStreamAsync("some-key", Token));
+
+        ex.Message.ShouldContain("StreamIdentity.AsGuid");
+    }
+
+    /// <summary>
+    ///     The refusal has to be a refusal, not a refusal-shaped no-op: a store with the matching
+    ///     identity still compacts.
+    /// </summary>
+    [Fact]
+    public async Task a_string_identified_store_still_compacts_through_its_own_overload()
+    {
+        const string streamKey = "purse/frodo";
+
+        await using (var session = _stringStore.LightweightSession())
+        {
+            session.Events.StartStream<Satchel>(streamKey, new CoinsEarned(100), new CoinsSpent(30));
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using (var session = _stringStore.LightweightSession())
+        {
+            await session.Events.CompactStreamAsync<Satchel>(streamKey);
+        }
+
+        await using var query = _stringStore.LightweightSession();
+        var events = await query.Events.FetchStreamAsync(streamKey, token: Token);
+
+        events.ShouldHaveSingleItem().Data.ShouldBeOfType<Compacted<Satchel>>().Snapshot.Balance.ShouldBe(70);
+    }
+
+    // ---- stream scoping within one tenant ----
+
+    [Fact]
+    public async Task compacting_one_stream_leaves_a_neighbouring_stream_untouched()
+    {
+        var compacted = Guid.NewGuid();
+        var neighbour = Guid.NewGuid();
+
+        await StartGuidStreamAsync(compacted, new CoinsEarned(100), new CoinsSpent(30), new CoinsEarned(5));
+        await StartGuidStreamAsync(neighbour, new CoinsEarned(7), new CoinsSpent(2), new CoinsEarned(1));
+
+        await using (var session = _guidStore.LightweightSession())
+        {
+            await session.Events.CompactStreamAsync<Purse>(compacted);
+        }
+
+        await using var query = _guidStore.LightweightSession();
+
+        (await query.Events.FetchStreamAsync(compacted, token: Token))
+            .ShouldHaveSingleItem().Data.ShouldBeOfType<Compacted<Purse>>().Snapshot.Balance.ShouldBe(75);
+
+        var untouched = await query.Events.FetchStreamAsync(neighbour, token: Token);
+        untouched.Count.ShouldBe(3);
+        untouched.ShouldAllBe(x => x.Data is CoinsEarned || x.Data is CoinsSpent);
+    }
+
+    /// <summary>
+    ///     The watermark half of the same question — a stream nobody compacted must still read zero.
+    /// </summary>
+    [Fact]
+    public async Task the_compaction_watermark_lands_only_on_the_compacted_stream()
+    {
+        var compacted = Guid.NewGuid();
+        var neighbour = Guid.NewGuid();
+
+        await StartGuidStreamAsync(compacted, new CoinsEarned(100), new CoinsSpent(30));
+        await StartGuidStreamAsync(neighbour, new CoinsEarned(7), new CoinsSpent(2));
+
+        await using (var session = _guidStore.LightweightSession())
+        {
+            await session.Events.CompactStreamAsync<Purse>(compacted);
+        }
+
+        await using var query = _guidStore.LightweightSession();
+
+        (await query.Events.FetchStreamStateAsync(compacted, Token))!.CompactedVersion.ShouldBe(2);
+        (await query.Events.FetchStreamStateAsync(neighbour, Token))!.CompactedVersion.ShouldBe(0);
+    }
+
+    // ---- helpers ----
+
+    private DocumentStore StoreFor(string schema, StreamIdentity identity)
+        => DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.DatabaseSchemaName = schema;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.StreamIdentity = identity;
+            options.Events.AddEventType(typeof(CoinsEarned));
+            options.Events.AddEventType(typeof(CoinsSpent));
+        });
+
+    private async Task StartGuidStreamAsync(Guid streamId, params object[] events)
+    {
+        await using var session = _guidStore.LightweightSession();
+        session.Events.StartStream<Purse>(streamId, events);
+        await session.SaveChangesAsync(Token);
+    }
+}

--- a/src/Fisher/Events/Storage/EventAuxiliaryOperationsForSqlite.cs
+++ b/src/Fisher/Events/Storage/EventAuxiliaryOperationsForSqlite.cs
@@ -53,6 +53,16 @@ internal sealed class SetStreamArchivedOperation : Weasel.Storage.IStorageOperat
 /// <summary>
 ///     Hard-deletes a stream and its events.
 /// </summary>
+/// <remarks>
+///     <b>Tag rows go first, and that is not tidiness.</b> Every <c>fi_event_tag_*</c> table has a real
+///     foreign key to <c>fi_events(seq_id)</c> and Weasel's default profile turns enforcement on, so
+///     deleting the events first fails the whole unit of work with
+///     <c>FOREIGN KEY constraint failed</c> — meaning a stream with a single tagged event could not be
+///     tombstoned at all. This is the third operation in this family to learn the ordering, after
+///     <c>DeleteAllEventDataAsync</c> (fisher#6) and
+///     <see cref="Protected.DeleteEventsOperation" />; unlike those two it is reached through a public
+///     API, so it is the one where the lesson was most visible.
+/// </remarks>
 internal sealed class TombstoneStreamOperation : Weasel.Storage.IStorageOperation
 {
     private readonly EventGraph _events;
@@ -72,6 +82,18 @@ internal sealed class TombstoneStreamOperation : Weasel.Storage.IStorageOperatio
 
     public void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
     {
+        // The sub-select re-reads the same tenant-and-stream predicate the event delete below uses, so
+        // a tag row can only be reached through an event this operation is already removing.
+        foreach (var registration in _events.TagTypes)
+        {
+            builder.Append($"""
+                            delete from {_events.TagTableName(registration)}
+                            where seq_id in (
+                                select seq_id from {_events.EventsTableName}
+                                where stream_id = @id and tenant_id = @tenant_id);
+                            """);
+        }
+
         builder.Append($"""
                         delete from {_events.EventsTableName}
                         where stream_id = @id and tenant_id = @tenant_id;


### PR DESCRIPTION
Closes #185.

The `critter-hardening-audit` protected-data audit (Stoat node `fisher-protected-audit`), applying polecat#546's checklist to Fisher. Every item got a discriminating test written first; where the item came back green, the test was re-run against a deliberately broken tree to prove it was not vacuously passing.

**Three of the four items were already safe, and the tests are what now hold them that way.** The full per-item verdicts, the injections used to falsify each test, and the reasoning are in #185. In brief:

- **Masking applies every matching rule** (marten#5199 / polecat#422) — already correct: `matched |= …`, and rules live in a `List<IMasker>` rather than a type-keyed registry, so two rules on one type are both kept. Five new tests; replacing `|=` with `matched = matched || …` reddens all five.
- **Cross-tenant destructive writes** (marten#5234 / polecat#547) — **Polecat's exact bug is structurally unreachable here.** `fi_events.seq_id` is one `INTEGER PRIMARY KEY AUTOINCREMENT` shared by every tenant in the file, so a sequence identifies exactly one row and the three unscoped `where seq_id` predicates have nowhere to escape to. That uniqueness is a precondition of the verdict rather than a detail, so it is now asserted directly — if Fisher ever adopts per-tenant sequencing, that test goes red before the isolation tests quietly stop proving anything. What does hold the line today is the read half, and dropping the tenant predicate from `FetchStreamAsync` reddens four of the five new tests.
- **`CompactStreamAsync<T>` identity assertions** (marten#5244) — already guarded on both typed overloads and, by delegation through `FetchStreamStateAsync`, on the untyped `IEventStore` pair. Seven new tests. Worth recording what the missing guard would produce: the untyped overloads fall through to `"Stream '<id>' does not exist."`, a plausible answer that sends the caller hunting a missing stream when the fault is the wrong overload.

## The one live defect

**`TombstoneStream` could not delete a tagged stream at all.** `fi_event_tag_*` carries a real, enforced foreign key to `fi_events(seq_id)`, and `TombstoneStreamOperation` deleted the events first — so tombstoning any stream with a single tagged event failed the whole unit of work with `SQLite Error 19: 'FOREIGN KEY constraint failed'`.

This is the same ordering lesson `DeleteAllEventDataAsync` (fisher#6) and `DeleteEventsOperation` both already record in their remarks; `TombstoneStream` is the only member of that family reached through a public API, and the only one that had no test saying it had learned it. Tag rows now go first, through a sub-select carrying the same tenant-and-stream predicate the event delete uses, so a tag row can only be reached through an event the operation is already removing.

Severity is bounded — the foreign key made this a loud, atomic failure rather than silent corruption, and nothing was lost. But a stream carrying any DCB tag could not be hard-deleted, which is a real hole in a right-to-erasure story.

## Tests

Four new files, 20 tests: `masking_rule_application` (5), `cross_tenant_protected_operations` (5), `stream_compacting_identity_and_scope` (7), `destructive_event_operation_sweep` (3).

`Fisher.Tests` **1574/1574 green on net9.0 and net10.0**, up from 1554. `Fisher.EntityFrameworkCore.Tests` 19/19 and `Fisher.AspNetCore.Tests` 36/36 on both TFMs — the latter failed 12 on its first net9.0 run and was green on three subsequent ones, unrelated to this change. HANDOFF.md's scoreboard is reconciled to 1629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
