### PR TITLE
gh-191: event upcasting over the shared JasperFx.Events.Upcasting contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,9 @@ Working, with tests:
   and as a document's
 - **Event rewriting** — `OverwriteEvent`, `CompletelyReplaceEvent`, event data masking through
   `Advanced.ApplyEventDataMaskingAsync`, and stream compacting via `CompactStreamAsync<T>`
+- **Event upcasting** — `Events.Upcasters`, over the shared `JasperFx.Events.Upcasting` contract: an
+  old stored event schema is reinterpreted as the current CLR event type on every read path, so the
+  old type can be deleted from the codebase
 - **Sessions and `SessionOptions`** — `QuerySession()` and `OpenSession(SessionOptions)` on the store,
   and enlistment: a session running on a connection or inside a transaction the caller owns
 - **Session tracking** — an identity map, dirty tracking, and `Eject` / `EjectAllOfType` /
@@ -3528,6 +3531,67 @@ Everything that reads the row's *columns* is unaffected — stream reads, the da
 queries, `QueryEventsAsync`'s metadata filters — which is why a stream can mix the two encodings
 freely, and why the daemon needed no change at all.
 
+### Event upcasting
+
+`StoreOptions.Events.Upcasters` (fisher#191) — how an old stored event schema is reinterpreted as the
+current CLR event type on every read path. **The registry, the transformation shape and the
+`IEventUpcaster` bases are all JasperFx's** (`JasperFx.Events.Upcasting`, jasperfx#752); Fisher
+supplies the read path and one `IUpcastPayload` adapter, the same division as the async daemon.
+
+The whole read-side integration is **one call in `FisherEventsRowReader.ReadEventCore`**, which is
+what having a single hydration point buys — every stream read, live aggregation, `FetchForWriting`,
+DCB tag query and daemon page already converges there.
+
+- ⚠️ **The registry is consulted BEFORE `ResolveEventType`, and that ordering is the marten#4680
+  authority rule** rather than an optimisation. A registered transformation is the authoritative
+  interpretation of its source event type name, so the stored `dotnet_type` hint does not get a vote.
+  The case it exists for is a store that still has the old CLR type in its codebase: a typed append
+  of it writes both the source name and a hint pointing at the old type, and letting the hint win
+  would read *those* rows as the old schema while every row the previous deployment wrote upcast
+  correctly — one store, one event type name, two answers.
+- ⚠️ **Hydration became asynchronous for this** (`ValueTask<IEvent?>` throughout). The shared contract
+  lets a transformation be registered async-only, whose synchronous delegate throws by design — so a
+  store hydrating synchronously could not honour one at all. Every Fisher read path was already
+  inside an `await reader.ReadAsync(...)` loop, so the cost is a `ValueTask` per row, and the ordinary
+  path awaits nothing and completes synchronously. `TryUpcast` is guarded on `Upcasters.HasAny`
+  first, so a store with no upcasts pays one boolean field read per row.
+- **`FisherUpcastPayload` is a `readonly struct`**, per-row and never cached, which is what the
+  contract expects — a transformation calls exactly one accessor exactly once. The ordinary path never
+  constructs one.
+- **The raw-`JsonDocument` accessor is unconditional here**, where the contract permits a store to
+  refuse: Fisher is System.Text.Json-only and `data` holds exactly the text it wrote. Marten's is
+  optional because its serializer is configurable. **A binary body (fisher#93) is the one exception** —
+  its `data` column holds only the `{}` placeholder, so a raw-JSON transformation over one is refused
+  by name rather than handed an empty object, which would upcast to an event with every member at its
+  default. A *typed* transformation reads it through the old type's own `IEventBinarySerializer`.
+- ⚠️ **The daemon's server-side type filter is widened with every transformation's SOURCE name**, or a
+  shard filtered on the new types reads nothing at all from the history it was pointed at — silently,
+  reporting itself caught up. The filter is pushed into SQLite precisely so non-matching rows never
+  leave it, which is why the loader's in-memory check (which does see the hydrated, upcast event)
+  cannot rescue it. **`UpcastingCompliance` does not reach this**: its daemon fact registers a
+  snapshot projection, whose `IncludedEventTypes` allow list is empty, so no SQL filter is composed
+  at all. `upcasting.a_subscription_filtered_on_the_new_type_receives_the_upcast_old_rows` is what
+  pins it, and it fails by delivering nothing when the widening is removed.
+- **The target event types are pre-registered in `DocumentStore`'s constructor**, from
+  `Upcasters.AllTransformations`. Nothing else would: dropping the old type is the point of an
+  upcast, so no `AddEventType`, projection registration or append ever mentions the new type either.
+  Done at construction rather than at registration because a transformation may be registered through
+  the shared JasperFx surface, which Fisher owns no hook in.
+- **The envelope keeps the row's stored `type` and `dotnet_type`**, not the transformation's. It is a
+  claim about the row, and nothing dispatches on it — `IEvent.EventType` is `Event<T>`'s `T`, which is
+  the new type.
+- **Upcasting does not reach a projection that has already run.** The high-water mark is a sequence
+  and registering a transformation does not move it, so a document built from the old schema keeps
+  what it derived until that projection is rebuilt. Same caveat as masking, and the same reason.
+
+`UpcastingCompliance` is the definition, and it is **the first suite in the library written ahead of
+any store implementing the behaviour** — its gate ships closed and Fisher is the first to flip it, so
+all seven facts ran for the first time anywhere here. Enrolling it found one suite bug: its
+raw-JSON fact reached the stored body with a case-sensitive `GetProperty("CartId")`, which is
+Marten's default casing and not Polecat's or Fisher's — fixed upstream in jasperfx#787.
+`Events/upcasting.cs` covers the two things the suite structurally cannot see: the server-side filter
+above, and binary bodies, which the shared upcasting fixture knows nothing about.
+
 ### Querying event bodies
 
 `EventOperations.QueryEventDataAsync<T>(predicate)` (fisher#41) — the counterpart to
@@ -3628,7 +3692,7 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**Fisher enrolls 49 of the 52 suites `JasperFx.Events.ComplianceTests` 2.65.0 ships — 509 tests.**
+**Fisher enrolls 50 of the 52 suites `JasperFx.Events.ComplianceTests` 2.65.0 ships — 516 tests.**
 `JasperFx.Events.ComplianceTests` is referenced unconditionally — the old `$(EnableComplianceTests)`
 gate is gone. See HANDOFF.md for the live scoreboard, which is machine-checked against a real run by
 `scripts/check_scoreboard.py`; what follows is the history and the mechanics.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,31 +12,41 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1761 tests on net9.0 and net10.0**, two of them red — 1706 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 509 of
-them are shared cross-store compliance tests — 440 event sourcing and 69 document. On JasperFx **2.65.0** / Weasel **9.29.0**.
+**1772 tests on net9.0 and net10.0**, five of them red — 1717 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 516 of
+them are shared cross-store compliance tests — 447 event sourcing and 69 document. On JasperFx **2.65.0** / Weasel **9.29.0**.
 
-### Red — 2 facts
+### Red — 5 facts
+
+**Every one is upstream, fixed, merged, and waiting on a JasperFx release.** Nothing in `src/Fisher`
+is implicated in any of them. Verified by packing `jasperfx` main to a local feed and running
+Fisher's whole suite against it: all five green, nothing else moved.
 
 - `Fisher.Tests.Compliance.stream_archiving_compliance.capturing_an_archived_event_archives_a_string_identified_stream`
 - `Fisher.Tests.Compliance.stream_archiving_compliance.capturing_an_archived_event_through_an_async_snapshot_archives_the_stream`
+- `Fisher.Tests.Compliance.upcasting_compliance.a_raw_json_transformation_upcasts_without_the_old_clr_type`
+- `Fisher.Tests.Compliance.upcasting_compliance.upcasting_applies_in_live_aggregation`
+- `Fisher.Tests.Compliance.upcasting_compliance.upcasting_applies_in_async_daemon_projections`
 
-**Both are jasperfx#778, a real product bug in `JasperFx.Events` that Fisher found by being the store
-that ran the suite**, and both are fixed and merged upstream — the fix simply missed the 2.65.0 cut
-and lands in the release after it. Verified by packing `jasperfx` main plus jasperfx#784 to a local
-feed and running Fisher's whole suite against it: both green, nothing else moved.
+**The first two are jasperfx#778, a real product bug in `JasperFx.Events` that Fisher found by being
+the store that ran the suite.** An `Archived` event the aggregate applies nothing for did not archive
+its stream, on any store. `Archived` carries no state, so an aggregate has no reason to declare an
+`Apply` for it — which left it out of the projection's `AllEventTypes`, so `AppliesTo` answered
+false, the inline path screened the whole stream out *before reading anything*, and the async shard's
+own filter never delivered the event into a slice at all. Marten's four local archiving tests all
+append a handled event beside the marker, which is why it survived there. jasperfx#780 closed the
+innermost of three gates — and on Fisher changed nothing, which is what sent jasperfx#784 after the
+two outside it.
 
-An `Archived` event the aggregate applies nothing for did not archive its stream, on any store.
-`Archived` carries no state, so an aggregate has no reason to declare an `Apply` for it — which left
-it out of the projection's `AllEventTypes`, so `AppliesTo` answered false, the inline path screened
-the whole stream out *before reading anything*, and the async shard's own filter never delivered the
-event into a slice at all. Marten's four local archiving tests all append a handled event beside the
-marker, which is why it survived there. jasperfx#780 closed the innermost of three gates — and on
-Fisher changed nothing, which is what sent #784 after the two outside it.
+**The last three are jasperfx#787, a suite bug**, and the first two of them are one cause:
+`UpcastingCompliance`'s raw-JSON fact reached the stored body with a case-sensitive
+`GetProperty("CartId")`. Property casing is a store-serializer decision — Marten's default
+`PropertyNamingPolicy` is null, Polecat's and Fisher's is camelCase — so the fact passed on Marten
+and threw `KeyNotFoundException` on the other two. The live-aggregation and daemon facts append a
+coupon event and go down with it; the daemon one surfaces sixty seconds later as a shard that
+recorded no progress. Fixed upstream in jasperfx#788.
 
-**Fisher's own count is unchanged by this.** Nothing in `src/Fisher` is implicated — the wave's
-genuine Fisher findings are the five listed under "Wave 13" below, and all five are fixed here.
-jasperfx#779, the suite bug the same enrollment turned up, is already in 2.65.0.
+jasperfx#779, the other suite bug this wave's enrollment turned up, is already in 2.65.0.
 
 Note that 440 is not quite *every* event suite the shared library has, and three of the shortfall are
 enrolled-and-gated rather than absent:
@@ -492,10 +502,10 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.65.0 ships 52 suites; Fisher enrolls **49 of them, 509 tests**.
-Fisher passes **507 of them, across all
-49 suites**. Every suite compiles; every one is also subclassed and running. The two that do not pass
-are the upstream one declared at the top of this file, not Fisher behaviour.
+`JasperFx.Events.ComplianceTests` 2.65.0 ships 52 suites; Fisher enrolls **50 of them, 516 tests**.
+Fisher passes **511 of them, across all
+50 suites**. Every suite compiles; every one is also subclassed and running. The five that do not pass
+are the upstream ones declared at the top of this file, not Fisher behaviour.
 
 **What that does and does not claim, because the difference is load-bearing** (fisher#124). The suite
 pins **API portability, not behavioural equivalence**: code written against one store compiles and
@@ -528,7 +538,7 @@ shape: `DocumentLoadAndStoreCompliance` gained three tests for `LoadAsync<T>(obj
 fisher#89) and `DocumentComplianceConfig` gained `ValueTypes`. Diffing the suite *list* would have
 reported a clean bump — diff the contents.
 
-The library is now two halves. The **event sourcing** half is 42 enrolled suites and 440 tests, and the
+The library is now two halves. The **event sourcing** half is 43 enrolled suites and 447 tests, and the
 upstream backlog it emptied in 2.45.0 refilled in 2.64.0 — see "Wave 13" below. The
 **document** half arrived in 2.47.0 (jasperfx#647) and is now seven suites, 69 tests, over the
 store-agnostic document contract Fisher implements for fisher#68. Every suite added since 2.49.0 has
@@ -627,12 +637,12 @@ case is what is Fisher's alone — the `ResetAllDataAsync` daemon handling, `Fet
 and `UnknownNaturalKeyException` (which jasperfx#764 excludes on purpose), the subscription wrapper's
 naming.
 
-**Green on all forty-nine is not the same as feature-complete.** The suites cover what is portable
+**Green on all fifty is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 49 suites, 509 tests
+### Green — 50 suites, 516 tests
 
-Event sourcing — 42 suites, 440 tests:
+Event sourcing — 43 suites, 447 tests:
 
 | Suite | Tests |
 |---|---|
@@ -662,6 +672,7 @@ Event sourcing — 42 suites, 440 tests:
 | `ProjectionSideEffectCompliance` | 9 |
 | `SelfAggregatingEvolveCompliance` | 8 |
 | `LiveAggregationCompliance` | 7 |
+| `UpcastingCompliance` | 7 |
 | `AssignTagWhereCompliance` | 6 |
 | `BinaryEventSerializationCompliance` | 6 |
 | `DcbHasTagLinqCompliance` | 6 |

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 49 suites and 509 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,706.
+> Fisher passes **all 50 suites and 516 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,717.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,13 +20,16 @@ It was filed because of fisher#138, where Fisher registered only an `IHostedServ
 implementing nothing else and both documented routes to the running daemon failed while all 37 suites
 passed. Its pause/resume fact targets exactly the `StartAsync` bug that had.
 
-Two upstream issues were **found** by enrolling the 2.64.0 wave.
-[jasperfx#779](https://github.com/JasperFx/jasperfx/issues/779), a suite bug, is already in 2.65.0.
-[jasperfx#778](https://github.com/JasperFx/jasperfx/issues/778) is the other and is the more
-interesting one: a real `JasperFx.Events` bug where an `Archived` event the aggregate applies nothing
-for did not archive its stream *on any store*. It is fixed and merged upstream but missed the 2.65.0
-cut, so two facts are red on Fisher until the release after it — see HANDOFF.md's "Red" section,
-which names them.
+Three upstream issues were **found** by enrolling the 2.64.0 wave and implementing upcasting against
+it. [jasperfx#779](https://github.com/JasperFx/jasperfx/issues/779), a suite bug, is already in
+2.65.0. The other two are fixed and merged upstream but missed that cut, so five facts are red on
+Fisher until the release after it — see HANDOFF.md's "Red" section, which names them:
+
+- [jasperfx#778](https://github.com/JasperFx/jasperfx/issues/778) is the interesting one: a real
+  `JasperFx.Events` bug where an `Archived` event the aggregate applies nothing for did not archive
+  its stream *on any store*.
+- [jasperfx#787](https://github.com/JasperFx/jasperfx/issues/787) is `UpcastingCompliance`'s raw-JSON
+  fact assuming a property casing, which made it pass on Marten and fail on Polecat and Fisher.
 
 Two filed since 1.0.5 have already **shipped**.
 [jasperfx#718](https://github.com/JasperFx/jasperfx/issues/718) is in 2.59.0 — the identity-less
@@ -445,7 +448,7 @@ Test counts keep understating the suites that matter. `AsyncDaemonCompliance` is
 the whole daemon; `FlatTableProjectionCompliance` is eight that demand an upsert generator, a
 migration hook and rebuild teardown.
 
-Being green on all forty-nine is not the same as being feature-complete against Marten. The suites
+Being green on all fifty is not the same as being feature-complete against Marten. The suites
 cover what is portable across stores; the deliberate gaps listed in HANDOFF.md are still gaps.
 
 ## Filed follow-ups

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -127,6 +127,7 @@ const config: UserConfig<DefaultTheme.Config> = {
             { text: 'Natural Keys', link: '/events/natural-keys' },
             { text: 'Dynamic Consistency Boundary', link: '/events/dcb' },
             { text: 'Rewriting Events', link: '/events/rewriting' },
+            { text: 'Upcasting Events', link: '/events/upcasting' },
             {
               text: 'Projections Overview', link: '/events/projections/', collapsed: true, items: [
                 { text: 'Single Stream Projections', link: '/events/projections/single-stream-projections' },

--- a/docs/events/index.md
+++ b/docs/events/index.md
@@ -70,6 +70,7 @@ See the [Quick Start](/events/quickstart) for a complete walkthrough.
 | [Natural Keys](/events/natural-keys) | Addressing a stream by a business identifier |
 | [DCB](/events/dcb) | Tags, tagged appends, consistency boundaries |
 | [Rewriting Events](/events/rewriting) | Overwrite, replace, masking, stream compacting |
+| [Upcasting Events](/events/upcasting) | Reading an old event schema as the current CLR type |
 | [Projections](/events/projections/) | Every shape, every lifecycle |
 | [Subscriptions](/events/subscriptions) | Arbitrary code over each range of events |
 

--- a/docs/events/upcasting.md
+++ b/docs/events/upcasting.md
@@ -1,0 +1,98 @@
+# Upcasting Events
+
+An event store keeps its JSON forever. Upcasting is how an application changes an event's schema
+without rewriting the rows that are already there: register a transformation, and **every read path
+hands back the new type** — stream fetches, live aggregation, `FetchForWriting`, the async daemon,
+subscriptions.
+
+```cs
+options.Events.Upcasters.Upcast<CartOpenedV1, CartInitialized>(
+    old => new CartInitialized(old.CartId, old.ClientId, "Opened"));
+```
+
+The old CLR type can then be deleted, which is the point: aggregations and projections are written
+against the new schema only.
+
+::: tip
+The registry, the transformation shape and the `IEventUpcaster` bases are all JasperFx's
+(`JasperFx.Events.Upcasting`) — Fisher supplies the read path and one `IUpcastPayload` adapter over
+its own reader and serializer. So an upcast registration ports between Fisher, Marten and Polecat
+unchanged.
+:::
+
+## The registration shapes
+
+| | |
+| :--- | :--- |
+| `Upcast<TOld, TNew>(old => new(...))` | Typed. Claims `TOld`'s conventional event type name |
+| `Upcast<TOld, TNew>(name, old => ...)` | Typed, claiming an explicit stored name |
+| `Upcast<TNew>(doc => ...)` | Raw `JsonDocument` — no old CLR type kept at all |
+| `Upcast<TNew>(name, doc => ...)` | Raw JSON, claiming an explicit stored name |
+| `Upcast<TOld, TNew>(async (old, ct) => ...)` | Async-only. See below |
+| `Upcast(new MyUpcaster())` / `Upcast<MyUpcaster>()` | Class-based, over `IEventUpcaster` |
+
+Registration is **last-wins per stored event type name**: re-registering a name replaces the earlier
+transformation.
+
+## Raw JSON is cheap here
+
+The raw-`JsonDocument` shape is what lets you drop the old type entirely, and Fisher can always offer
+it: `fi_events.data` holds exactly the text System.Text.Json wrote, so the document is a parse of a
+string already in hand. Marten's equivalent has to refuse when its configured serializer is not
+System.Text.Json.
+
+```cs
+options.Events.Upcasters.Upcast<DiscountApplied>(
+    "coupon_clipped",
+    document => new DiscountApplied(
+        document.RootElement.GetProperty("cartId").GetGuid(),
+        document.RootElement.GetProperty("percent").GetInt32() / 100.0));
+```
+
+::: warning
+Property names are **as stored**, and Fisher's default serializer is camelCase. A raw-JSON
+transformation reads what the serializer actually wrote, not the CLR member names — that is the
+trade for not keeping the old type. The typed shapes have no such concern: they deserialize through
+the store's own serializer.
+:::
+
+## The authority rule
+
+**A registered transformation is the authoritative interpretation of its source event type name.**
+Fisher stores a `dotnet_type` hint on every row, and that hint **does not get a vote**: the registry
+is consulted before the hint is resolved.
+
+That matters when the old CLR type is still in the codebase. A typed append of it writes both the
+source name and a `dotnet_type` pointing at the old type, so letting the hint win would read those
+rows back as the old schema while every row written by the previous deployment upcast correctly —
+one store, one event type name, two answers depending on which deployment wrote the row.
+
+## Async-only transformations
+
+Register a `Func<TOld, CancellationToken, Task<TNew>>` when the transformation genuinely has to
+await — a lookup, say. Fisher's read paths are all asynchronous, so an async-only registration works
+everywhere; prefer the synchronous form when you do not need it.
+
+## What upcasting does not reach
+
+- **A projection that has already run.** An upcast changes how a row is *read*, and the daemon's
+  high-water mark is a sequence — so a document, snapshot or flat table built from the old schema
+  keeps what it derived until that projection is rebuilt. Same caveat as
+  [event data masking](/events/rewriting#event-data-masking), and the same reason: upcasting is a
+  read-time reinterpretation, not a correction to anything derived.
+- **A binary event body's raw JSON.** A `[BinaryEvent]` row's `data` column holds only a placeholder,
+  so a raw-JSON transformation over one is refused by name rather than handed `{}`. Register a typed
+  upcast instead — it reads the body through the old type's own `IEventBinarySerializer`.
+
+## Subscriptions and projections filtered by event type
+
+Nothing to do. A subscription that names the **new** types still receives the old rows: Fisher pushes
+the type filter into SQL, and it is widened with every registered transformation's source name. Left
+alone, a filtered shard would read nothing at all from the history it was pointed at and report
+itself caught up.
+
+## Registering the new type
+
+Nothing to do here either. The store registers each transformation's target event type at
+construction — nothing else would, since dropping the old type means no `AddEventType`, projection
+registration or append ever mentions the new one.

--- a/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
+++ b/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
@@ -40,7 +40,22 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
     {
         await DisposeStoreAsync().ConfigureAwait(false);
 
-        _database = TemporaryDatabase.Create(config.SchemaName ?? "compliance");
+        // ⚠️ ONE file per fixture, kept across reconfigurations — not one per ConfigureAsync.
+        //
+        // A suite that reconfigures mid-test and expects to READ WHAT THE PREVIOUS CONFIGURATION
+        // WROTE cannot work otherwise, and UpcastingCompliance is built entirely on that shape: it
+        // writes rows through a "legacy" store that has never heard of the transformation, then hands
+        // the schema to the upcasting store to read back. That is the honest reproduction of the
+        // migration story, and against a fresh file per call it reads an empty database — six facts
+        // failing with "should have single item but had 0", which is what found this (fisher#191).
+        //
+        // Both siblings get this for free: one server, and the schema name is the isolation. Fisher's
+        // isolation is the FIXTURE — xUnit builds one per test — and the schema name folds into the
+        // table prefix, so two configurations naming different schemas still cannot see each other
+        // inside one file. Every suite that changes something structural (stream identity, conjoined
+        // tenancy) already changes SchemaName with it, which is what makes sharing the file safe:
+        // reconfiguring within one schema name only ever adds event types and projections.
+        _database ??= TemporaryDatabase.Create(config.SchemaName ?? "compliance");
 
         _store = DocumentStore.For(options =>
         {
@@ -414,6 +429,24 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
         CreateProjectionScenario() => new Fisher.Events.TestSupport.ProjectionScenario(Store);
 
     /// <summary>
+    ///     jasperfx#752 — Fisher routes every read path through <c>EventRegistry.Upcasters</c> and
+    ///     implements <c>IUpcastPayload</c> over its own row reader and serializer (fisher#191).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The one gate that shipped closed, because the contract was defined ahead of any store
+    ///         implementing it. Fisher is the first to flip it.
+    ///     </para>
+    ///     <para>
+    ///         The only part of the contract a store may decline is the raw-JSON accessor, and Fisher
+    ///         cannot need to: its <c>data</c> column holds exactly the text System.Text.Json wrote, so
+    ///         <c>AsJsonDocument</c> is a parse of a string already in hand. Marten's is optional
+    ///         because its serializer is configurable.
+    ///     </para>
+    /// </remarks>
+    public override bool SupportsUpcasting => true;
+
+    /// <summary>
     ///     fisher#37 / polecat#370 — Fisher ships <see cref="Fisher.Batching.FetchStreamStatePlan" /> and
     ///     <see cref="Fisher.Batching.FetchStreamPlan" />, each implementing both the standalone and the
     ///     batched plan interface.
@@ -624,6 +657,8 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
     public override async ValueTask DisposeAsync()
     {
         await DisposeStoreAsync().ConfigureAwait(false);
+
+        DisposeDatabase();
     }
 
     private async Task DisposeStoreAsync()
@@ -642,7 +677,17 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
             await _store.DisposeAsync().ConfigureAwait(false);
             _store = null;
         }
+    }
 
+    /// <summary>
+    ///     Drop the fixture's throwaway file, once, at the end.
+    /// </summary>
+    /// <remarks>
+    ///     Separate from <see cref="DisposeStoreAsync" /> because that one runs on every
+    ///     reconfiguration and the file has to outlive them — see <see cref="BuildStoreAsync" />.
+    /// </remarks>
+    private void DisposeDatabase()
+    {
         _database?.Dispose();
         _database = null;
     }
@@ -810,6 +855,22 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
         /// </remarks>
         public void UseMessageOutbox(RecordingMessageOutbox outbox)
             => _options.Events.MessageOutbox = outbox;
+
+        /// <summary>
+        ///     jasperfx#752 — register one event upcast transformation (fisher#191).
+        /// </summary>
+        /// <remarks>
+        ///     One member covers every registration shape, because
+        ///     <see cref="JasperFx.Events.Upcasting.UpcastTransformation" /> is the carrier all of them
+        ///     funnel into — so this is the whole of Fisher's registration seam, and it is exactly the
+        ///     call an application makes through <c>StoreOptions.Events.Upcasters</c>. Registering the
+        ///     transformation's target event type is deliberately <em>not</em> done here:
+        ///     <c>DocumentStore</c>'s constructor sweeps <c>AllTransformations</c> for that, so a store
+        ///     configured through the shared JasperFx surface gets it too rather than only one
+        ///     configured through this seam.
+        /// </remarks>
+        public void Upcast(JasperFx.Events.Upcasting.UpcastTransformation transformation)
+            => _options.Events.Upcasters.Register(transformation);
     }
 }
 

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -8,11 +8,9 @@ namespace Fisher.Tests.Compliance;
  * Fisher's session pair through FisherComplianceFixture. Marten and Polecat enroll the same way, so
  * these tests cannot drift between the products.
  *
- * Suites were added one at a time as Fisher grew into them, and forty-nine are enrolled from
- * JasperFx.Events.ComplianceTests 2.65.0, which itself ships fifty-two. Two are not enrolled:
- * SingleTenantedEventSlicingCompliance, for the precondition reason set out immediately below, and
- * UpcastingCompliance, which is the next node's work rather than this one's — Fisher has no
- * upcasting at all today, so enrolling it would be a suite that skips itself wholesale.
+ * Suites were added one at a time as Fisher grew into them, and fifty are enrolled from
+ * JasperFx.Events.ComplianceTests 2.65.0, which itself ships fifty-two. One is not enrolled:
+ * SingleTenantedEventSlicingCompliance, for the precondition reason set out below.
  *
  * Three of the ten suites this wave adds are enrolled and gated off rather than green, each for a
  * reason recorded at the flag on FisherComplianceFixture rather than here:
@@ -300,6 +298,28 @@ public class aggregate_to_linq_operator_compliance
 
 public class aggregate_to_many_compliance
     : AggregateToManyCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
+
+/*
+ * jasperfx#752 / fisher#191 — event upcasting: a transformation registered against
+ * EventRegistry.Upcasters reinterprets an old stored event schema as the current CLR event type on
+ * every read path, so no read — stream fetch, live aggregation, FetchForWriting, the daemon — ever
+ * hands application code the old schema.
+ *
+ * ⚠️ This suite was written BEFORE any store implemented the contract, which is unique in the
+ * library: its gate ships closed and the suite IS the specification. Fisher is the first store to
+ * flip it, so every one of these facts is running for the first time anywhere.
+ *
+ * Two of them are worth naming. `an_async_only_upcast_applies_on_the_async_read_path` is why Fisher's
+ * row hydration became asynchronous: an async-only transformation's synchronous delegate throws
+ * UpcastingException by design, so a store hydrating synchronously could not honour one at all — and
+ * every Fisher read path was already inside an `await reader.ReadAsync(...)` loop, so the change cost
+ * a ValueTask per row. And `a_typed_append_of_the_old_event_type_does_not_shadow_the_upcaster` is the
+ * marten#4680 authority rule: the stored dotnet_type hint does not get a vote, which is why the
+ * registry is consulted BEFORE ResolveEventType rather than as a fallback after it.
+ */
+
+public class upcasting_compliance
+    : UpcastingCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
 
 /*
  * fisher#93 — binary event serialization, arriving in JasperFx.Events.ComplianceTests 2.50.0 and

--- a/src/Fisher.Tests/Events/upcasting.cs
+++ b/src/Fisher.Tests/Events/upcasting.cs
@@ -1,0 +1,313 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using Fisher.Subscriptions;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Upcasting;
+
+namespace Fisher.Tests.Events;
+
+public record LanternLit(Guid LanternId, string Keeper);
+
+public record LanternDimmed(Guid LanternId, int Level);
+
+public record LanternKindled(Guid LanternId, string Keeper, string Status);
+
+public record LanternDarkened(Guid LanternId, double Fraction);
+
+/// <summary>
+///     fisher#191 — the Fisher half of the shared event upcasting contract
+///     (<c>JasperFx.Events.Upcasting</c>, jasperfx#752).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>What the shared suite covers and this does not.</b> <c>UpcastingCompliance</c> pins the
+///         contract itself — every registration shape, every read path, the marten#4680 authority rule
+///         — for all three stores. What is left here is the two things it structurally cannot see:
+///         the daemon's <em>server-side</em> event type filter, which is SQL Fisher writes, and a
+///         binary event body, which is a Fisher/Polecat feature the shared suite's upcasting fixture
+///         knows nothing about.
+///     </para>
+///     <para>
+///         The daemon fact is the one that would otherwise be untested code. The shared suite's daemon
+///         fact registers a snapshot projection, whose <c>IncludedEventTypes</c> allow list is empty —
+///         so no SQL filter is composed at all and the widening below is never exercised. A
+///         subscription that names its types is what reaches it.
+///     </para>
+/// </remarks>
+public class upcasting : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("upcasting");
+    private DocumentStore? _store;
+    private IProjectionDaemon? _daemon;
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_daemon is not null)
+        {
+            await _daemon.StopAllAsync();
+            _daemon.Dispose();
+        }
+
+        if (_store is not null)
+        {
+            await _store.DisposeAsync();
+        }
+
+        _database.Dispose();
+    }
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private async Task<DocumentStore> StoreAsync(Action<StoreOptions> configure)
+    {
+        var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            configure(options);
+        });
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        return store;
+    }
+
+    /// <summary>
+    ///     Write rows the way the pre-migration application really wrote them — through a store that
+    ///     has never heard of the transformation — then dispose it.
+    /// </summary>
+    private async Task<Guid> AppendLegacyAsync(params object[] events)
+    {
+        await using var legacy = await StoreAsync(options =>
+        {
+            options.Events.AddEventType(typeof(LanternLit));
+            options.Events.AddEventType(typeof(LanternDimmed));
+        });
+
+        var streamId = Guid.NewGuid();
+
+        await using var session = legacy.LightweightSession();
+        session.Events.StartStream(streamId, events);
+        await session.SaveChangesAsync(Token);
+
+        return streamId;
+    }
+
+    private static void RegisterUpcasts(StoreOptions options)
+    {
+        options.Events.Upcasters.Upcast<LanternLit, LanternKindled>(
+            old => new LanternKindled(old.LanternId, old.Keeper, "Lit"));
+
+        options.Events.Upcasters.Upcast<LanternDimmed, LanternDarkened>(
+            old => new LanternDarkened(old.LanternId, old.Level / 100.0));
+    }
+
+    /// <summary>
+    ///     ⚠️ A subscription filtered on the NEW event types still receives the old rows, because the
+    ///     daemon's server-side <c>type in (...)</c> filter is widened with every registered
+    ///     transformation's SOURCE name.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Without the widening this fails by delivering <b>nothing</b> and reporting the shard
+    ///         caught up — the worst shape a filter bug can take, since a subscription that receives no
+    ///         events looks exactly like a quiet store. The filter is pushed into SQLite precisely so
+    ///         non-matching rows never leave it, which is also why the loader's in-memory check (which
+    ///         does see the hydrated, upcast event) cannot rescue it.
+    ///     </para>
+    ///     <para>
+    ///         Not reachable from <c>UpcastingCompliance</c>: its daemon fact registers a snapshot
+    ///         projection, whose allow list is empty, so no SQL filter is composed at all.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_subscription_filtered_on_the_new_type_receives_the_upcast_old_rows()
+    {
+        var streamId = await AppendLegacyAsync(new LanternLit(Guid.NewGuid(), "Beregond"),
+            new LanternDimmed(Guid.NewGuid(), 40));
+
+        var subscription = new RecordingSubscription();
+
+        _store = await StoreAsync(options =>
+        {
+            RegisterUpcasts(options);
+            options.Projections.Subscribe(subscription,
+                o => o.IncludeType<LanternDarkened>());
+        });
+
+        _daemon = await _store.BuildProjectionDaemonAsync();
+        await _daemon.StartAllAsync();
+
+        await subscription.WaitForAsync(1);
+
+        var received = subscription.Received.ShouldHaveSingleItem();
+        received.Data.ShouldBeOfType<LanternDarkened>().Fraction.ShouldBe(0.4);
+        received.StreamId.ShouldBe(streamId);
+
+        // And only that one: widening the filter must not smuggle in the other transformation's
+        // source rows, which the subscription did not ask for.
+        subscription.Received.ShouldAllBe(x => x.Data is LanternDarkened);
+    }
+
+    /// <summary>
+    ///     A raw-JSON transformation over an event whose body is a BLOB is refused by name rather than
+    ///     handed the <c>{}</c> placeholder that <c>data</c> holds for those rows (fisher#93).
+    /// </summary>
+    /// <remarks>
+    ///     Silent otherwise, and in the worst direction: <c>JsonDocument.Parse("{}")</c> succeeds, so
+    ///     the transformation would run against an empty object and produce an event with every member
+    ///     at its default — a plausible-looking row rather than an error.
+    /// </remarks>
+    [Fact]
+    public async Task a_raw_json_upcast_over_a_binary_body_is_refused_by_name()
+    {
+        var streamId = await AppendBinaryLanternAsync();
+
+        _store = await StoreAsync(options =>
+        {
+            options.Events.UseBinarySerializer<LanternLit>(new GzipJsonSerializer());
+            options.Events.Upcasters.Upcast<LanternKindled>(
+                JasperFx.Events.EventTypeExtensions.GetEventTypeName<LanternLit>(),
+                _ => new LanternKindled(Guid.Empty, "unreachable", "unreachable"));
+        });
+
+        await using var session = _store.LightweightSession();
+
+        var ex = await Should.ThrowAsync<UpcastingException>(
+            () => session.Events.FetchStreamAsync(streamId, token: Token));
+
+        ex.Message.ShouldContain("data_binary");
+    }
+
+    /// <summary>
+    ///     A <em>typed</em> transformation over a binary body reads it through the old type's own
+    ///     <c>IEventBinarySerializer</c>, so upcasting and binary bodies compose.
+    /// </summary>
+    [Fact]
+    public async Task a_typed_upcast_reads_a_binary_body_through_its_own_serializer()
+    {
+        var streamId = await AppendBinaryLanternAsync();
+
+        _store = await StoreAsync(options =>
+        {
+            options.Events.UseBinarySerializer<LanternLit>(new GzipJsonSerializer());
+            RegisterUpcasts(options);
+        });
+
+        await using var session = _store.LightweightSession();
+        var events = await session.Events.FetchStreamAsync(streamId, token: Token);
+
+        events.ShouldHaveSingleItem().Data.ShouldBeOfType<LanternKindled>()
+            .Keeper.ShouldBe("Beregond");
+    }
+
+    /// <summary>
+    ///     The store registers every transformation's TARGET event type at construction, because
+    ///     nothing else would: dropping the old type is the point of an upcast, so no
+    ///     <c>AddEventType</c>, projection registration or append ever mentions the new one either.
+    /// </summary>
+    [Fact]
+    public async Task the_transformation_target_type_is_registered_by_the_store()
+    {
+        _store = await StoreAsync(RegisterUpcasts);
+
+        _store.Options.EventGraph.AllKnownEventTypes()
+            .Select(x => x.EventType)
+            .ShouldContain(typeof(LanternKindled));
+    }
+
+    private async Task<Guid> AppendBinaryLanternAsync()
+    {
+        await using var legacy = await StoreAsync(options =>
+            options.Events.UseBinarySerializer<LanternLit>(new GzipJsonSerializer()));
+
+        var streamId = Guid.NewGuid();
+
+        await using var session = legacy.LightweightSession();
+        session.Events.StartStream(streamId, new LanternLit(Guid.NewGuid(), "Beregond"));
+        await session.SaveChangesAsync(Token);
+
+        return streamId;
+    }
+
+    /// <summary>
+    ///     Gzipped JSON, which is the shape the shared binary suite uses too — arbitrary bytes are
+    ///     exactly what a text round trip would corrupt, and nothing else is.
+    /// </summary>
+    private sealed class GzipJsonSerializer : IEventBinarySerializer
+    {
+        public byte[] Serialize(Type type, object data)
+        {
+            using var output = new MemoryStream();
+            using (var gzip = new System.IO.Compression.GZipStream(output,
+                       System.IO.Compression.CompressionLevel.Fastest, leaveOpen: true))
+            {
+                var json = JsonSerializer.SerializeToUtf8Bytes(data, type);
+                gzip.Write(json, 0, json.Length);
+            }
+
+            return output.ToArray();
+        }
+
+        public object Deserialize(Type type, byte[] data)
+        {
+            using var input = new MemoryStream(data);
+            using var gzip = new System.IO.Compression.GZipStream(input,
+                System.IO.Compression.CompressionMode.Decompress);
+            using var output = new MemoryStream();
+            gzip.CopyTo(output);
+
+            return JsonSerializer.Deserialize(Encoding.UTF8.GetString(output.ToArray()), type)!;
+        }
+    }
+
+    /// <inheritdoc cref="a_subscription_filtered_on_the_new_type_receives_the_upcast_old_rows" />
+    private sealed class RecordingSubscription : SubscriptionBase
+    {
+        private readonly ConcurrentQueue<IEvent> _received = new();
+
+        internal IReadOnlyList<IEvent> Received => _received.ToArray();
+
+        public override Task<IDaemonChangeListener> ProcessEventsAsync(EventRange page,
+            ISubscriptionController controller, IDocumentSession operations,
+            CancellationToken cancellationToken)
+        {
+            foreach (var @event in page.Events)
+            {
+                _received.Enqueue(@event);
+            }
+
+            return Task.FromResult<IDaemonChangeListener>(NullDaemonChangeListener.Instance);
+        }
+
+        /// <remarks>
+        ///     Waits on the subscription's own signal rather than on non-staleness, which is true the
+        ///     moment the batch's transaction commits — strictly before anything downstream of it. See
+        ///     the note in <c>subscriptions.cs</c>; the same race applies to any post-delivery
+        ///     assertion.
+        /// </remarks>
+        internal async Task WaitForAsync(int count, int timeoutSeconds = 30)
+        {
+            var deadline = DateTimeOffset.UtcNow.AddSeconds(timeoutSeconds);
+
+            while (DateTimeOffset.UtcNow < deadline)
+            {
+                if (_received.Count >= count)
+                {
+                    return;
+                }
+
+                await Task.Delay(25, TestContext.Current.CancellationToken);
+            }
+
+            throw new TimeoutException(
+                $"The subscription received {_received.Count} events, expected at least {count}.");
+        }
+    }
+}

--- a/src/Fisher/DocumentStore.cs
+++ b/src/Fisher/DocumentStore.cs
@@ -41,6 +41,18 @@ public partial class DocumentStore : IDocumentStore
         // only place it can happen, since the point is to know about types nobody mentioned.
         options.Projections.DiscoverGeneratedEvolvers(AppDomain.CurrentDomain.GetAssemblies());
 
+        // Every upcast transformation's TARGET event type is registered here (fisher#191), because
+        // nothing else will. The old type is usually gone from the codebase — dropping it is the
+        // point of an upcast — so no AddEventType, no projection registration and no append ever
+        // mentions the new type either; a store that only READS upcast rows would otherwise have no
+        // mapping for the type its own transformation produces, and hydration would build one per
+        // read rather than once. Done at construction because a transformation may be registered
+        // through the shared JasperFx.Events.Upcasting surface, which Fisher does not own a hook in.
+        foreach (var transformation in options.EventGraph.Upcasters.AllTransformations)
+        {
+            options.EventGraph.AddEventType(transformation.EventType);
+        }
+
         // A flat table's physical name folds in the store's logical schema, and this is the first
         // moment that schema is final — the projection and DatabaseSchemaName are usually set in the
         // same configuration lambda, in whichever order the caller wrote them.

--- a/src/Fisher/Events/Daemon/FisherEventLoader.cs
+++ b/src/Fisher/Events/Daemon/FisherEventLoader.cs
@@ -64,6 +64,24 @@ internal sealed class FisherEventLoader : IEventLoader
                 _allowedEventTypeNames.Add(_events.EventMappingFor(type).EventTypeName);
             }
 
+            // ⚠️ An upcast target's SOURCE names have to be allowed too, or the filter excludes
+            // exactly the rows upcasting exists to read (fisher#191). A projection that folds the new
+            // schema declares the new types, and every row written before the migration carries the
+            // OLD name — so a shard filtered on the declared set alone reads nothing at all from the
+            // history it was pointed at, silently, and reports itself caught up.
+            //
+            // The wrong-looking alternative is to leave the SQL filter alone and rely on the
+            // in-memory check below, which does see the hydrated (upcast) event. It would not help:
+            // the filter is pushed into SQLite precisely so non-matching rows never leave it, and the
+            // old-named rows never would.
+            foreach (var transformation in _events.Upcasters.AllTransformations)
+            {
+                if (included.Contains(transformation.EventType))
+                {
+                    _allowedEventTypeNames.Add(transformation.EventTypeName);
+                }
+            }
+
             // The filter is pushed into SQL so non-matching rows never leave SQLite — a
             // subscription scoped to a few event types in a busy store would otherwise deserialize
             // essentially the whole event log to produce nothing. Marten pushes the same filter
@@ -126,7 +144,8 @@ internal sealed class FisherEventLoader : IEventLoader
         await using var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
         while (await reader.ReadAsync(token).ConfigureAwait(false))
         {
-            var @event = FisherEventsRowReader.ReadEventAcrossStreams(reader, ctx, slots, isGuid);
+            var @event = await FisherEventsRowReader.ReadEventAcrossStreams(reader, ctx, slots, isGuid, token)
+                .ConfigureAwait(false);
 
             if (@event is null)
             {

--- a/src/Fisher/Events/EventOperations.Querying.cs
+++ b/src/Fisher/Events/EventOperations.Querying.cs
@@ -118,8 +118,8 @@ public partial class EventOperations
         while (await reader.ReadAsync(token).ConfigureAwait(false))
         {
             var @event = isGuid
-                ? FisherEventsRowReader.ReadEventAsGuid(reader, ctx, slots)
-                : FisherEventsRowReader.ReadEventAsString(reader, ctx, slots);
+                ? await FisherEventsRowReader.ReadEventAsGuid(reader, ctx, slots, token).ConfigureAwait(false)
+                : await FisherEventsRowReader.ReadEventAsString(reader, ctx, slots, token).ConfigureAwait(false);
 
             // Null means dotnet_type named a type this process cannot resolve. Skipping rather than
             // throwing matches Marten and Polecat: a deployment that has not been told about an
@@ -216,8 +216,8 @@ public partial class EventOperations
         var slots = MetadataSlots.For(options);
 
         return isGuid
-            ? FisherEventsRowReader.ReadEventAsGuid(reader, ctx, slots)
-            : FisherEventsRowReader.ReadEventAsString(reader, ctx, slots);
+            ? await FisherEventsRowReader.ReadEventAsGuid(reader, ctx, slots, token).ConfigureAwait(false)
+            : await FisherEventsRowReader.ReadEventAsString(reader, ctx, slots, token).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Fisher/Events/EventOperations.RawQuery.cs
+++ b/src/Fisher/Events/EventOperations.RawQuery.cs
@@ -84,7 +84,8 @@ public partial class EventOperations
         await using var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
         while (await reader.ReadAsync(token).ConfigureAwait(false))
         {
-            var @event = FisherEventsRowReader.ReadEventAcrossStreams(reader, ctx, slots, isGuid);
+            var @event = await FisherEventsRowReader.ReadEventAcrossStreams(reader, ctx, slots, isGuid, token)
+                    .ConfigureAwait(false);
 
             if (@event is not null)
             {
@@ -184,7 +185,8 @@ public partial class EventOperations
         {
             while (await reader.ReadAsync(token).ConfigureAwait(false))
             {
-                var @event = FisherEventsRowReader.ReadEventAcrossStreams(reader, ctx, slots, isGuid);
+                var @event = await FisherEventsRowReader.ReadEventAcrossStreams(reader, ctx, slots, isGuid, token)
+                    .ConfigureAwait(false);
 
                 if (@event is not null)
                 {

--- a/src/Fisher/Events/EventOperations.Tags.cs
+++ b/src/Fisher/Events/EventOperations.Tags.cs
@@ -170,7 +170,8 @@ public partial class EventOperations
         await using var reader = await command.ExecuteReaderAsync(cancellation).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellation).ConfigureAwait(false))
         {
-            var @event = FisherEventsRowReader.ReadEventAcrossStreams(reader, ctx, slots, isGuid);
+            var @event = await FisherEventsRowReader
+                .ReadEventAcrossStreams(reader, ctx, slots, isGuid, cancellation).ConfigureAwait(false);
 
             // Null means dotnet_type named a type this process cannot resolve; skip it, as the
             // stream reads do.

--- a/src/Fisher/Events/Internal/FisherEventsRowReader.cs
+++ b/src/Fisher/Events/Internal/FisherEventsRowReader.cs
@@ -87,10 +87,10 @@ internal static class FisherEventsRowReader
     ///     Returns null when <c>dotnet_type</c> does not resolve to a type this process knows, so
     ///     callers can skip with a single <c>continue</c>.
     /// </summary>
-    internal static IEvent? ReadEventAsGuid(DbDataReader reader, in EventHydrationContext ctx,
-        in MetadataSlots slots)
+    internal static async ValueTask<IEvent?> ReadEventAsGuid(DbDataReader reader, EventHydrationContext ctx,
+        MetadataSlots slots, CancellationToken token)
     {
-        var @event = ReadEventCore(reader, ctx, slots);
+        var @event = await ReadEventCore(reader, ctx, slots, token).ConfigureAwait(false);
 
         if (@event is null)
         {
@@ -104,10 +104,10 @@ internal static class FisherEventsRowReader
     /// <summary>
     ///     Read the current row as a hydrated <see cref="IEvent" /> for a string-identified stream.
     /// </summary>
-    internal static IEvent? ReadEventAsString(DbDataReader reader, in EventHydrationContext ctx,
-        in MetadataSlots slots)
+    internal static async ValueTask<IEvent?> ReadEventAsString(DbDataReader reader, EventHydrationContext ctx,
+        MetadataSlots slots, CancellationToken token)
     {
-        var @event = ReadEventCore(reader, ctx, slots);
+        var @event = await ReadEventCore(reader, ctx, slots, token).ConfigureAwait(false);
 
         if (@event is null)
         {
@@ -130,10 +130,10 @@ internal static class FisherEventsRowReader
     ///     wrong id. <c>stream_id</c> is at ordinal 2 of <see cref="CoreSelectColumns" />, which is why
     ///     this belongs here rather than at the call site.
     /// </remarks>
-    internal static IEvent? ReadEventAcrossStreams(DbDataReader reader, in EventHydrationContext ctx,
-        in MetadataSlots slots, bool isGuidIdentity)
+    internal static async ValueTask<IEvent?> ReadEventAcrossStreams(DbDataReader reader,
+        EventHydrationContext ctx, MetadataSlots slots, bool isGuidIdentity, CancellationToken token)
     {
-        var @event = ReadEventCore(reader, ctx, slots);
+        var @event = await ReadEventCore(reader, ctx, slots, token).ConfigureAwait(false);
 
         if (@event is null)
         {
@@ -189,10 +189,66 @@ internal static class FisherEventsRowReader
     }
 
     /// <summary>
+    ///     Run the registered upcast transformation for this row's stored event type name, if there is
+    ///     one, and return the transformed body. Null means "no transformation" — hydrate normally.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>The stored event type name decides, and the <c>dotnet_type</c> hint does not get a
+    ///         vote</b> — the marten#4680 authority rule, which the shared registry states as: a
+    ///         registered transformation is the authoritative interpretation of its source name. It is
+    ///         consulted <em>before</em> <c>ResolveEventType</c> for exactly that reason. The case it
+    ///         exists for is a store that still has the old CLR type in its codebase: a typed append of
+    ///         it writes both the source name and a <c>dotnet_type</c> pointing at the old type, and
+    ///         letting the hint win would read those rows back as the old schema while every row
+    ///         written by the previous deployment upcast correctly. Same store, same event type name,
+    ///         two answers.
+    ///     </para>
+    ///     <para>
+    ///         <b>Guarded on <c>HasAny</c> first</b>, so a store with no upcasts pays one boolean field
+    ///         read per row and nothing else — no dictionary probe, no payload struct, no state
+    ///         machine, since the method completes synchronously.
+    ///     </para>
+    /// </remarks>
+    private static async ValueTask<object?> TryUpcast(DbDataReader reader, EventHydrationContext ctx,
+        MetadataSlots slots, string typeName, CancellationToken token)
+    {
+        var upcasters = ctx.EventGraph.Upcasters;
+
+        if (!upcasters.HasAny || !upcasters.TryFindTransformation(typeName, out var transformation))
+        {
+            return null;
+        }
+
+        var binary = reader.IsDBNull(slots.BinaryDataIdx)
+            ? null
+            : (byte[])reader.GetValue(slots.BinaryDataIdx);
+
+        var payload = new Upcasting.FisherUpcastPayload(ctx.EventGraph, ctx.Serializer,
+            reader.GetString(4), binary, typeName);
+
+        // The async delegate, always — never the sync one. An async-only registration's synchronous
+        // delegate throws UpcastingException by design, and Fisher has no synchronous read path to
+        // reserve it for; a transformation registered the ordinary way wraps its sync delegate here
+        // and completes without awaiting anything.
+        return await transformation.UpcastAsync(payload, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
     ///     Everything except the stream identity, which the specialized wrappers assign.
     /// </summary>
-    private static IEvent? ReadEventCore(DbDataReader reader, in EventHydrationContext ctx,
-        in MetadataSlots slots)
+    /// <remarks>
+    ///     <para>
+    ///         <b>Asynchronous because upcasting can be</b> (fisher#191). The shared contract lets a
+    ///         transformation be registered async-only, whose synchronous delegate throws by design —
+    ///         so a store that hydrated synchronously could not honour one at all. Every Fisher read
+    ///         path that reaches here is already inside an <c>await reader.ReadAsync(...)</c> loop, so
+    ///         the change costs a <c>ValueTask</c> per row and nothing else; the ordinary path never
+    ///         awaits anything and completes synchronously.
+    ///     </para>
+    /// </remarks>
+    private static async ValueTask<IEvent?> ReadEventCore(DbDataReader reader, EventHydrationContext ctx,
+        MetadataSlots slots, CancellationToken token)
     {
         var seqId = reader.GetInt64(0);
         var eventId = Guid.Parse(reader.GetString(1));
@@ -204,7 +260,9 @@ internal static class FisherEventsRowReader
         var dotNetTypeName = reader.IsDBNull(8) ? null : reader.GetString(8);
         var isArchived = reader.GetInt64(9) != 0;
 
-        var resolvedType = ctx.EventGraph.ResolveEventType(dotNetTypeName);
+        var upcast = await TryUpcast(reader, ctx, slots, typeName, token).ConfigureAwait(false);
+
+        var resolvedType = upcast?.GetType() ?? ctx.EventGraph.ResolveEventType(dotNetTypeName);
 
         if (resolvedType is null)
         {
@@ -217,9 +275,9 @@ internal static class FisherEventsRowReader
         // never by the event type's current setting (fisher#93). That is what makes marking a type
         // [BinaryEvent] an in-place change: rows written before the change still carry JSON, and this
         // still reads them. A dispatch on the type would misread every one of them instead.
-        var data = reader.IsDBNull(slots.BinaryDataIdx)
+        var data = upcast ?? (reader.IsDBNull(slots.BinaryDataIdx)
             ? ctx.Serializer.FromJson(resolvedType, reader.GetString(4))
-            : DeserializeBinary(reader, slots, mapping, resolvedType);
+            : DeserializeBinary(reader, slots, mapping, resolvedType));
 
         var @event = mapping.Wrap(data);
 

--- a/src/Fisher/Events/Upcasting/FisherUpcastPayload.cs
+++ b/src/Fisher/Events/Upcasting/FisherUpcastPayload.cs
@@ -1,0 +1,116 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Fisher.Serialization;
+using JasperFx.Events.Upcasting;
+
+namespace Fisher.Events.Upcasting;
+
+/// <summary>
+///     Fisher's half of the shared upcasting contract (jasperfx#752): one stored event body, presented
+///     to an <see cref="UpcastTransformation" /> without saying how Fisher read it.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>A per-row struct, deliberately.</b> The contract says an implementation is short-lived
+///         and that a transformation calls exactly one accessor exactly once per event, so there is
+///         nothing to cache and no state to share. Making it a readonly struct keeps the ordinary read
+///         path — the one where no transformation is registered and this is never constructed —
+///         allocation-identical to what it was, and costs one boxing conversion on the rows that
+///         actually upcast.
+///     </para>
+///     <para>
+///         <b>Fisher is System.Text.Json-only, which is what makes the raw-JSON half unconditional
+///         here.</b> The contract permits a store whose serializer cannot produce a
+///         <see cref="JsonDocument" /> to refuse; Marten has to, because its serializer is
+///         configurable. Fisher's <c>data</c> column is the literal text System.Text.Json wrote, so
+///         <see cref="AsJsonDocument" /> is a parse of a string already in hand.
+///     </para>
+///     <para>
+///         <b>The async accessors do not stream, and that is honest rather than lazy.</b> Fisher's
+///         reads have already materialized the row's body into a <c>string</c> by the time hydration
+///         runs — the row reader takes it off <c>DbDataReader.GetString</c> — so an "async" accessor
+///         has nothing left to await. The contract offers the pair for stores that can stream; saying
+///         so is better than wrapping the sync path in a <c>Task.Run</c> to look asynchronous.
+///     </para>
+///     <para>
+///         <b>A binary body (fisher#93) is served through its own serializer, and refuses the JSON
+///         accessor.</b> A binary row's <c>data</c> column holds only <c>EventsTable.JsonPlaceholder</c>,
+///         so handing that to a raw-JSON transformation would upcast <c>{}</c> — an event with every
+///         member at its default, silently. The refusal names the column and the setting, which is the
+///         same discipline the binary read path already follows.
+///     </para>
+/// </remarks>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification =
+        "Class-level: deserializes the stored body through the configured ISerializer. The old event type flows in from the registered UpcastTransformation, which the consumer preserves.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification =
+        "Class-level: ISerializer.FromJson is annotated RDC. AOT consumers supply a source-generator-backed ISerializer.")]
+internal readonly struct FisherUpcastPayload : IUpcastPayload
+{
+    private readonly EventGraph _events;
+    private readonly ISerializer _serializer;
+    private readonly string _json;
+    private readonly byte[]? _binary;
+    private readonly string _eventTypeName;
+
+    internal FisherUpcastPayload(EventGraph events, ISerializer serializer, string json, byte[]? binary,
+        string eventTypeName)
+    {
+        _events = events;
+        _serializer = serializer;
+        _json = json;
+        _binary = binary;
+        _eventTypeName = eventTypeName;
+    }
+
+    /// <summary>
+    ///     Deserialize the stored body as the transformation's old CLR type.
+    /// </summary>
+    public T As<T>() where T : notnull
+    {
+        if (_binary is null)
+        {
+            return _serializer.FromJson<T>(_json);
+        }
+
+        // The old type is only known here, which is why the binary serializer is resolved at this
+        // point rather than carried in: the row reader knows the row is binary, the transformation
+        // knows what it is a body of, and neither knows both.
+        var mapping = _events.EventMappingFor(typeof(T));
+
+        if (mapping.BinarySerializer is not { } serializer)
+        {
+            throw new UpcastingException(
+                $"The event at type name '{_eventTypeName}' has a BLOB body in data_binary, and no "
+                + $"IEventBinarySerializer is registered for the upcast source type '{typeof(T).FullName}'. "
+                + "Register one with StoreOptions.Events.UseBinarySerializer<T>(...), or set "
+                + "StoreOptions.Events.DefaultBinarySerializer.");
+        }
+
+        return (T)serializer.Deserialize(typeof(T), _binary);
+    }
+
+    /// <inheritdoc cref="As{T}" />
+    public ValueTask<T> AsAsync<T>(CancellationToken token) where T : notnull => new(As<T>());
+
+    /// <summary>
+    ///     The stored body as raw JSON, for a transformation that keeps no old CLR type.
+    /// </summary>
+    public JsonDocument AsJsonDocument()
+    {
+        if (_binary is not null)
+        {
+            throw new UpcastingException(
+                $"The event at type name '{_eventTypeName}' has a BLOB body in data_binary, so it has "
+                + "no JSON to transform — its data column holds only the placeholder. Register a typed "
+                + "upcast over the old event type instead, which reads the body through its own "
+                + "IEventBinarySerializer.");
+        }
+
+        return JsonDocument.Parse(_json);
+    }
+
+    /// <inheritdoc cref="AsJsonDocument" />
+    public ValueTask<JsonDocument> AsJsonDocumentAsync(CancellationToken token) => new(AsJsonDocument());
+}

--- a/src/Fisher/StoreOptions.cs
+++ b/src/Fisher/StoreOptions.cs
@@ -5,6 +5,7 @@ using Fisher.Storage;
 using JasperFx;
 using JasperFx.MultiTenancy;
 using JasperFx.Events;
+using JasperFx.Events.Upcasting;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Fetching;
 using JasperFx.Events.Tags;
@@ -513,6 +514,39 @@ public class EventStoreOptions : IEventStoreInstrumentation
         EventGraph!.UseBinarySerializer<TEvent>(serializer);
         return this;
     }
+
+    /// <summary>
+    ///     Event upcasting: how an old stored event schema is reinterpreted as the current CLR event
+    ///     type on every read path (fisher#191).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The registry, the transformation shape and the <c>IEventUpcaster</c> bases are all
+    ///         JasperFx's (<c>JasperFx.Events.Upcasting</c>, jasperfx#752) — Fisher supplies the read
+    ///         path and one <c>IUpcastPayload</c> adapter over its own reader and serializer, the same
+    ///         division as the async daemon. So an upcast registration ports between the three stores
+    ///         unchanged, which is the whole reason the contract was lifted.
+    ///     </para>
+    ///     <para>
+    ///         Forwarded from <see cref="Fisher.Events.EventGraph" /> rather than declared here, the
+    ///         same shape <see cref="DefaultBinarySerializer" /> takes: the graph is the
+    ///         <c>EventRegistry</c> the shared contract hangs off, and this is where a Fisher
+    ///         application configures its event store.
+    ///     </para>
+    ///     <para>
+    ///         <b>Registering a transformation is what makes its source name authoritative on read</b>
+    ///         (marten#4680): a stored <c>dotnet_type</c> hint pointing at the old CLR type does not
+    ///         shadow it, so the old type staying in the codebase — and even being appended typed —
+    ///         does not divide the store's history into rows that upcast and rows that do not.
+    ///     </para>
+    ///     <example>
+    ///         <code>
+    ///         options.Events.Upcasters.Upcast&lt;CartOpenedV1, CartInitialized&gt;(
+    ///             old =&gt; new CartInitialized(old.CartId, old.ClientId, "Opened"));
+    ///         </code>
+    ///     </example>
+    /// </remarks>
+    public UpcastingRegistry Upcasters => EventGraph!.Upcasters;
 
     /// <summary>
     ///     Keep recently fetched snapshots of <typeparamref name="T" /> in a node-local cache, so that a


### PR DESCRIPTION
Closes #191.

Fisher had **no upcasting at all**, and for a store that keeps event JSON forever it was the biggest
long-lived-application gap left. The registry, the transformation shape and the `IEventUpcaster`
bases are all JasperFx's (jasperfx#752); what lands here is the read path and one `IUpcastPayload`
adapter — the same division as the async daemon, so an upcast registration ports between the three
stores unchanged.

```csharp
options.Events.Upcasters.Upcast<CartOpenedV1, CartInitialized>(
    old => new CartInitialized(old.CartId, old.ClientId, "Opened"));
```

**The read-side integration is one call in `FisherEventsRowReader.ReadEventCore`**, which is what
having a single hydration point buys: every stream read, live aggregation, `FetchForWriting`, DCB tag
query and daemon page already converges there.

## Five decisions

| | |
|---|---|
| **The registry is consulted *before* `ResolveEventType`** | That ordering **is** the marten#4680 authority rule rather than an optimisation. A registered transformation is the authoritative interpretation of its source name, so the stored `dotnet_type` hint does not get a vote — otherwise a store that still has the old CLR type reads *typed appends of it* back as the old schema while every row the previous deployment wrote upcasts correctly. |
| **Hydration became asynchronous** (`ValueTask<IEvent?>`) | The contract lets a transformation be registered async-only, whose synchronous delegate throws by design — a store hydrating synchronously could not honour one at all. Every read path was already inside an `await reader.ReadAsync(...)` loop, so the cost is a `ValueTask` per row; `TryUpcast` is guarded on `HasAny` first, so a store with no upcasts pays one boolean field read and completes synchronously. |
| **The raw-`JsonDocument` accessor is unconditional** | Where the contract lets a store refuse: Fisher is System.Text.Json-only and `data` holds exactly the text it wrote. A **binary** body is the one exception — its `data` holds only the `{}` placeholder, so a raw-JSON transformation over one is refused by name rather than handed an empty object that would upcast to every member at its default. A *typed* transformation reads it through the old type's own `IEventBinarySerializer`. |
| **The daemon's server-side type filter is widened with every transformation's SOURCE name** | Or a shard filtered on the new types reads nothing at all from the history it was pointed at — silently, reporting itself caught up. |
| **Target event types are pre-registered in `DocumentStore`'s constructor** | Nothing else would: dropping the old type is the point of an upcast, so no `AddEventType`, projection registration or append ever mentions the new one either. |

## Two findings from being first

`UpcastingCompliance` is **the first suite in the library written ahead of any store implementing the
behaviour** — its gate ships closed, and Fisher is the first to flip it, so all seven facts ran for
the first time anywhere here.

**The fixture created a new throwaway database on every `ConfigureAsync`**, so a suite that
reconfigures mid-test and expects to read what the previous configuration wrote read an empty file.
`UpcastingCompliance` is built entirely on that shape — it writes through a "legacy" store that has
never heard of the transformation, which is the honest reproduction of a migration — and six facts
failed with "should have single item but had 0". One file per **fixture** now, which is what both
siblings get for free from having one server: xUnit builds one fixture per test, and
`DatabaseSchemaName` folds into the table prefix, so two configurations naming different schemas
still cannot see each other inside one file.

**jasperfx#787** is the other: the suite's raw-JSON fact reached the stored body with a
case-sensitive `GetProperty("CartId")`, which is Marten's default casing and not Polecat's or
Fisher's. Fixed upstream in jasperfx#788.

## What the shared suite cannot see

`Events/upcasting.cs` covers the two Fisher-specific halves. The daemon filter is the one that would
otherwise be untested code — the suite's daemon fact registers a snapshot projection, whose
`IncludedEventTypes` allow list is empty, so no SQL filter is composed at all and the widening is
never exercised. `a_subscription_filtered_on_the_new_type_receives_the_upcast_old_rows` reaches it,
and **fails by delivering nothing** when the widening is removed, which was verified. The other two
facts are binary bodies, which the shared upcasting fixture knows nothing about.

## Tests

`Fisher.Tests` **1717**, `Fisher.AspNetCore.Tests` 36, `Fisher.EntityFrameworkCore.Tests` 19 —
**1772 in total, identical on net9.0 and net10.0**, and `scripts/check_scoreboard.py` agrees with
both runs.

**Five are red and every one is upstream**, fixed, merged and waiting on a JasperFx release —
jasperfx#778's two archiving facts and jasperfx#787's three. Nothing in `src/Fisher` is implicated in
any of them; `HANDOFF.md` names them all. Verified green at **1713** against a local pack of
`jasperfx` main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)