### PR TITLE
Session semantics: guard the session's lazily-built shared state against the async daemon (marten#4657/#4667)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -511,6 +511,25 @@ Six things that are decisions rather than mechanics:
   presented as a multi-stream rebuild intermittently missing one slice's document. Note how closely it
   rhymes with fisher#12: same silent outcome, one layer up. `concurrent_operation_queueing` pins both
   the add and the take.
+- **So is every other lazily-built field on the session, and that half was missed for a year.** The
+  queue got a lock out of fisher#13 and the fields beside it kept their `??=`, which is a read, a
+  branch and a write — so two slices arriving together each construct one and **one is silently
+  discarded with everything recorded on it**. Two of them are on the write path a slice actually
+  takes: `IStorageSession.Versions` is resolved by the numeric and optimistic storages while
+  *constructing* an upsert, on the calling thread, and `_queryProvider` is resolved by `Query<T>()`,
+  which is how a slice reads what it is about to fold into. A discarded version tracker means a later
+  guarded write compares against a version the session no longer remembers reading — a spurious
+  `ConcurrencyException` at best, a stale write accepted at worst. One layer down,
+  `FisherVersionTracker`'s two `Dictionary<Type, object>` fields were mutated unguarded by
+  `ForType`/`RevisionsFor`, which is the shape that loses an entry outright.
+  **This is marten#4657/#4667 reached from the other side**: there, concurrent slices were handed
+  separate sessions that *shared* a `VersionTracker`, an `ItemMap` and a `ChangeTrackers` list; here
+  they share the session itself, which is a shorter route to the same place. `FisherSession.LazilyCreate`
+  is the one place a lazily-built field is now created, and `concurrent_session_tracker_state` pins it
+  — four of its five tests fail without the guards.
+  **The tracker's *inner* dictionaries stay unguarded, deliberately**: they are handed to a storage
+  operation, which writes into one during postprocessing, and postprocessing runs inside
+  `ExecuteBatchAsync`, which is strictly sequential because SQLite takes one writer per file.
 - **The batch must stay atomic.** It commits the projection's document writes *and* the progression
   row in one transaction. Splitting them lets a crash between them either replay events already
   applied or skip events never applied, permanently and with nothing to signal it. Sessions are
@@ -1420,13 +1439,18 @@ of change detection.
   inconsistent and is not: a tracker is a queued write that has not been asked for yet. Pending DCB
   boundaries go too — a boundary guards appends that are being dropped, so keeping it would fail a
   later commit on behalf of a unit of work that no longer exists.
-- **The map and the tracker list are unguarded, and fisher#13 is the reason that needs saying.** They
-  are exactly the kind of shared mutable per-session state the operation queue turned out to be. The
-  difference is that a tracking mode is only ever chosen by whoever opens the session, and the one
-  caller that drives a session from several threads — the async daemon — opens `LightweightSession()`
-  everywhere. `the_daemon_opens_untracked_sessions` pins that, so making the daemon's sessions tracked
-  has to be a deliberate act. Guarding here would also only be half a guard: Weasel's selectors hold
-  their own reference to the same dictionary.
+- **The map's and the tracker list's *contents* are unguarded, and fisher#13 is the reason that needs
+  saying.** They are exactly the kind of shared mutable per-session state the operation queue turned
+  out to be. The difference is that a tracking mode is only ever chosen by whoever opens the session,
+  and the one caller that drives a session from several threads — the async daemon — opens
+  `LightweightSession()` everywhere. `the_daemon_opens_untracked_sessions` and
+  `concurrent_session_tracker_state.the_daemons_own_sessions_are_untracked` both pin that, so making
+  the daemon's sessions tracked has to be a deliberate act. Guarding the contents would also only be
+  half a guard: Weasel's selectors hold their own reference to the same dictionary.
+  **Their *creation* is guarded**, along with every other lazily-built field on the session — see the
+  async daemon section. Not an inconsistency: it keeps the argument above about what the dictionary
+  holds, rather than also about whether two callers can end up holding different dictionaries, and it
+  costs a lock taken once per session.
 - **There is no `QueryOnly` tracking value**, where Marten has one. Marten's names a session that
   cannot write; Fisher has none — `QuerySession()`'s narrowing is a convention — so a mode resolving
   the query-only flavor would make `Store` throw on a session the store hands out as writeable.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1609 tests green on net9.0 and net10.0**, with no known intermittent failures — 1554 in
+**1635 tests green on net9.0 and net10.0**, with no known intermittent failures — 1580 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 391 of
 them are shared cross-store compliance tests — 322 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1635 tests green on net9.0 and net10.0**, with no known intermittent failures — 1580 in
+**1655 tests green on net9.0 and net10.0**, with no known intermittent failures — 1600 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 391 of
 them are shared cross-store compliance tests — 322 event sourcing and 69 document. On JasperFx **2.63.0** / Weasel **9.29.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 40 suites and 391 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,580.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,600.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 40 suites and 391 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,554.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,580.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/src/Fisher.Tests/Documents/concurrent_revision_write_loss.cs
+++ b/src/Fisher.Tests/Documents/concurrent_revision_write_loss.cs
@@ -1,0 +1,282 @@
+using JasperFx;
+using Microsoft.Data.Sqlite;
+using Weasel.Core;
+using Weasel.Storage;
+
+namespace Fisher.Tests.Documents;
+
+/// <summary>
+///     Silent write-loss on a revisioned upsert — Marten <c>c09eed24c</c> + <c>c8e851722</c>, checked
+///     against genuinely concurrent writers rather than against the sequential guard
+///     <c>numeric_revisions</c> already pins.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>The Marten bug.</b> <c>mt_upsert_&lt;doc&gt;</c> ran a conditional
+///         <c>ON CONFLICT … DO UPDATE … WHERE revision &gt; mt_version</c> and then unconditionally
+///         re-<c>SELECT</c>ed <c>mt_version</c> as its return value. When a concurrent transaction had
+///         already moved the version past the caller's revision the UPDATE matched no row, but the
+///         function still returned a non-zero version — which Marten reads as success. The write was
+///         dropped and reported as landed. The fix made the returned value come from the UPDATE
+///         itself, via <c>RETURNING</c>.
+///     </para>
+///     <para>
+///         <b>Why Fisher's shape is the fixed one already.</b> The upsert is
+///         <c>insert … on conflict … do update set … where (? = 0 or t.revision &lt; ?) returning revision</c>
+///         — one statement, and <c>RETURNING</c> in SQLite emits a row only for a row the statement
+///         actually wrote. A guard that matches nothing yields no row, which is exactly what the
+///         shared numeric operations' postprocessing reads as a <see cref="ConcurrencyException" />.
+///         There is no second read to disagree with the first, because there is no second read.
+///     </para>
+///     <para>
+///         <b>SQLite's one-writer-per-file does not by itself make this safe, which is why these are
+///         behavioural tests and not a comment.</b> Serialising the writers removes the interleaving,
+///         not the staleness: two sessions can both read revision 1, and the second's commit then runs
+///         against a row already at 2. That is the whole of the bug — a guard evaluated against a row
+///         somebody else moved — and it survives serialisation intact. What one writer per file
+///         guarantees is only that the two do not overlap <em>inside</em> the statement.
+///     </para>
+///     <para>
+///         <b>Every assertion pairs a reported outcome with the stored row</b>, because a silent loss
+///         is precisely the case where the two disagree. Asserting only that one writer threw would
+///         pass against a store that dropped the winner's write as well.
+///     </para>
+/// </remarks>
+public class concurrent_revision_write_loss : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("revision-races");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private async Task<Permit> StorePermitAsync(string description)
+    {
+        var permit = new Permit { Id = Guid.NewGuid(), Description = description };
+
+        await using var session = _store.LightweightSession();
+        session.Store(permit);
+        await session.SaveChangesAsync(Token);
+
+        return permit;
+    }
+
+    private async Task<(long Revision, string Description)> StoredAsync(Guid id)
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "select revision, json_extract(data, '$.description') from fi_doc_permit where id = @id";
+        command.Parameters.AddWithValue("@id", id.ToString());
+
+        await using var reader = await command.ExecuteReaderAsync(Token);
+        (await reader.ReadAsync(Token)).ShouldBeTrue();
+
+        return (reader.GetInt64(0), reader.GetString(1));
+    }
+
+    /// <remarks>
+    ///     Two writers, both holding revision 1, both trying to move it to 2. Exactly one may win, and
+    ///     — the half that catches the Marten shape — <b>the row must hold what the winner wrote</b>.
+    ///     A silent loss shows as both reporting success with only one description stored.
+    /// </remarks>
+    [Fact]
+    public async Task two_writers_at_the_same_revision_do_not_both_report_success()
+    {
+        var permit = await StorePermitAsync("Trout, one rod");
+
+        await using var first = _store.LightweightSession();
+        await using var second = _store.LightweightSession();
+
+        var mine = await first.LoadAsync<Permit>(permit.Id, Token);
+        var theirs = await second.LoadAsync<Permit>(permit.Id, Token);
+
+        mine!.Version.ShouldBe(1);
+        theirs!.Version.ShouldBe(1);
+
+        mine.Description = "Pike";
+        theirs.Description = "Perch";
+
+        first.UpdateRevision(mine, 2);
+        second.UpdateRevision(theirs, 2);
+
+        var winners = new List<string>();
+
+        foreach (var (session, document) in new[] { (first, mine), (second, theirs) })
+        {
+            try
+            {
+                await session.SaveChangesAsync(Token);
+                winners.Add(document.Description);
+            }
+            catch (ConcurrencyException)
+            {
+            }
+        }
+
+        winners.Count.ShouldBe(1);
+
+        var stored = await StoredAsync(permit.Id);
+        stored.Revision.ShouldBe(2);
+        stored.Description.ShouldBe(winners.Single());
+    }
+
+    /// <remarks>
+    ///     <para>
+    ///         The same fact scaled: eight writers all holding revision 1 and all claiming revision 2.
+    ///         Exactly one may report success, and the row must agree with whoever did.
+    ///     </para>
+    ///     <para>
+    ///         <b>The eight reads overlap and the eight commits are deliberately serialised</b>, and
+    ///         that is the honest shape rather than a weakening. What this bug class is about is a
+    ///         guard evaluated against a row somebody else moved — which is entirely a property of
+    ///         the eight <em>reads</em> having happened before any commit. Releasing eight commits at
+    ///         once on one SQLite file adds no staleness whatever: the file takes one writer at a
+    ///         time regardless, so the seven losers would simply queue at the write lock, each waiting
+    ///         out the connection's 30-second busy timeout. That turns a deterministic assertion into
+    ///         a minutes-long test whose failures are timeouts.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task racing_writers_never_report_success_for_a_write_that_did_not_land()
+    {
+        const int writers = 8;
+
+        var permit = await StorePermitAsync("Trout, one rod");
+
+        var sessions = new List<IDocumentSession>();
+        var documents = new List<Permit>();
+
+        // Every writer reads before any of them writes — this is where the staleness comes from.
+        await Task.WhenAll(Enumerable.Range(0, writers).Select(async i =>
+        {
+            var session = _store.LightweightSession();
+
+            var loaded = await session.LoadAsync<Permit>(permit.Id, Token);
+            loaded!.Version.ShouldBe(1);
+            loaded.Description = $"Writer {i}";
+
+            lock (sessions)
+            {
+                sessions.Add(session);
+                documents.Add(loaded);
+            }
+        }));
+
+        var reported = new List<string>();
+
+        for (var i = 0; i < writers; i++)
+        {
+            sessions[i].UpdateRevision(documents[i], 2);
+
+            try
+            {
+                await sessions[i].SaveChangesAsync(Token);
+                reported.Add(documents[i].Description);
+            }
+            catch (ConcurrencyException)
+            {
+            }
+        }
+
+        foreach (var session in sessions)
+        {
+            await session.DisposeAsync();
+        }
+
+        reported.Count.ShouldBe(1);
+
+        var stored = await StoredAsync(permit.Id);
+        stored.Revision.ShouldBe(2);
+        stored.Description.ShouldBe(reported.Single());
+    }
+
+    /// <remarks>
+    ///     The auto-increment path, which has no guard to fail and therefore a different way to lose a
+    ///     write: the final revision must account for every success. Six racing writers that all
+    ///     succeed must leave the row at 1 + 6, so a dropped update shows as a revision lower than the
+    ///     number of writes claimed to have landed.
+    /// </remarks>
+    [Fact]
+    public async Task auto_increment_accounts_for_every_reported_success()
+    {
+        const int writers = 6;
+
+        var permit = await StorePermitAsync("Trout, one rod");
+
+        var successes = 0;
+
+        for (var i = 0; i < writers; i++)
+        {
+            await using var session = _store.LightweightSession();
+
+            // Revision 0 is the auto sentinel: increment whatever is stored, guard always passes.
+            session.Store(new Permit { Id = permit.Id, Description = $"Writer {i}", Version = 0 });
+
+            try
+            {
+                await session.SaveChangesAsync(Token);
+                successes++;
+            }
+            catch (ConcurrencyException)
+            {
+            }
+        }
+
+        successes.ShouldBe(writers);
+        (await StoredAsync(permit.Id)).Revision.ShouldBe(1 + writers);
+    }
+
+    /// <remarks>
+    ///     <c>TryUpdateRevision</c> is the "last writer loses quietly" variant, so it reports nothing
+    ///     — which makes it the one shape where a silent loss is <em>correct</em>. What must still hold
+    ///     is that the row keeps the newer write rather than the dropped one, and that everything else
+    ///     in the unit of work commits.
+    /// </remarks>
+    [Fact]
+    public async Task a_dropped_try_update_leaves_the_newer_write_in_place()
+    {
+        var permit = await StorePermitAsync("Trout, one rod");
+
+        await using (var ahead = _store.LightweightSession())
+        {
+            var theirs = await ahead.LoadAsync<Permit>(permit.Id, Token);
+            theirs!.Description = "Pike";
+            ahead.UpdateRevision(theirs, 5);
+            await ahead.SaveChangesAsync(Token);
+        }
+
+        var other = new Permit { Id = Guid.NewGuid(), Description = "Unrelated" };
+
+        await using (var stale = _store.LightweightSession())
+        {
+            stale.TryUpdateRevision(new Permit { Id = permit.Id, Description = "Perch" }, 2);
+            stale.Store(other);
+
+            await stale.SaveChangesAsync(Token);
+        }
+
+        var stored = await StoredAsync(permit.Id);
+        stored.Revision.ShouldBe(5);
+        stored.Description.ShouldBe("Pike");
+
+        (await StoredAsync(other.Id)).Description.ShouldBe("Unrelated");
+    }
+}

--- a/src/Fisher.Tests/Documents/server_timestamp_utc.cs
+++ b/src/Fisher.Tests/Documents/server_timestamp_utc.cs
@@ -1,0 +1,366 @@
+using Fisher.Storage;
+using JasperFx;
+using Microsoft.Data.Sqlite;
+using Weasel.Core;
+
+namespace Fisher.Tests.Documents;
+
+/// <summary>
+///     Server-written timestamps really are UTC — marten#5136's shape, checked against SQLite's
+///     idioms rather than PostgreSQL's.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>The Marten bug.</b> <c>now() at time zone 'utc'</c> written into a <c>timestamptz</c>
+///         column yields a naive timestamp that PostgreSQL then re-interprets in the server's own
+///         zone, so <c>mt_last_modified</c> and <c>mt_events.timestamp</c> came out skewed by the
+///         server's UTC offset. Invisible on a UTC server, which is where it was tested.
+///     </para>
+///     <para>
+///         <b>SQLite's analogues, and why Fisher's spelling is the correct one.</b> There is no
+///         date/time type at all, so the entire question is what text goes into a TEXT column. SQLite's
+///         <c>'now'</c> modifier is UTC by construction; <c>datetime('now','localtime')</c> is the way
+///         to get the machine's wall clock, and <c>CURRENT_TIMESTAMP</c> is UTC but renders
+///         <c>'YYYY-MM-DD HH:MM:SS'</c> with no sub-second part and no zone marker.
+///         <see cref="SqliteTimestamp.NowExpression" /> is <c>strftime('%Y-%m-%dT%H:%M:%fZ','now')</c>
+///         — UTC, milliseconds, and a literal <c>Z</c> that is honest rather than decorative.
+///     </para>
+///     <para>
+///         <b>Two halves, because neither alone is enough.</b> The behavioural tests compare a stored
+///         instant against a client-side UTC window, which catches a local-time expression outright —
+///         but only on a client that is not itself on UTC, so they <b>skip rather than pass</b> when
+///         the host is at offset zero. A UTC CI runner therefore cannot green them by accident. The
+///         schema tests are timezone-independent and always run: they are what would catch a
+///         <c>'localtime'</c> modifier or a stray <c>CURRENT_TIMESTAMP</c> introduced later, on any
+///         host.
+///     </para>
+///     <para>
+///         Fisher's client side is clean too and stays that way by the same means:
+///         <see cref="SqliteTimestamp.ToDatabaseValue" /> calls <c>ToUniversalTime()</c>, and
+///         <see cref="SqliteTimestamp.FromDatabaseValue" /> parses with <c>AssumeUniversal</c> — so a
+///         value that lost its <c>Z</c> is still read as UTC rather than as local, which is the read
+///         half of the same mistake.
+///     </para>
+/// </remarks>
+public class server_timestamp_utc : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("utc-timestamps");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<Boat>().SoftDeleted();
+            options.Schema.For<Boat>().Metadata(m => m.CreatedAt.Enabled = true);
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    ///     The client's current offset from UTC. Zero means this run cannot tell a UTC expression from
+    ///     a local-time one, whatever the store does.
+    /// </summary>
+    private static TimeSpan LocalOffset => TimeZoneInfo.Local.GetUtcOffset(DateTimeOffset.UtcNow);
+
+    /// <summary>
+    ///     Skip rather than pass when the host is on UTC, so this file cannot go green by accident on
+    ///     a UTC CI runner.
+    /// </summary>
+    private static void RequireANonUtcHost()
+    {
+        if (LocalOffset == TimeSpan.Zero)
+        {
+            Assert.Skip(
+                "This host is on UTC, so a local-time expression would be indistinguishable from a "
+                + "UTC one. The schema tests in this class still discriminate and still ran.");
+        }
+    }
+
+    private async Task<string?> ScalarAsync(string sql)
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        var value = await command.ExecuteScalarAsync(Token);
+        return value as string;
+    }
+
+    private async Task<IReadOnlyList<(string Table, string Sql)>> SchemaAsync()
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "select name, sql from sqlite_master where sql is not null";
+
+        var rows = new List<(string, string)>();
+
+        await using var reader = await command.ExecuteReaderAsync(Token);
+        while (await reader.ReadAsync(Token))
+        {
+            rows.Add((reader.GetString(0), reader.GetString(1)));
+        }
+
+        return rows;
+    }
+
+    // ---- behavioural: only meaningful off UTC ----
+
+    [Fact]
+    public async Task a_documents_last_modified_is_the_real_utc_instant()
+    {
+        RequireANonUtcHost();
+
+        var id = Guid.NewGuid();
+
+        var before = DateTimeOffset.UtcNow;
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new Boat { Id = id, Name = "Northern Star" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        var after = DateTimeOffset.UtcNow;
+
+        await using var query = _store.QuerySession();
+        var metadata = await query.MetadataForAsync<Boat>(id, Token);
+
+        metadata.ShouldNotBeNull();
+
+        // A dropped or inverted offset lands a whole timezone away — hours, not the milliseconds of
+        // slack these bounds allow.
+        metadata.LastModified.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(-1));
+        metadata.LastModified.ShouldBeLessThanOrEqualTo(after.AddSeconds(1));
+    }
+
+    [Fact]
+    public async Task a_documents_created_at_is_the_real_utc_instant()
+    {
+        RequireANonUtcHost();
+
+        var id = Guid.NewGuid();
+
+        var before = DateTimeOffset.UtcNow;
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new Boat { Id = id, Name = "Northern Star" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        var after = DateTimeOffset.UtcNow;
+
+        // created_at is filled by the column DEFAULT rather than by a write binder, so it is the one
+        // that exercises NowDefaultExpression rather than NowExpression.
+        await using var query = _store.QuerySession();
+        var metadata = await query.MetadataForAsync<Boat>(id, Token);
+
+        metadata!.CreatedAt.ShouldNotBeNull();
+        metadata.CreatedAt.Value.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(-1));
+        metadata.CreatedAt.Value.ShouldBeLessThanOrEqualTo(after.AddSeconds(1));
+    }
+
+    [Fact]
+    public async Task a_soft_deletions_deleted_at_is_the_real_utc_instant()
+    {
+        RequireANonUtcHost();
+
+        var id = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new Boat { Id = id, Name = "Northern Star" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        var before = DateTimeOffset.UtcNow;
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Delete<Boat>(id);
+            await session.SaveChangesAsync(Token);
+        }
+
+        var after = DateTimeOffset.UtcNow;
+
+        await using var query = _store.QuerySession();
+        var metadata = await query.MetadataForAsync<Boat>(id, Token);
+
+        metadata!.DeletedAt.ShouldNotBeNull();
+        metadata.DeletedAt.Value.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(-1));
+        metadata.DeletedAt.Value.ShouldBeLessThanOrEqualTo(after.AddSeconds(1));
+    }
+
+    /// <remarks>
+    ///     This one is checking the <em>client</em> half rather than the column default: since
+    ///     fisher#119 the append stamps <c>IEvent.Timestamp</c> from <c>DateTimeOffset.UtcNow</c>
+    ///     through <see cref="SqliteTimestamp.ToDatabaseValue" /> and persists that value. So a
+    ///     sabotaged <see cref="SqliteTimestamp.NowExpression" /> leaves this test green — which is
+    ///     the point of it: the two paths have to agree, and this is the one that pins the path the
+    ///     schema tests below cannot see.
+    /// </remarks>
+    [Fact]
+    public async Task an_events_timestamp_is_the_real_utc_instant()
+    {
+        RequireANonUtcHost();
+
+        var before = DateTimeOffset.UtcNow;
+
+        Guid streamId;
+
+        await using (var session = _store.LightweightSession())
+        {
+            streamId = session.Events.StartStream<Boat>(new BoatLaunched("Northern Star")).Id;
+            await session.SaveChangesAsync(Token);
+        }
+
+        var after = DateTimeOffset.UtcNow;
+
+        await using var query = _store.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: Token);
+
+        var timestamp = events.Single().Timestamp;
+        timestamp.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(-1));
+        timestamp.ShouldBeLessThanOrEqualTo(after.AddSeconds(1));
+    }
+
+    /// <remarks>
+    ///     The expression on its own, against the client's own UTC clock — the narrowest statement of
+    ///     the property, with no Fisher column in the way. If this fails, everything above is failing
+    ///     for one reason.
+    /// </remarks>
+    [Fact]
+    public async Task the_now_expression_agrees_with_the_clients_utc_clock()
+    {
+        RequireANonUtcHost();
+
+        var before = DateTimeOffset.UtcNow;
+        var rendered = await ScalarAsync($"select {SqliteTimestamp.NowExpression}");
+        var after = DateTimeOffset.UtcNow;
+
+        rendered.ShouldNotBeNull();
+
+        var parsed = SqliteTimestamp.FromDatabaseValue(rendered);
+        parsed.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(-1));
+        parsed.ShouldBeLessThanOrEqualTo(after.AddSeconds(1));
+    }
+
+    // ---- schema: timezone-independent, always run ----
+
+    /// <remarks>
+    ///     The property a UTC deployment cannot check behaviourally and still has to hold. Asserted
+    ///     over the whole schema rather than over a list of columns, because the risk is a
+    ///     <em>new</em> column spelling its own default.
+    /// </remarks>
+    [Fact]
+    public async Task no_schema_object_asks_sqlite_for_local_time()
+    {
+        foreach (var (name, sql) in await SchemaAsync())
+        {
+            sql.ShouldNotContain("localtime", Case.Insensitive,
+                $"'{name}' asks SQLite for the machine's wall clock, which is not UTC.");
+
+            // CURRENT_TIMESTAMP is UTC but has no sub-second part and no zone marker, so it neither
+            // round-trips through SqliteTimestamp nor orders events appended in the same second.
+            sql.ShouldNotContain("CURRENT_TIMESTAMP", Case.Insensitive,
+                $"'{name}' should use SqliteTimestamp.NowDefaultExpression instead.");
+        }
+    }
+
+    /// <remarks>
+    ///     Every server-written timestamp default is the one shared expression, so there is exactly one
+    ///     place the idiom can be got wrong. Discovered from the schema rather than listed, or a table
+    ///     added later would simply not be checked.
+    /// </remarks>
+    [Fact]
+    public async Task every_timestamp_default_in_the_schema_is_the_shared_utc_expression()
+    {
+        var defaults = 0;
+
+        foreach (var (name, sql) in await SchemaAsync())
+        {
+            var index = 0;
+
+            while ((index = sql.IndexOf("DEFAULT (", index, StringComparison.OrdinalIgnoreCase)) >= 0)
+            {
+                var open = index + "DEFAULT ".Length;
+                var close = sql.IndexOf(')', open);
+
+                // strftime(...) itself carries a nested paren, so take the matching one.
+                var depth = 0;
+                for (var i = open; i < sql.Length; i++)
+                {
+                    if (sql[i] == '(')
+                    {
+                        depth++;
+                    }
+                    else if (sql[i] == ')' && --depth == 0)
+                    {
+                        close = i;
+                        break;
+                    }
+                }
+
+                var expression = sql[open..(close + 1)];
+
+                expression.ShouldBe(SqliteTimestamp.NowDefaultExpression,
+                    $"'{name}' declares an expression default that is not the shared UTC one.");
+
+                defaults++;
+                index = close;
+            }
+        }
+
+        // The event store alone contributes four (fi_events.timestamp, fi_streams.timestamp and
+        // .created, fi_event_progression.last_updated), so a zero here means the walk found nothing
+        // and asserted nothing.
+        defaults.ShouldBeGreaterThanOrEqualTo(4);
+    }
+
+    /// <remarks>
+    ///     The read half of the same mistake. A value that reached the column without its <c>Z</c> —
+    ///     from a hand-written statement, or an older store — must still be read as UTC rather than
+    ///     silently reinterpreted in the machine's zone.
+    /// </remarks>
+    [Fact]
+    public void a_stored_timestamp_without_a_zone_marker_is_still_read_as_utc()
+    {
+        var withZ = SqliteTimestamp.FromDatabaseValue("2026-09-06T14:23:05.123Z");
+        var withoutZ = SqliteTimestamp.FromDatabaseValue("2026-09-06T14:23:05.123");
+
+        withoutZ.ShouldBe(withZ);
+        withoutZ.Offset.ShouldBe(TimeSpan.Zero);
+    }
+
+    /// <remarks>
+    ///     And the write half: a client-supplied value is normalised to UTC rather than written with
+    ///     whatever offset it happened to carry, so the column stays comparable as text.
+    /// </remarks>
+    [Fact]
+    public void a_client_timestamp_is_written_as_utc_whatever_offset_it_carried()
+    {
+        var instant = new DateTimeOffset(2026, 9, 6, 9, 23, 5, 123, TimeSpan.FromHours(-5));
+
+        SqliteTimestamp.ToDatabaseValue(instant).ShouldBe("2026-09-06T14:23:05.123Z");
+        SqliteTimestamp.ToDatabaseValue(instant.ToUniversalTime())
+            .ShouldBe(SqliteTimestamp.ToDatabaseValue(instant));
+    }
+}
+
+public record BoatLaunched(string Name);

--- a/src/Fisher.Tests/Documents/tenant_scope_read_isolation.cs
+++ b/src/Fisher.Tests/Documents/tenant_scope_read_isolation.cs
@@ -1,0 +1,254 @@
+using Fisher.Linq;
+using JasperFx;
+using JasperFx.MultiTenancy;
+
+namespace Fisher.Tests.Documents;
+
+/// <summary>
+///     The read half of <c>ForTenant</c> under a <em>tracking</em> session — the shape polecat#554
+///     turned out to be, ported here as a standing guard rather than as a fix.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>What the Polecat bug was.</b> Every read member of its <c>NestedTenantSession</c>
+///         delegated to the parent session with no tenant argument, so
+///         <c>session.ForTenant("b").LoadAsync&lt;Doc&gt;(id)</c> answered with tenant <c>a</c>'s
+///         document. It stayed quiet because the <em>writes</em> were already tenant-correct, and the
+///         existing tenancy tests only ever asserted the write side. Fixing the queries was only half
+///         the repair: both of Polecat's identity maps are keyed <c>(type, id)</c> with no tenant
+///         component, so a shared map let one tenant's instance answer for another even once the SQL
+///         was right — marten#4801 arrived at by a second route.
+///     </para>
+///     <para>
+///         <b>Why Fisher does not have it.</b> A tenant scope here is a whole second
+///         <see cref="Fisher.Internal.FisherSession" />, not a delegating facade: it shares the
+///         parent's connection and operation queue and nothing else. The identity map, the change
+///         trackers and the version tracker are all instance fields on the scope, so there is no
+///         per-member delegation to forget a tenant argument in and no map keyed without a tenant.
+///         That is a claim about a design, though, and <c>cross_tenant_writes</c> only exercises it on
+///         a <c>LightweightSession</c> — where <c>DocumentTracking.None</c> means no identity map is
+///         resolved at all, so the half of polecat#554 that needed the second fix is precisely the
+///         half those tests cannot see. Everything here runs on <c>IdentitySession</c> and
+///         <c>DirtyTrackedSession</c> for that reason.
+///     </para>
+///     <para>
+///         <b>The order of operations in each test is load-bearing.</b> A cache that answers for the
+///         wrong tenant only does so once something has populated it, so every test reads or writes
+///         through one tenant <em>first</em> and then asks the other. Reversing them would pass
+///         against a completely broken map.
+///     </para>
+///     <para>
+///         marten#4947 is respected from the other side: Fisher refuses a non-multi-tenanted type
+///         through <c>ForTenant</c> by name rather than isolating state for it, so the
+///         over-isolation regression #4947 fixed has no way to arise. That refusal is pinned by
+///         <c>cross_tenant_writes.a_single_tenant_document_type_is_refused_by_name</c>.
+///     </para>
+/// </remarks>
+public class tenant_scope_read_isolation : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("tenant-scope-reads");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+            options.Schema.For<Boat>().MultiTenanted();
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    ///     Seed the same identity into both tenants with different names, which is what makes every
+    ///     assertion below able to tell the two apart.
+    /// </summary>
+    private async Task SeedBothAsync(Guid id)
+    {
+        await using var seed = _store.LightweightSession("north");
+
+        seed.Store(new Boat { Id = id, Name = "North's" });
+        seed.ForTenant("south").Store(new Boat { Id = id, Name = "South's" });
+
+        await seed.SaveChangesAsync(Token);
+    }
+
+    [Fact]
+    public async Task the_parents_cached_document_does_not_answer_for_the_scope()
+    {
+        var id = Guid.NewGuid();
+        await SeedBothAsync(id);
+
+        await using var session = _store.IdentitySession("north");
+
+        // Populates the parent's identity map under this id first. This is the step that made
+        // polecat#554's second half fail after its queries were already fixed.
+        (await session.LoadAsync<Boat>(id, Token))!.Name.ShouldBe("North's");
+
+        (await session.ForTenant("south").LoadAsync<Boat>(id, Token))!.Name.ShouldBe("South's");
+    }
+
+    [Fact]
+    public async Task the_scopes_cached_document_does_not_answer_for_the_parent()
+    {
+        var id = Guid.NewGuid();
+        await SeedBothAsync(id);
+
+        await using var session = _store.IdentitySession("north");
+
+        // The other direction. A shared map poisoned by the scope is just as wrong, and is the way
+        // round an application hits when an admin operation reads another tenant before its own.
+        (await session.ForTenant("south").LoadAsync<Boat>(id, Token))!.Name.ShouldBe("South's");
+
+        (await session.LoadAsync<Boat>(id, Token))!.Name.ShouldBe("North's");
+    }
+
+    [Fact]
+    public async Task two_scopes_do_not_share_an_identity_map_entry()
+    {
+        var id = Guid.NewGuid();
+        await SeedBothAsync(id);
+
+        // A third tenant, so neither scope is the session's own and the parent is not involved.
+        await using var third = _store.LightweightSession("east");
+        third.Store(new Boat { Id = id, Name = "East's" });
+        await third.SaveChangesAsync(Token);
+
+        await using var session = _store.IdentitySession("north");
+
+        (await session.ForTenant("south").LoadAsync<Boat>(id, Token))!.Name.ShouldBe("South's");
+        (await session.ForTenant("east").LoadAsync<Boat>(id, Token))!.Name.ShouldBe("East's");
+
+        // And back, because a map that is merely last-writer-wins would pass the two above.
+        (await session.ForTenant("south").LoadAsync<Boat>(id, Token))!.Name.ShouldBe("South's");
+    }
+
+    [Fact]
+    public async Task a_scope_read_of_a_missing_document_does_not_fall_through_to_the_parent()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var seed = _store.LightweightSession("north"))
+        {
+            seed.Store(new Boat { Id = id, Name = "North's" });
+            await seed.SaveChangesAsync(Token);
+        }
+
+        await using var session = _store.IdentitySession("north");
+
+        (await session.LoadAsync<Boat>(id, Token))!.Name.ShouldBe("North's");
+
+        // Nothing is stored for "south" at all. Every read shape has to say so rather than handing
+        // back what the parent has — CheckExistsAsync worst of all, since "does this tenant own that
+        // id?" is the natural spelling of an authorization gate.
+        (await session.ForTenant("south").LoadAsync<Boat>(id, Token)).ShouldBeNull();
+        (await session.ForTenant("south").CheckExistsAsync<Boat>(id, Token)).ShouldBeFalse();
+        (await session.ForTenant("south").LoadManyAsync<Boat>(Token, id)).ShouldBeEmpty();
+        (await session.ForTenant("south").Query<Boat>().ToListAsync(Token)).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task every_read_shape_through_a_scope_answers_for_the_scopes_tenant()
+    {
+        var id = Guid.NewGuid();
+        await SeedBothAsync(id);
+
+        await using var session = _store.IdentitySession("north");
+
+        // Warm the parent on every shape first, so a delegating read has something wrong to return.
+        (await session.LoadAsync<Boat>(id, Token))!.Name.ShouldBe("North's");
+        (await session.Query<Boat>().ToListAsync(Token)).Single().Name.ShouldBe("North's");
+
+        var scope = session.ForTenant("south");
+
+        (await scope.LoadAsync<Boat>(id, Token))!.Name.ShouldBe("South's");
+        (await scope.LoadManyAsync<Boat>(Token, id)).Single().Name.ShouldBe("South's");
+        (await scope.CheckExistsAsync<Boat>(id, Token)).ShouldBeTrue();
+        (await scope.Query<Boat>().ToListAsync(Token)).Single().Name.ShouldBe("South's");
+
+        // Substrings rather than the whole name: the serializer escapes the apostrophe, so
+        // "South's" is not literally present in the JSON.
+        var json = await scope.LoadJsonAsync<Boat>(id, Token);
+        json.ShouldNotBeNull();
+        json.ShouldContain("South");
+        json.ShouldNotContain("North");
+
+        // And the parent still answers for itself afterwards, which is the half a per-member tenant
+        // argument gets right and a shared cache gets wrong.
+        (await session.LoadAsync<Boat>(id, Token))!.Name.ShouldBe("North's");
+    }
+
+    [Fact]
+    public async Task an_uncommitted_write_through_a_scope_is_visible_only_to_that_scope()
+    {
+        var id = Guid.NewGuid();
+        await SeedBothAsync(id);
+
+        await using var session = _store.IdentitySession("north");
+
+        session.ForTenant("south").Store(new Boat { Id = id, Name = "South's, amended" });
+
+        // Not yet committed. The scope must see its own pending write and the parent must not — the
+        // property marten#4947 protects, checked here where isolation is correct rather than where
+        // it would be over-isolation.
+        (await session.ForTenant("south").LoadAsync<Boat>(id, Token))!.Name.ShouldBe("South's, amended");
+        (await session.LoadAsync<Boat>(id, Token))!.Name.ShouldBe("North's");
+    }
+
+    [Fact]
+    public async Task a_dirty_tracked_scope_does_not_track_the_parents_document()
+    {
+        var id = Guid.NewGuid();
+        await SeedBothAsync(id);
+
+        await using (var session = _store.DirtyTrackedSession("north"))
+        {
+            var north = await session.LoadAsync<Boat>(id, Token);
+            var south = await session.ForTenant("south").LoadAsync<Boat>(id, Token);
+
+            // Two distinct instances, or dirty tracking would flush one tenant's edits onto the
+            // other's row.
+            ReferenceEquals(north, south).ShouldBeFalse();
+
+            south!.Name = "South's, renamed";
+
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var north2 = _store.LightweightSession("north");
+        await using var south2 = _store.LightweightSession("south");
+
+        (await north2.LoadAsync<Boat>(id, Token))!.Name.ShouldBe("North's");
+        (await south2.LoadAsync<Boat>(id, Token))!.Name.ShouldBe("South's, renamed");
+    }
+
+    /// <remarks>
+    ///     The marten#4801 guard rail. Its first cut isolated <c>ForTenant(ownTenant)</c> from the
+    ///     session as well, which broke the case where the two must agree — including seeing the
+    ///     session's own uncommitted writes.
+    /// </remarks>
+    [Fact]
+    public async Task a_scope_of_the_sessions_own_tenant_is_the_session()
+    {
+        var id = Guid.NewGuid();
+
+        await using var session = _store.IdentitySession("north");
+
+        session.ForTenant("north").ShouldBeSameAs(session);
+
+        session.Store(new Boat { Id = id, Name = "North's" });
+
+        (await session.ForTenant("north").LoadAsync<Boat>(id, Token))!.Name.ShouldBe("North's");
+    }
+}

--- a/src/Fisher.Tests/Events/concurrent_session_tracker_state.cs
+++ b/src/Fisher.Tests/Events/concurrent_session_tracker_state.cs
@@ -1,0 +1,257 @@
+using Fisher.Internal;
+using Fisher.Tests.Documents;
+using JasperFx;
+using Weasel.Core;
+using Weasel.Storage;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>
+///     The rest of the session's shared mutable state under the async daemon's concurrent writers —
+///     marten#4657 / marten#4667, and the half of fisher#13 that the operation queue's lock did not
+///     cover.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Why this is a real caller and not a synthetic one.</b> JasperFx's <c>ExecutionStage</c>
+///         fans its executions out with <c>Task.WhenAll</c> and they all queue onto the <em>same</em>
+///         Fisher session — the premise <c>concurrent_operation_queueing</c> already establishes and
+///         fisher#13 was. <c>_operations</c> got a lock out of that bug. The session's other shared
+///         fields did not, and two of them are on the write path a projection slice takes:
+///         <c>Versions</c> is resolved by <c>NumericLightweightFisherStorage.Upsert</c> and its
+///         optimistic twin at operation-construction time, on the calling thread, and
+///         <c>_queryProvider</c> is resolved by <c>Query&lt;T&gt;()</c>, which is how a
+///         <c>ViewProjection</c> looks up what it is about to fold into.
+///     </para>
+///     <para>
+///         <b>What goes wrong is not an exception.</b> <c>_versionTracker ??= new FisherVersionTracker()</c>
+///         is a read, a branch and a write, so two slices arriving together each construct a tracker
+///         and one is silently discarded along with everything recorded on it. The next optimistic or
+///         numeric write then guards against a version the session no longer remembers reading — a
+///         spurious <c>ConcurrencyException</c> at best, a stale write accepted at worst. One layer
+///         down, <c>FisherVersionTracker</c>'s two <c>Dictionary&lt;Type, object&gt;</c> fields are
+///         mutated unguarded by <c>ForType</c> / <c>RevisionsFor</c>, which is the shape that loses
+///         entries outright or spins forever inside a resize.
+///     </para>
+///     <para>
+///         Marten's #4657 is exactly this: projection slices handed sessions that shared a
+///         <c>VersionTracker</c>, an <c>ItemMap</c> and a <c>ChangeTrackers</c> list, racing on them.
+///         Fisher shares one session rather than several that share state, which arrives at the same
+///         place by a shorter route.
+///     </para>
+///     <para>
+///         <b>The identity map and the change trackers are deliberately not covered here</b>, and the
+///         reason is a real invariant rather than an omission: both are populated only under
+///         <c>DocumentTracking.IdentityOnly</c> or <c>DirtyTracking</c>, and the daemon opens its
+///         sessions through <c>DocumentStore.OpenSessionOn</c>, which takes the default
+///         <c>DocumentTracking.None</c>. <c>the_daemons_own_sessions_are_untracked</c> below is what
+///         keeps that true, because it is the premise the omission rests on.
+///     </para>
+/// </remarks>
+public class concurrent_session_tracker_state : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("tracker-races");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    ///     Release <paramref name="workers" /> tasks at the same instant and wait for all of them, so
+    ///     the contended field is genuinely contended rather than reached by staggered thread starts.
+    /// </summary>
+    private static Task ReleaseTogetherAsync(int workers, Func<int, Task> work)
+    {
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var tasks = Enumerable.Range(0, workers).Select(i => Task.Run(async () =>
+        {
+            await start.Task;
+            await work(i);
+        })).ToArray();
+
+        start.SetResult();
+
+        return Task.WhenAll(tasks);
+    }
+
+    /// <remarks>
+    ///     Repeated, because the window is the gap between the null check and the assignment and one
+    ///     attempt can easily miss it. A single duplicate anywhere across the rounds is a failure:
+    ///     under the daemon that is one slice's version bookkeeping thrown away.
+    /// </remarks>
+    [Fact]
+    public async Task concurrent_slices_see_one_version_tracker()
+    {
+        const int rounds = 300;
+        const int workers = 8;
+
+        for (var round = 0; round < rounds; round++)
+        {
+            await using var session = _store.LightweightSession();
+            var storage = (IStorageSession)session;
+
+            var seen = new IVersionTracker[workers];
+
+            await ReleaseTogetherAsync(workers, i =>
+            {
+                seen[i] = storage.Versions;
+                return Task.CompletedTask;
+            });
+
+            seen.Distinct().Count().ShouldBe(1);
+        }
+    }
+
+    /// <remarks>
+    ///     The same window on the query provider. A projection slice that reads before it writes —
+    ///     the shape marten#4667 actually bit on — takes it through <c>Query&lt;T&gt;()</c>.
+    /// </remarks>
+    [Fact]
+    public async Task concurrent_slices_see_one_query_provider()
+    {
+        const int rounds = 300;
+        const int workers = 8;
+
+        for (var round = 0; round < rounds; round++)
+        {
+            await using var session = _store.LightweightSession();
+
+            var seen = new object[workers];
+
+            await ReleaseTogetherAsync(workers, i =>
+            {
+                seen[i] = session.Query<Permit>().Provider;
+                return Task.CompletedTask;
+            });
+
+            seen.Distinct().Count().ShouldBe(1);
+        }
+    }
+
+    /// <remarks>
+    ///     <para>
+    ///         The realistic shape, one level up from the field: many concurrent <c>Store</c> calls
+    ///         for a revisioned type on one session, which is what a multi-stream projection writing
+    ///         snapshots does. Every one of them resolves
+    ///         <c>session.Versions.RevisionsFor&lt;Permit, Guid&gt;()</c> while constructing its
+    ///         upsert, on the calling thread.
+    ///     </para>
+    ///     <para>
+    ///         <b>The assertion is on the dictionary's identity, not on its contents, and the reason
+    ///         is worth stating because the obvious assertion is vacuous.</b> An operation is handed
+    ///         the revision dictionary at construction and writes into it during <em>postprocessing</em>,
+    ///         which happens when the batch executes — so before a <c>SaveChangesAsync</c> the
+    ///         dictionary is empty however the race went, and a count assertion here reads zero on
+    ///         correct code. What the loss actually looks like is two dictionaries: the operations
+    ///         built first hold one, the tracker ends up holding another, and everything the first
+    ///         set postprocesses lands in an orphan no later write will ever consult.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task concurrent_stores_capture_one_revision_dictionary()
+    {
+        const int workers = 8;
+        const int each = 250;
+
+        await using var session = _store.LightweightSession();
+        var storage = (IStorageSession)session;
+
+        var captured = new Dictionary<Guid, long>[workers];
+
+        await ReleaseTogetherAsync(workers, w =>
+        {
+            // Exactly what NumericLightweightFisherStorage.Upsert does while building each operation.
+            captured[w] = storage.Versions.RevisionsFor<Permit, Guid>();
+
+            for (var i = 0; i < each; i++)
+            {
+                var permit = new Permit { Id = Guid.NewGuid(), Description = "Trout, one rod" };
+                session.UpdateRevision(permit, 1);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        captured.Distinct().Count().ShouldBe(1);
+
+        // fisher#13's own property, re-checked here because this file drives the same session the
+        // same way and a regression in either lock would show up first as a lost operation.
+        ((FisherSession)session).PendingOperations.Count.ShouldBe(workers * each);
+    }
+
+    /// <remarks>
+    ///     The version tracker's own dictionaries, driven directly across several document types.
+    ///     One type alone barely exercises them — the outer <c>Dictionary&lt;Type, object&gt;</c> is
+    ///     written once and read forever after — so the contention that matters comes from a
+    ///     composite projection whose concurrent slices write <em>different</em> snapshot types.
+    /// </remarks>
+    [Fact]
+    public async Task the_version_tracker_keeps_every_type_written_concurrently()
+    {
+        const int rounds = 200;
+
+        for (var round = 0; round < rounds; round++)
+        {
+            await using var session = _store.LightweightSession();
+            var versions = ((IStorageSession)session).Versions;
+
+            var id = Guid.NewGuid();
+
+            await ReleaseTogetherAsync(4, i =>
+            {
+                switch (i)
+                {
+                    case 0:
+                        versions.StoreVersion<Permit, Guid>(id, Guid.NewGuid());
+                        break;
+                    case 1:
+                        versions.StoreVersion<Licence, Guid>(id, Guid.NewGuid());
+                        break;
+                    case 2:
+                        versions.StoreRevision<Permit, Guid>(id, 1);
+                        break;
+                    default:
+                        versions.StoreRevision<Licence, Guid>(id, 1);
+                        break;
+                }
+
+                return Task.CompletedTask;
+            });
+
+            versions.VersionFor<Permit, Guid>(id).ShouldNotBeNull();
+            versions.VersionFor<Licence, Guid>(id).ShouldNotBeNull();
+            versions.RevisionFor<Permit, Guid>(id).ShouldBe(1);
+            versions.RevisionFor<Licence, Guid>(id).ShouldBe(1);
+        }
+    }
+
+    /// <remarks>
+    ///     The premise the identity map and change trackers are left unguarded on. If the daemon ever
+    ///     opened a tracking session, both would become concurrently mutated too and this file would
+    ///     need two more tests — so the assertion belongs here rather than in a configuration test.
+    /// </remarks>
+    [Fact]
+    public void the_daemons_own_sessions_are_untracked()
+    {
+        var session = (FisherSession)_store.OpenSessionOn(_store.Database, StorageConstants.DefaultTenantId);
+
+        session.SessionOptions.Tracking.ShouldBe(DocumentTracking.None);
+    }
+}

--- a/src/Fisher/Internal/FisherSession.Documents.cs
+++ b/src/Fisher/Internal/FisherSession.Documents.cs
@@ -133,11 +133,22 @@ internal partial class FisherSession
     ///     Start a LINQ query over a document type.
     /// </summary>
     /// <remarks>
-    ///     The provider is cached per session because it holds the session, and the session's single
-    ///     connection is what lets a query inside a unit of work see that unit of work's own writes.
+    ///     <para>
+    ///         The provider is cached per session because it holds the session, and the session's
+    ///         single connection is what lets a query inside a unit of work see that unit of work's
+    ///         own writes.
+    ///     </para>
+    ///     <para>
+    ///         Built through <c>LazilyCreate</c> rather than by <c>??=</c>, because the async daemon
+    ///         drives one session from several threads and a projection slice that reads before it
+    ///         writes — marten#4667's shape — comes through here. Two providers is not merely
+    ///         wasteful: since fisher#179 a provider holds the cached config-only halves of query
+    ///         construction, so a discarded one silently halves that cache.
+    ///     </para>
     /// </remarks>
     public IQueryable<T> Query<T>() where T : notnull
-        => new Linq.FisherQueryable<T>(_queryProvider ??= new Linq.FisherQueryProvider(this));
+        => new Linq.FisherQueryable<T>(
+            LazilyCreate(ref _queryProvider, () => new Linq.FisherQueryProvider(this)));
 
     /// <inheritdoc cref="Store{T}" />
     public void Store<T>(params T[] documents) where T : notnull

--- a/src/Fisher/Internal/FisherSession.cs
+++ b/src/Fisher/Internal/FisherSession.cs
@@ -58,6 +58,38 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
     ///     error anywhere. Exactly the shape of fisher#12, one layer up.
     /// </remarks>
     private readonly System.Threading.Lock _operationsLock;
+
+    /// <summary>
+    ///     Guards the creation of every lazily-built field on this session.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>The second half of fisher#13.</b> That bug was the async daemon queueing onto one
+    ///         session from several threads, and <see cref="_operationsLock" /> answered it for the
+    ///         operation queue. Every other field here is created by a <c>??=</c>, which is a read, a
+    ///         branch and a write — so two of JasperFx's concurrent projection slices arriving
+    ///         together each construct one and <em>one of them is silently discarded</em>, along with
+    ///         everything recorded on it.
+    ///     </para>
+    ///     <para>
+    ///         <b>That is reachable on the daemon's own untracked sessions, which is why it is not
+    ///         covered by the identity map's "a tracking session is single-threaded" argument below.</b>
+    ///         <see cref="IStorageSession.Versions" /> is resolved by the numeric and optimistic
+    ///         storages while <em>constructing</em> each upsert — on the calling thread, before
+    ///         anything is queued — and the query provider is resolved by <c>Query&lt;T&gt;()</c>,
+    ///         which is how a projection slice reads what it is about to fold into. A discarded
+    ///         version tracker means a later guarded write compares against a version the session no
+    ///         longer remembers reading.
+    ///     </para>
+    ///     <para>
+    ///         Held only across construction, never across use: what has to be true is that exactly
+    ///         one instance ever escapes. <c>marten#4657</c>/<c>#4667</c> is the same bug reached from
+    ///         the other side — projection slices handed separate sessions that <em>shared</em> these
+    ///         fields, where Fisher's slices share the session itself.
+    ///     </para>
+    /// </remarks>
+    private readonly System.Threading.Lock _lazyLock = new();
+
     private List<IChangeTracker>? _changeTrackers;
     private readonly Sessions.IConnectionLifetime _lifetime;
 
@@ -181,15 +213,22 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
             return this;
         }
 
-        _tenantScopes ??= new Dictionary<string, FisherSession>();
-
-        if (!_tenantScopes.TryGetValue(tenantId, out var scope))
+        // Guarded for the same reason the operation queue is (fisher#13): a projection applying its
+        // slices concurrently onto one session may reach here from several threads, and two
+        // unsynchronised adds to a Dictionary lose an entry or corrupt it outright. Losing one here
+        // means a whole tenant's queued work is never collected by SaveChangesAsync.
+        lock (_lazyLock)
         {
-            scope = new FisherSession(this, tenantId);
-            _tenantScopes[tenantId] = scope;
-        }
+            _tenantScopes ??= new Dictionary<string, FisherSession>();
 
-        return scope;
+            if (!_tenantScopes.TryGetValue(tenantId, out var scope))
+            {
+                scope = new FisherSession(this, tenantId);
+                _tenantScopes[tenantId] = scope;
+            }
+
+            return scope;
+        }
     }
 
     /// <inheritdoc />
@@ -1168,12 +1207,36 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
 
     // ---- IStorageSession ----
 
-    IStorageSerializer IStorageSession.Serializer
-        => _storageSerializer ??= StorageSerializerAdapter.For(FisherSerializer);
+    IStorageSerializer IStorageSession.Serializer => LazilyCreate(ref _storageSerializer,
+        () => StorageSerializerAdapter.For(FisherSerializer));
 
     IStorageDatabase IStorageSession.Database => FisherDatabase;
 
-    IVersionTracker IStorageSession.Versions => _versionTracker ??= new FisherVersionTracker();
+    IVersionTracker IStorageSession.Versions
+        => LazilyCreate(ref _versionTracker, static () => new FisherVersionTracker());
+
+    /// <summary>
+    ///     Build <paramref name="field" /> once, however many threads ask at once — see
+    ///     <see cref="_lazyLock" /> for why <c>??=</c> is not enough here.
+    /// </summary>
+    /// <remarks>
+    ///     Double-checked: the uncontended read is the same read <c>??=</c> made, so the lock is paid
+    ///     for exactly once per field per session. The field is a reference, and the reference is
+    ///     published by the lock's release, so a caller that saw non-null saw a fully constructed
+    ///     instance.
+    /// </remarks>
+    private T LazilyCreate<T>(ref T? field, Func<T> create) where T : class
+    {
+        if (field is not null)
+        {
+            return field;
+        }
+
+        lock (_lazyLock)
+        {
+            return field ??= create();
+        }
+    }
 
     /// <summary>
     ///     One tracker per document this session read under
@@ -1183,7 +1246,8 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
     /// </summary>
     IList<IChangeTracker> IStorageSession.ChangeTrackers => ChangeTrackers;
 
-    private List<IChangeTracker> ChangeTrackers => _changeTrackers ??= new List<IChangeTracker>();
+    private List<IChangeTracker> ChangeTrackers
+        => LazilyCreate(ref _changeTrackers, static () => new List<IChangeTracker>());
 
     /// <summary>
     ///     The identity map, one <c>Dictionary&lt;TId, TDoc&gt;</c> per document type.
@@ -1207,7 +1271,14 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
     /// </remarks>
     Dictionary<Type, object> IStorageSession.ItemMap => ItemMap;
 
-    private Dictionary<Type, object> ItemMap => _itemMap ??= new Dictionary<Type, object>();
+    /// <remarks>
+    ///     Its <em>creation</em> is guarded even though its contents are not, which is not an
+    ///     inconsistency: the argument above is that a tracking session has one caller, and it costs
+    ///     nothing to keep that argument about the dictionary's contents alone rather than also about
+    ///     whether two callers can end up holding different dictionaries.
+    /// </remarks>
+    private Dictionary<Type, object> ItemMap
+        => LazilyCreate(ref _itemMap, static () => new Dictionary<Type, object>());
 
     ConcurrencyChecks IStorageSession.Concurrency => ConcurrencyChecks.Enabled;
 

--- a/src/Fisher/Internal/FisherVersionTracker.cs
+++ b/src/Fisher/Internal/FisherVersionTracker.cs
@@ -4,66 +4,128 @@ namespace Fisher.Internal;
 
 /// <summary>
 ///     Session-scoped document version/revision bookkeeping behind the shared
-///     <see cref="IVersionTracker" /> seam of the closed-shape storage runtime. Ported unchanged
-///     from Polecat — the bookkeeping is pure in-memory dictionaries with nothing dialect-specific
-///     in it.
+///     <see cref="IVersionTracker" /> seam of the closed-shape storage runtime. Ported from Polecat —
+///     the bookkeeping is pure in-memory dictionaries with nothing dialect-specific in it.
 /// </summary>
+/// <remarks>
+///     <para>
+///         <b>Guarded, which is the one way it diverges from Polecat's, and the reason is Fisher's
+///         daemon rather than a difference of taste.</b> Polecat hands each concurrent projection
+///         slice its own session and therefore its own tracker; JasperFx's <c>ExecutionStage</c> fans
+///         its executions out with <c>Task.WhenAll</c> onto the <em>same</em> Fisher session, so the
+///         slices share one of these — the fisher#13 shape, and the same place marten#4657 arrived
+///         at from the other direction.
+///     </para>
+///     <para>
+///         <b>The two outer dictionaries are what actually race.</b> <see cref="ForType{TDoc,TId}" />
+///         and <see cref="RevisionsFor{TDoc,TId}" /> are called by the numeric and optimistic storages
+///         while <em>constructing</em> an upsert — on the calling thread — so a composite projection
+///         whose concurrent slices write different snapshot types has two threads adding to a
+///         <c>Dictionary&lt;Type, object&gt;</c> at once. That loses an entry or spins inside a
+///         resize, and the loss is silent: the operations built first keep the dictionary they were
+///         handed and postprocess into an orphan nothing will read.
+///     </para>
+///     <para>
+///         <b>The inner dictionaries are returned unguarded, deliberately.</b> They are handed to a
+///         storage operation, which writes into one during postprocessing — and postprocessing happens
+///         inside <c>FisherSession.ExecuteBatchAsync</c>, which is strictly sequential because SQLite
+///         permits one writer per file. What the lock has to cover is every mutation reachable from a
+///         <em>caller's</em> thread, which is what the members below do.
+///     </para>
+/// </remarks>
 internal class FisherVersionTracker : IVersionTracker
 {
     private readonly Dictionary<Type, object> _versions = new();
     private readonly Dictionary<Type, object> _revisions = new();
+    private readonly System.Threading.Lock _lock = new();
 
     public Dictionary<TId, Guid> ForType<TDoc, TId>() where TId : notnull
     {
-        if (_versions.TryGetValue(typeof(TDoc), out var raw) && raw is Dictionary<TId, Guid> existing)
+        lock (_lock)
         {
-            return existing;
-        }
+            if (_versions.TryGetValue(typeof(TDoc), out var raw) && raw is Dictionary<TId, Guid> existing)
+            {
+                return existing;
+            }
 
-        var fresh = new Dictionary<TId, Guid>();
-        _versions[typeof(TDoc)] = fresh;
-        return fresh;
+            var fresh = new Dictionary<TId, Guid>();
+            _versions[typeof(TDoc)] = fresh;
+            return fresh;
+        }
     }
 
     public Dictionary<TId, long> RevisionsFor<TDoc, TId>() where TId : notnull
     {
-        if (_revisions.TryGetValue(typeof(TDoc), out var raw) && raw is Dictionary<TId, long> existing)
+        lock (_lock)
         {
-            return existing;
-        }
+            if (_revisions.TryGetValue(typeof(TDoc), out var raw) && raw is Dictionary<TId, long> existing)
+            {
+                return existing;
+            }
 
-        var fresh = new Dictionary<TId, long>();
-        _revisions[typeof(TDoc)] = fresh;
-        return fresh;
+            var fresh = new Dictionary<TId, long>();
+            _revisions[typeof(TDoc)] = fresh;
+            return fresh;
+        }
     }
 
     public Guid? VersionFor<TDoc, TId>(TId id) where TId : notnull
     {
-        return ForType<TDoc, TId>().TryGetValue(id, out var version) ? version : null;
+        var versions = ForType<TDoc, TId>();
+
+        lock (_lock)
+        {
+            return versions.TryGetValue(id, out var version) ? version : null;
+        }
     }
 
     public long? RevisionFor<TDoc, TId>(TId id) where TId : notnull
     {
-        return RevisionsFor<TDoc, TId>().TryGetValue(id, out var revision) ? revision : null;
+        var revisions = RevisionsFor<TDoc, TId>();
+
+        lock (_lock)
+        {
+            return revisions.TryGetValue(id, out var revision) ? revision : null;
+        }
     }
 
     public void StoreVersion<TDoc, TId>(TId id, Guid guid) where TId : notnull
     {
-        ForType<TDoc, TId>()[id] = guid;
+        var versions = ForType<TDoc, TId>();
+
+        lock (_lock)
+        {
+            versions[id] = guid;
+        }
     }
 
     public void StoreRevision<TDoc, TId>(TId id, long revision) where TId : notnull
     {
-        RevisionsFor<TDoc, TId>()[id] = revision;
+        var revisions = RevisionsFor<TDoc, TId>();
+
+        lock (_lock)
+        {
+            revisions[id] = revision;
+        }
     }
 
     public void ClearVersion<TDoc, TId>(TId id) where TId : notnull
     {
-        ForType<TDoc, TId>().Remove(id);
+        var versions = ForType<TDoc, TId>();
+
+        lock (_lock)
+        {
+            versions.Remove(id);
+        }
     }
 
     public void ClearRevision<TDoc, TId>(TId id) where TId : notnull
     {
-        RevisionsFor<TDoc, TId>().Remove(id);
+        var revisions = RevisionsFor<TDoc, TId>();
+
+        lock (_lock)
+        {
+            revisions.Remove(id);
+        }
     }
 }


### PR DESCRIPTION
Closes #187 — the session-semantics audit, from Stoat plan `critter-hardening-audit`, node `fisher-session-semantics-audit`.

Five bug classes checked against a discriminating test each. **One is a real bug here**; the other four are safe by construction and now have standing guards that say so.

| # | Bug class | Verdict |
|---|---|---|
| 1 | `ForTenant` read scoping / identity map (polecat#554, marten#4801/#4947/#4956) | Already safe — 8 of 8 pass unmodified |
| 2 | Revisioned upsert write-loss (Marten `c09eed24c` + `c8e851722`) | Already safe — 4 of 4 pass unmodified |
| 3 | UTC timestamp idiom (marten#5136) | Already safe — 9 of 9; 5 fail under sabotage |
| 4 | Patch `[JsonPropertyName]` / duplicated columns (marten#5290/#5295) | Already covered — not duplicated |
| 5 | **Daemon session races (marten#4657/#4667)** | **BUG CONFIRMED and fixed** |

## The bug

fisher#13 gave the session's operation queue a lock, because JasperFx's `ExecutionStage` fans its executions out with `Task.WhenAll` onto the **same** Fisher session. Every other lazily-built field on that session kept its `??=` — a read, a branch and a write — so two concurrent slices each construct one and **one is silently discarded with everything recorded on it**.

Two of them are on the write path a slice actually takes. `IStorageSession.Versions` is resolved by the numeric and optimistic storages while *constructing* an upsert, on the calling thread; a discarded version tracker means a later guarded write compares against a version the session no longer remembers reading. `_queryProvider` is resolved by `Query<T>()`, which is how a slice reads what it is about to fold into — marten#4667's shape. One layer down, `FisherVersionTracker`'s two `Dictionary<Type, object>` fields were mutated unguarded, which loses an entry outright when concurrent slices write different snapshot types.

This is marten#4657/#4667 reached from the other side: there, slices were handed separate sessions that *shared* these fields; here they share the session itself.

## The fix

`FisherSession.LazilyCreate` is now the one place a lazily-built field is created — double-checked, so the uncontended read is the same read `??=` made. `ForTenant`'s scope dictionary takes the same lock. `FisherVersionTracker` guards its two outer dictionaries and every mutation reachable from a caller's thread.

The tracker's **inner** dictionaries stay unguarded deliberately: they are handed to a storage operation, which writes into one during postprocessing, and postprocessing runs inside `ExecuteBatchAsync`, which is strictly sequential because SQLite takes one writer per file. The identity map's and change trackers' **contents** stay unguarded too — CLAUDE.md's existing position, unchanged; only their creation is guarded, and `the_daemons_own_sessions_are_untracked` pins the premise that argument rests on.

## Tests

26 new, in four files. The three "already safe" classes were run against unmodified `main` **before a line of production code was touched**, so those verdicts are not "fixed in passing"; the timestamp class was additionally verified by sabotage.

- `Events/concurrent_session_tracker_state.cs` — 5, **4 fail on unmodified `main`**.
- `Documents/tenant_scope_read_isolation.cs` — 8. The existing `cross_tenant_writes` coverage runs on a `LightweightSession`, where `DocumentTracking.None` means no identity map is resolved at all — precisely the half polecat#554 needed its second fix for. These run on `IdentitySession` and `DirtyTrackedSession`.
- `Documents/concurrent_revision_write_loss.cs` — 4. Behavioural rather than SQL-shape, because one-writer-per-file removes the interleaving but not the staleness.
- `Documents/server_timestamp_utc.cs` — 9. The behavioural half **skips rather than passes** on a UTC host, so a UTC CI runner cannot green it by accident.

Full findings, evidence and the reasoning behind each "safe by construction" verdict are in #187.

## Validation

- Full `dotnet test fisher.slnx`, **both TFMs**, all six assemblies green — after merging `origin/main`, which brought #186 in concurrently.
- Scoreboard reconciled from a real run on both TFMs: 1655 tests, 1600 in `Fisher.Tests`.
- CI is stalled org-wide and was not a gate; all validation above is local.
- No NuGet package published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
