### PR TITLE
Container-scoped projections and subscriptions (gh-194)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,9 @@ Working, with tests:
   range of events, its writes committing in the batch's transaction
 - **DI registration** — `AddFisher(...)`, scoped sessions, and hosted services for schema application
   and the async daemon
+- **Container-scoped projections and subscriptions** — `AddProjectionWithServices<T>` and
+  `AddSubscriptionWithServices<T>`, so a projection or subscription takes injected services, resolved
+  from a fresh IoC scope per unit of work
 - **The command line** — `ISystemPart` and `IDatabaseSource` registered from both `AddFisher` and
   `AddFisherStore<T>`, so `db-apply` / `db-assert` / `db-patch` / `db-dump`, the `resources` commands
   and `describe` all see a Fisher store; plus `AssertDatabaseMatchesConfigurationOnStartup()`
@@ -2180,6 +2183,58 @@ hosted services. The store is a singleton, sessions are scoped, and the returned
       assemblies in one process in a fixed order — an intermittent under xUnit's parallel collections
       rather than a test. What is Fisher's to get right is read it, buffer it, log it once; detecting
       it is JasperFx's and is tested there.
+
+#### Container-scoped projections and subscriptions — fisher#194
+
+`AddProjectionWithServices<T>(lifecycle, lifetime)` and `AddSubscriptionWithServices<T>(lifetime)`, on
+`FisherConfigurationExpression`, on `FisherStoreConfigurationExpression<T>`, and as bare
+`IServiceCollection` extensions for a modular monolith registering from a module rather than from the
+composition root. `IFisherRegistrable` is the static-abstract dispatch, mirroring `IMartenRegistrable`
+— which wrapper a projection needs depends on what *kind* of projection it is, and only its base class
+knows.
+
+**Almost none of this is Fisher's, and that is the finding rather than the shortcut.**
+`JasperFx.Events.Projections.ContainerScoped` already carries `ScopedProjectionWrapper<,,>`,
+`ScopedAggregationWrapper<,,,,>` / `ScopedSingleStreamAggregationWrapper<,,,,>` and the non-generic
+`ScopedAggregationWrapper.Build(...)` factory, all public and all generic over the store's session
+pair. So Fisher closes them over `IDocumentSession` / `IQuerySession` and writes no wrapper at all.
+**Polecat has no equivalent surface**, so Fisher is the second store to have this rather than the
+third.
+
+- **Scope lifetime is the design, and the shared wrappers settle it: one `IServiceScope` per unit of
+  work.** An async projection outlives every request scope by construction — it runs from a hosted
+  service where there is no request — so a wrapper that resolves once and holds is reaching into a
+  disposed provider by its second batch, and one that opens a scope and keeps it leaks a scope per
+  registration for the life of the process. The wrappers open, resolve, use and dispose inside each
+  inline `ApplyAsync`, each daemon page and each slicing pass, holding nothing across a boundary.
+  That is also why `Transient` is treated as `Scoped` rather than refused: the wrapper resolves afresh
+  per batch either way, so the two lifetimes describe the same behaviour.
+- **The scopes come from the root provider**, which is what `IConfigureFisher` hands the callback and
+  what the store is built from. A scope created from a scoped provider is a child of something that
+  gets disposed.
+- **Both paths land on Fisher's own `Add(ProjectionBase, lifecycle)`, where Marten's equivalent calls
+  the base graph's `Add(IProjectionSource, ...)`.** That overload is what sweeps `PublishedTypes()`
+  into the schema, so a container-scoped projection's document table is created with the rest of the
+  migration. Through the narrower one the projection would work against a table that was never
+  migrated — the silent half of fisher#111, reached from a new direction.
+- **The subscription wrapper is Fisher's, and that is a gap rather than a choice.**
+  `JasperFx.Events.Subscriptions.ScopedSubscriptionServiceWrapper` exists, is generic over the session
+  pair, and is `internal` with nothing in the library referencing it — so no consumer can reach it, and
+  Marten carries its own copy for the same reason. `Subscriptions/ScopedSubscriptionWrapper.cs` is
+  Fisher's, and its constructor copies the inner subscription's `Name`, `Version`, `Options` and event
+  filtering across, because it is the *wrapper* the daemon reads those from. Dropping them is how a
+  scoped subscription silently loses a batch size or a `SubscribeFromPresent()` its constructor set —
+  marten#4318, found the hard way over there.
+- **A `Singleton` registration is the projection itself, with no wrapper**, which is correct whenever
+  its dependencies are singletons too. A bare `IProjection` is wrapped in `ProjectionWrapper` *here*
+  rather than at the graph, so the caller's `configure` lambda can reach the name and filtering surface
+  a raw `IProjection` does not have.
+- **The load-bearing tests count scopes, not results.** A projection that merely works passes every
+  correctness assertion written against a single commit and then fails on the second daemon batch, so
+  `a_scoped_projection_gets_one_scope_per_unit_of_work` counts creations *and* disposals — a wrapper
+  that opened a scope per batch and kept it passes the first half and leaks — and
+  `a_scoped_projection_runs_under_the_async_daemon` deliberately commits a second batch after the
+  daemon has already run one.
 
 #### The command-line seam — fisher#172
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1772 tests green on net9.0 and net10.0** — 1717 in
+**1784 tests green on net9.0 and net10.0** — 1729 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 516 of
 them are shared cross-store compliance tests — 447 event sourcing and 69 document. On JasperFx **2.66.0** / Weasel **9.29.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 50 suites and 516 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,717.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,729.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -139,6 +139,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                 { text: 'Composite Projections', link: '/events/projections/composite' },
                 { text: 'Asynchronous Projections', link: '/events/projections/async-daemon' },
                 { text: 'EF Core Projections', link: '/events/projections/efcore' },
+                { text: 'Container-Scoped Projections', link: '/events/projections/container-scoped' },
                 { text: 'ProjectLatest — Include Pending Events', link: '/events/projections/project-latest' },
                 { text: 'Side Effects', link: '/events/projections/side-effects' },
               ]

--- a/docs/events/projections/container-scoped.md
+++ b/docs/events/projections/container-scoped.md
@@ -1,0 +1,135 @@
+# Container-Scoped Projections
+
+A projection or subscription built by the application's **IoC container**, so it can take injected
+services — an `HttpClient`, an `ILogger<T>`, a scoped repository, anything the container knows how to
+build.
+
+```cs
+builder.Services.AddFisher(opts =>
+{
+    opts.ConnectionString = connectionString;
+})
+.AddProjectionWithServices<OrderSummaryProjection>(
+    ProjectionLifecycle.Inline, ServiceLifetime.Scoped)
+.AddSubscriptionWithServices<OrderNotifier>(ServiceLifetime.Scoped)
+.AddAsyncDaemon(DaemonMode.Solo);
+```
+
+The projection itself is an ordinary one. Nothing about it says it is container-built:
+
+```cs
+public partial class OrderSummaryProjection : SingleStreamProjection<OrderSummary, Guid>
+{
+    private readonly IPricingService _pricing;
+
+    public OrderSummaryProjection(IPricingService pricing) => _pricing = pricing;
+
+    public OrderSummary Create(IEvent<OrderPlaced> e) =>
+        new() { Id = e.StreamId, Total = _pricing.Quote(e.Data.Sku) };
+}
+```
+
+Every projection base class works — `SingleStreamProjection<TDoc, TId>`,
+`MultiStreamProjection<TDoc, TId>`, `EventProjection`, and a bare `IProjection`.
+
+## Scope lifetime — the thing to understand
+
+**An async projection outlives every request scope in the process.** It runs from a hosted service,
+where there is no request at all, and it keeps running for as long as the store does. So a
+container-scoped projection cannot simply be resolved once and held: the service graph behind it
+would come from a scope disposed long before the daemon's next batch, and the first scoped dependency
+touched would throw `ObjectDisposedException`. Nor can the wrapper open a scope and keep it — that
+leaks one scope, and everything in it, for the life of the process.
+
+**Fisher's answer is a scope per unit of work.** A fresh `IServiceScope` is opened, the projection is
+resolved inside it, and the scope is disposed before control returns — once per inline
+`SaveChangesAsync`, once per daemon page, once per slicing pass. Nothing is held across a batch
+boundary, so nothing is resolved from a disposed provider and nothing accumulates.
+
+::: tip
+Two consequences worth planning around. Your projection's constructor runs **once per batch**, so keep
+it cheap — the expensive thing belongs in a singleton dependency. And a projection instance never sees
+more than one batch, so anything it must remember between batches belongs in a dependency or in the
+projected document, never in a field.
+:::
+
+This is also why `ServiceLifetime.Transient` and `ServiceLifetime.Scoped` behave identically here: the
+wrapper resolves afresh per batch either way, so the two lifetimes describe the same behaviour.
+
+| Lifetime | What is registered | Scopes opened |
+|---|---|---|
+| `Singleton` | the resolved projection itself | none |
+| `Scoped` | a wrapper around the projection | one per unit of work |
+| `Transient` | the same wrapper | one per unit of work |
+
+`Singleton` is the cheapest and is correct whenever the projection's dependencies are themselves
+singletons. It is registered directly, with no wrapper at all.
+
+## Registering without the `AddFisher` chain
+
+The `AddFisher(...)` chain is consumed once, at the composition root, which is inconvenient in a
+modular monolith where each module wants to register its own projections. The bare
+`IServiceCollection` extensions do the same job from anywhere:
+
+```cs
+// In a module's own registration, long after AddFisher was called
+services.AddProjectionWithServices<OrderSummaryProjection>(
+    ProjectionLifecycle.Async, ServiceLifetime.Scoped);
+
+services.AddSubscriptionWithServices<OrderNotifier>(ServiceLifetime.Scoped);
+```
+
+Both have a `TStore` overload for a [secondary store](/configuration/multiple-stores):
+
+```cs
+services.AddProjectionWithServices<OrderSummaryProjection, IReportingStore>(
+    ProjectionLifecycle.Async, ServiceLifetime.Scoped);
+```
+
+## Subscriptions
+
+A [subscription](/events/subscriptions) is always asynchronous, so there is no lifecycle argument —
+only the IoC lifetime, which means exactly what it means for a projection. A `Scoped` subscription
+gets a fresh scope per page of events, disposed before the daemon commits that page's progress.
+
+```cs
+public class OrderNotifier : SubscriptionBase
+{
+    private readonly INotificationClient _client;
+
+    public OrderNotifier(INotificationClient client)
+    {
+        _client = client;
+        Options.BatchSize = 100;
+    }
+
+    public override async Task<IDaemonChangeListener> ProcessEventsAsync(EventRange page,
+        ISubscriptionController controller, IDocumentSession operations, CancellationToken token)
+    {
+        foreach (var placed in page.Events.Select(x => x.Data).OfType<OrderPlaced>())
+        {
+            await _client.NotifyAsync(placed.Sku, token);
+        }
+
+        return NullDaemonChangeListener.Instance;
+    }
+}
+```
+
+::: warning
+Options a subscription sets in its own constructor — `Name`, `Version`, `Options.BatchSize`,
+`SubscribeFromPresent()`, event filtering — are read off the **wrapper**, not off the subscription, so
+Fisher copies them across at registration. If you find one being ignored, that copy is where to look.
+:::
+
+## Where the machinery lives
+
+Almost none of this is Fisher's. The container-scoped wrappers are
+`JasperFx.Events.Projections.ContainerScoped`, shared with Marten and generic over the store's session
+types — so what Fisher supplies is the registration surface and the dispatch that picks the right
+wrapper for the kind of projection being registered. The one piece written here is the subscription
+wrapper, because the shared library's equivalent is `internal`.
+
+One thing Fisher's registration does that its sibling's does not: a container-scoped projection's
+**published document type is mapped into the schema**, so its table is created with the rest of the
+migration. Without that the projection would work against a table that was never created.

--- a/src/Fisher.Tests/Projections/container_scoped_projections.cs
+++ b/src/Fisher.Tests/Projections/container_scoped_projections.cs
@@ -1,0 +1,539 @@
+using Fisher.Linq;
+using Fisher.Projections;
+using Fisher.Subscriptions;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Fisher.Tests.Projections;
+
+/// <summary>
+///     <c>AddProjectionWithServices</c> / <c>AddSubscriptionWithServices</c> — projections and
+///     subscriptions built by the application's IoC container (fisher#194).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>The load-bearing assertions are the scope-lifetime ones</b>, not the "it runs" ones. A
+///         projection that merely works is the easy half: resolving it once at startup and holding it
+///         passes every correctness test written against a single commit, and then fails in production
+///         on the second daemon batch, when the scope it was resolved from has long been disposed. So
+///         <see cref="a_scoped_projection_gets_one_scope_per_unit_of_work" /> counts scopes and
+///         disposals rather than trusting the result, and
+///         <see cref="a_scoped_projection_survives_many_batches" /> is the one that would actually
+///         catch a captured provider.
+///     </para>
+///     <para>
+///         Fisher writes none of the projection wrappers — they are
+///         <c>JasperFx.Events.Projections.ContainerScoped</c>'s, shared with Marten — so these tests
+///         are about Fisher's registration surface reaching the right one, and about the table mapping
+///         that Fisher's own <c>Add(ProjectionBase, ...)</c> does and the base graph's narrower
+///         overload does not.
+///     </para>
+/// </remarks>
+public class container_scoped_projections : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("container-scoped");
+
+    public ValueTask InitializeAsync()
+    {
+        ScopeLedger.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _database.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private ServiceProvider ProviderFor(Action<FisherConfigurationExpression> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(x => x.SetMinimumLevel(LogLevel.Warning));
+        services.AddScoped<GreetingSource>();
+
+        var expression = services.AddFisher(o =>
+        {
+            o.ConnectionString = _database.ConnectionString;
+            o.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        configure(expression);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<DocumentStore> ReadyStoreAsync(ServiceProvider provider)
+    {
+        var store = provider.GetRequiredService<DocumentStore>();
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+        return store;
+    }
+
+    // ---------- the round trip ----------
+
+    [Fact]
+    public async Task an_inline_scoped_projection_runs_with_its_injected_service()
+    {
+        await using var provider = ProviderFor(x => x.AddProjectionWithServices<GreetedProjection>(
+            ProjectionLifecycle.Inline, ServiceLifetime.Scoped));
+
+        var store = await ReadyStoreAsync(provider);
+        var id = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Greeted>(id, new PersonNamed("Alice"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.QuerySession();
+        var greeted = await query.LoadAsync<Greeted>(id, TestContext.Current.CancellationToken);
+
+        greeted.ShouldNotBeNull();
+
+        // The greeting is the injected service's, not a constant the projection could have carried —
+        // so this fails if the projection was built with `new` rather than by the container.
+        greeted.Greeting.ShouldBe("Hello, Alice");
+    }
+
+    /// <summary>
+    ///     The published document type's table exists, which is Fisher's own contribution rather than
+    ///     the shared wrapper's.
+    /// </summary>
+    /// <remarks>
+    ///     A wrapper handed to <c>ProjectionGraph.Add(IProjectionSource, ...)</c> — which is what
+    ///     Marten's equivalent calls — never passes the <c>PublishedTypes()</c> sweep that maps the
+    ///     document type, so its table is never migrated. Silent at registration, and the projection
+    ///     then writes to a table that does not exist. See fisher#111 for the same failure on the
+    ///     non-DI path.
+    /// </remarks>
+    [Fact]
+    public async Task the_projected_document_type_is_mapped_into_the_schema()
+    {
+        await using var provider = ProviderFor(x => x.AddProjectionWithServices<GreetedProjection>(
+            ProjectionLifecycle.Inline, ServiceLifetime.Scoped));
+
+        var store = provider.GetRequiredService<DocumentStore>();
+
+        store.Options.Schema.HasMappingFor(typeof(Greeted)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task the_projections_event_types_reach_the_event_graph()
+    {
+        await using var provider = ProviderFor(x => x.AddProjectionWithServices<GreetedProjection>(
+            ProjectionLifecycle.Inline, ServiceLifetime.Scoped));
+
+        var store = provider.GetRequiredService<DocumentStore>();
+
+        store.Options.EventGraph.AllKnownEventTypes().Select(x => x.EventType)
+            .ShouldContain(typeof(PersonNamed));
+    }
+
+    // ---------- scope lifetime, which is the design ----------
+
+    /// <summary>
+    ///     One scope per unit of work, opened and disposed inside it.
+    /// </summary>
+    [Fact]
+    public async Task a_scoped_projection_gets_one_scope_per_unit_of_work()
+    {
+        await using var provider = ProviderFor(x => x.AddProjectionWithServices<GreetedProjection>(
+            ProjectionLifecycle.Inline, ServiceLifetime.Scoped));
+
+        var store = await ReadyStoreAsync(provider);
+
+        // Registration itself resolves the projection once, to read its name and filtering off it, so
+        // the baseline is taken after the store is built rather than assumed to be zero.
+        var before = ScopeLedger.Created;
+
+        for (var i = 0; i < 3; i++)
+        {
+            await using var session = store.LightweightSession();
+            session.Events.StartStream<Greeted>(Guid.NewGuid(), new PersonNamed($"Person {i}"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (ScopeLedger.Created - before).ShouldBe(3);
+
+        // And every one of them was let go of. A wrapper that opened a scope per batch and kept it
+        // would pass the count above and leak all three.
+        ScopeLedger.Disposed.ShouldBe(ScopeLedger.Created);
+    }
+
+    /// <summary>
+    ///     The failure a captured scope actually produces: fine on the first commit, dead on the next.
+    /// </summary>
+    [Fact]
+    public async Task a_scoped_projection_survives_many_batches()
+    {
+        await using var provider = ProviderFor(x => x.AddProjectionWithServices<GreetedProjection>(
+            ProjectionLifecycle.Inline, ServiceLifetime.Scoped));
+
+        var store = await ReadyStoreAsync(provider);
+        var ids = new List<Guid>();
+
+        for (var i = 0; i < 5; i++)
+        {
+            var id = Guid.NewGuid();
+            ids.Add(id);
+
+            await using var session = store.LightweightSession();
+            session.Events.StartStream<Greeted>(id, new PersonNamed($"Person {i}"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.QuerySession();
+
+        foreach (var id in ids)
+        {
+            var greeted = await query.LoadAsync<Greeted>(id, TestContext.Current.CancellationToken);
+            greeted.ShouldNotBeNull();
+        }
+    }
+
+    /// <summary>
+    ///     Transient is treated as Scoped, which is what makes the two behave identically rather than
+    ///     one of them silently capturing.
+    /// </summary>
+    [Fact]
+    public async Task transient_behaves_as_scoped()
+    {
+        await using var provider = ProviderFor(x => x.AddProjectionWithServices<GreetedProjection>(
+            ProjectionLifecycle.Inline, ServiceLifetime.Transient));
+
+        var store = await ReadyStoreAsync(provider);
+        var before = ScopeLedger.Created;
+
+        for (var i = 0; i < 2; i++)
+        {
+            await using var session = store.LightweightSession();
+            session.Events.StartStream<Greeted>(Guid.NewGuid(), new PersonNamed($"Person {i}"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (ScopeLedger.Created - before).ShouldBe(2);
+        ScopeLedger.Disposed.ShouldBe(ScopeLedger.Created);
+    }
+
+    /// <summary>
+    ///     A Singleton registration is the projection itself, with no wrapper — so it opens no scopes.
+    /// </summary>
+    [Fact]
+    public async Task a_singleton_projection_is_registered_directly()
+    {
+        await using var provider = ProviderFor(x => x.AddProjectionWithServices<SingletonGreetedProjection>(
+            ProjectionLifecycle.Inline, ServiceLifetime.Singleton));
+
+        var store = await ReadyStoreAsync(provider);
+
+        store.Options.Projections.All
+            .ShouldContain(x => ReferenceEquals(x, provider.GetRequiredService<SingletonGreetedProjection>()));
+
+        var id = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Greeted>(id, new PersonNamed("Bob"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<Greeted>(id, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Greeting.ShouldBe("Hi, Bob");
+    }
+
+    // ---------- the other projection kinds ----------
+
+    [Fact]
+    public async Task an_event_projection_can_take_services()
+    {
+        await using var provider = ProviderFor(x => x.AddProjectionWithServices<GreetingLogProjection>(
+            ProjectionLifecycle.Inline, ServiceLifetime.Scoped));
+
+        var store = await ReadyStoreAsync(provider);
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Greeted>(Guid.NewGuid(), new PersonNamed("Carol"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.QuerySession();
+        var entries = await query.Query<GreetingLogEntry>().ToListAsync(TestContext.Current.CancellationToken);
+
+        entries.Single().Text.ShouldBe("Hello, Carol");
+    }
+
+    [Fact]
+    public async Task a_multi_stream_projection_can_take_services()
+    {
+        await using var provider = ProviderFor(x => x.AddProjectionWithServices<GreetingRollupProjection>(
+            ProjectionLifecycle.Inline, ServiceLifetime.Scoped));
+
+        var store = await ReadyStoreAsync(provider);
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Greeted>(Guid.NewGuid(), new PersonNamed("Dave"));
+            session.Events.StartStream<Greeted>(Guid.NewGuid(), new PersonNamed("Erin"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.QuerySession();
+        var rollup = await query.LoadAsync<GreetingRollup>(GreetingRollup.OnlyId,
+            TestContext.Current.CancellationToken);
+
+        rollup.ShouldNotBeNull();
+        rollup.Count.ShouldBe(2);
+
+        // Through the injected service, so this is not a count the projection could have kept alone.
+        rollup.Last.ShouldBe("Hello, Erin");
+    }
+
+    // ---------- the async daemon, where a captured scope would be fatal ----------
+
+    [Fact]
+    public async Task a_scoped_projection_runs_under_the_async_daemon()
+    {
+        await using var provider = ProviderFor(x => x.AddProjectionWithServices<GreetedProjection>(
+            ProjectionLifecycle.Async, ServiceLifetime.Scoped));
+
+        var store = await ReadyStoreAsync(provider);
+        var id = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Greeted>(id, new PersonNamed("Frank"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(30));
+
+        await using (var query = store.QuerySession())
+        {
+            (await query.LoadAsync<Greeted>(id, TestContext.Current.CancellationToken))
+                .ShouldNotBeNull().Greeting.ShouldBe("Hello, Frank");
+        }
+
+        // A second batch, after the daemon has already run one — this is the shape that catches a
+        // provider captured on the first page.
+        var second = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Greeted>(second, new PersonNamed("Grace"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(30));
+
+        await using (var query = store.QuerySession())
+        {
+            (await query.LoadAsync<Greeted>(second, TestContext.Current.CancellationToken))
+                .ShouldNotBeNull().Greeting.ShouldBe("Hello, Grace");
+        }
+
+        await daemon.StopAllAsync();
+    }
+
+    // ---------- subscriptions ----------
+
+    [Fact]
+    public async Task a_scoped_subscription_runs_with_its_injected_service()
+    {
+        RecordingSubscription.Seen.Clear();
+
+        await using var provider = ProviderFor(x =>
+            x.AddSubscriptionWithServices<RecordingSubscription>(ServiceLifetime.Scoped));
+
+        var store = await ReadyStoreAsync(provider);
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Greeted>(Guid.NewGuid(), new PersonNamed("Heidi"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(30));
+        await daemon.StopAllAsync();
+
+        RecordingSubscription.Seen.ShouldContain("Hello, Heidi");
+    }
+
+    /// <summary>
+    ///     The wrapper carries the inner subscription's own name and options rather than dropping them.
+    /// </summary>
+    /// <remarks>
+    ///     marten#4318 over there: a subscription that set its batch size or its starting position in
+    ///     its constructor had those silently discarded on the Scoped path, because it is the wrapper
+    ///     the daemon reads them off, not the subscription.
+    /// </remarks>
+    [Fact]
+    public async Task a_scoped_subscription_keeps_its_own_name_and_options()
+    {
+        await using var provider = ProviderFor(x =>
+            x.AddSubscriptionWithServices<RecordingSubscription>(ServiceLifetime.Scoped));
+
+        var store = provider.GetRequiredService<DocumentStore>();
+
+        var source = store.Options.Projections.AllShards()
+            .Single(x => x.Name.Name == "recorder");
+
+        source.Options.BatchSize.ShouldBe(37);
+    }
+}
+
+#region Projections, subscriptions and the services they take
+
+/// <summary>
+///     Counts the IoC scopes a container-scoped registration opens, and the ones it closes.
+/// </summary>
+/// <remarks>
+///     Static because the thing being measured is the wrapper's behaviour over the life of a store, and
+///     the wrapper is handed the root provider — there is no per-test instance for it to be given.
+///     <c>InitializeAsync</c> resets it, and the suite's facts do not run concurrently within a class.
+/// </remarks>
+public static class ScopeLedger
+{
+    private static int _created;
+    private static int _disposed;
+
+    public static int Created => Volatile.Read(ref _created);
+    public static int Disposed => Volatile.Read(ref _disposed);
+
+    public static void Reset()
+    {
+        Volatile.Write(ref _created, 0);
+        Volatile.Write(ref _disposed, 0);
+    }
+
+    public static void Opened() => Interlocked.Increment(ref _created);
+    public static void Closed() => Interlocked.Increment(ref _disposed);
+}
+
+/// <summary>
+///     The injected service. Scoped and disposable, so it records both halves of a scope's life.
+/// </summary>
+public class GreetingSource : IDisposable
+{
+    public GreetingSource() => ScopeLedger.Opened();
+
+    public string Greet(string name) => $"Hello, {name}";
+
+    public void Dispose() => ScopeLedger.Closed();
+}
+
+public record PersonNamed(string Name);
+
+public class Greeted
+{
+    public Guid Id { get; set; }
+    public string Greeting { get; set; } = string.Empty;
+}
+
+/// <summary>
+///     A single stream projection that cannot be constructed without the container.
+/// </summary>
+public partial class GreetedProjection : SingleStreamProjection<Greeted, Guid>
+{
+    private readonly GreetingSource _greetings;
+
+    public GreetedProjection(GreetingSource greetings) => _greetings = greetings;
+
+    public Greeted Create(IEvent<PersonNamed> e) =>
+        new() { Id = e.StreamId, Greeting = _greetings.Greet(e.Data.Name) };
+}
+
+/// <summary>
+///     The same shape with a different greeting, so the Singleton fact reads a value only this type
+///     produces.
+/// </summary>
+public partial class SingletonGreetedProjection : SingleStreamProjection<Greeted, Guid>
+{
+    public Greeted Create(IEvent<PersonNamed> e) =>
+        new() { Id = e.StreamId, Greeting = $"Hi, {e.Data.Name}" };
+}
+
+public class GreetingLogEntry
+{
+    public Guid Id { get; set; }
+    public string Text { get; set; } = string.Empty;
+}
+
+public partial class GreetingLogProjection : EventProjection
+{
+    private readonly GreetingSource _greetings;
+
+    public GreetingLogProjection(GreetingSource greetings) => _greetings = greetings;
+
+    public GreetingLogEntry Create(IEvent<PersonNamed> e) =>
+        new() { Id = e.Id, Text = _greetings.Greet(e.Data.Name) };
+}
+
+public class GreetingRollup
+{
+    public static readonly Guid OnlyId = new("a0f6d4c1-7b2e-4f0a-9c8d-5e1b3a2f6c47");
+
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+    public string Last { get; set; } = string.Empty;
+}
+
+public partial class GreetingRollupProjection : MultiStreamProjection<GreetingRollup, Guid>
+{
+    private readonly GreetingSource _greetings;
+
+    public GreetingRollupProjection(GreetingSource greetings)
+    {
+        _greetings = greetings;
+        Identity<PersonNamed>(_ => GreetingRollup.OnlyId);
+    }
+
+    public void Apply(PersonNamed e, GreetingRollup rollup)
+    {
+        rollup.Count++;
+        rollup.Last = _greetings.Greet(e.Name);
+    }
+}
+
+/// <summary>
+///     A subscription that needs the container, and sets its own options in its constructor.
+/// </summary>
+public class RecordingSubscription : SubscriptionBase
+{
+    public static readonly List<string> Seen = [];
+
+    private readonly GreetingSource _greetings;
+
+    public RecordingSubscription(GreetingSource greetings)
+    {
+        _greetings = greetings;
+        Name = "recorder";
+        Options.BatchSize = 37;
+    }
+
+    public override Task<IDaemonChangeListener> ProcessEventsAsync(EventRange page,
+        ISubscriptionController controller, IDocumentSession operations, CancellationToken cancellationToken)
+    {
+        foreach (var e in page.Events.Select(x => x.Data).OfType<PersonNamed>())
+        {
+            lock (Seen)
+            {
+                Seen.Add(_greetings.Greet(e.Name));
+            }
+        }
+
+        return Task.FromResult<IDaemonChangeListener>(NullDaemonChangeListener.Instance);
+    }
+}
+
+#endregion

--- a/src/Fisher/FisherServiceCollectionExtensions.cs
+++ b/src/Fisher/FisherServiceCollectionExtensions.cs
@@ -1,8 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
 using Fisher.Internal;
+using Fisher.Projections;
 using JasperFx;
 using JasperFx.Descriptors;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Subscriptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -263,6 +266,155 @@ public static class FisherServiceCollectionExtensions
     }
 
     /// <summary>
+    ///     Register a projection that is built by the application's IoC container, so it can take
+    ///     injected services (fisher#194).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>What <paramref name="lifetime" /> buys, and what it costs.</b>
+    ///         <see cref="ServiceLifetime.Singleton" /> resolves the projection once and registers it
+    ///         directly — the cheapest option, and correct for a projection whose dependencies are all
+    ///         singletons themselves. <see cref="ServiceLifetime.Scoped" /> and
+    ///         <see cref="ServiceLifetime.Transient" /> both wrap it, and the wrapper opens a fresh IoC
+    ///         scope per unit of work — per <c>SaveChangesAsync</c> for an Inline projection, per daemon
+    ///         page for an Async one — resolves the projection inside that scope and lets go of it
+    ///         before the scope closes.
+    ///     </para>
+    ///     <para>
+    ///         <b>That per-batch scope is the whole reason this is not just <c>AddSingleton</c>.</b> An
+    ///         async projection outlives every request scope in the process; it runs from a hosted
+    ///         service where there is no request at all. A projection resolved once from a scope and
+    ///         held would be reaching into a disposed provider by its second batch, and one that opened
+    ///         a scope and kept it would leak that scope for the life of the store. The wrapper does
+    ///         neither, which is also why Transient and Scoped behave identically here.
+    ///     </para>
+    ///     <para>
+    ///         The wrappers themselves are JasperFx's — <c>JasperFx.Events.Projections.ContainerScoped</c>,
+    ///         shared with Marten — so what Fisher supplies is this registration surface and the
+    ///         <see cref="IFisherRegistrable" /> dispatch that picks the right wrapper for the kind of
+    ///         projection being registered.
+    ///     </para>
+    /// </remarks>
+    /// <param name="lifecycle">Fisher's projection lifecycle — Inline, Async or Live.</param>
+    /// <param name="lifetime">The IoC lifetime of the projection instance.</param>
+    /// <param name="configure">Optional configuration of the projection's name, version and filtering.</param>
+    /// <typeparam name="TProjection">
+    ///     The projection class. Deriving from <see cref="SingleStreamProjection{TDoc,TId}" />,
+    ///     <see cref="MultiStreamProjection{TDoc,TId}" /> or <see cref="EventProjection" />, or
+    ///     implementing <see cref="IProjection" />, is what satisfies the constraint.
+    /// </typeparam>
+    public static IServiceCollection AddProjectionWithServices<TProjection>(
+        this IServiceCollection services,
+        ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime = ServiceLifetime.Scoped,
+        Action<ProjectionBase>? configure = null)
+        where TProjection : class, IFisherRegistrable
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        TProjection.Register<TProjection>(services, lifecycle, lifetime, configure);
+        return services;
+    }
+
+    /// <summary>
+    ///     The same, against the secondary store registered as <typeparamref name="TStore" />.
+    /// </summary>
+    /// <inheritdoc cref="AddProjectionWithServices{TProjection}" />
+    public static IServiceCollection AddProjectionWithServices<TProjection, TStore>(
+        this IServiceCollection services,
+        ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime = ServiceLifetime.Scoped,
+        Action<ProjectionBase>? configure = null)
+        where TProjection : class, IFisherRegistrable
+        where TStore : class, IDocumentStore
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        TProjection.Register<TProjection, TStore>(services, lifecycle, lifetime, configure);
+        return services;
+    }
+
+    /// <summary>
+    ///     Register a subscription that is built by the application's IoC container (fisher#194).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A subscription is always asynchronous, so there is no lifecycle argument — only the IoC
+    ///         lifetime, which behaves exactly as it does for a projection: Singleton registers the
+    ///         resolved instance, while Scoped and Transient both go through a wrapper that opens a
+    ///         fresh scope per page of events and disposes it before the daemon commits the page's
+    ///         progress.
+    ///     </para>
+    ///     <para>
+    ///         This one needs a Fisher wrapper where the projection half needed none — see
+    ///         <c>ScopedSubscriptionWrapper</c> for why the shared library's equivalent is unreachable.
+    ///     </para>
+    /// </remarks>
+    public static IServiceCollection AddSubscriptionWithServices<TSubscription>(
+        this IServiceCollection services,
+        ServiceLifetime lifetime = ServiceLifetime.Scoped,
+        Action<ISubscriptionOptions>? configure = null)
+        where TSubscription : class, Subscriptions.ISubscription
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        RegisterSubscription<TSubscription>(services, lifetime,
+            (s, callback) => s.ConfigureFisher(callback), configure);
+
+        return services;
+    }
+
+    /// <summary>
+    ///     The same, against the secondary store registered as <typeparamref name="TStore" />.
+    /// </summary>
+    /// <inheritdoc cref="AddSubscriptionWithServices{TSubscription}" />
+    public static IServiceCollection AddSubscriptionWithServices<TSubscription, TStore>(
+        this IServiceCollection services,
+        ServiceLifetime lifetime = ServiceLifetime.Scoped,
+        Action<ISubscriptionOptions>? configure = null)
+        where TSubscription : class, Subscriptions.ISubscription
+        where TStore : class, IDocumentStore
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        RegisterSubscription<TSubscription>(services, lifetime,
+            (s, callback) => s.ConfigureFisher<TStore>(callback), configure);
+
+        return services;
+    }
+
+    private static void RegisterSubscription<TSubscription>(IServiceCollection services, ServiceLifetime lifetime,
+        Action<IServiceCollection, Action<IServiceProvider, StoreOptions>> configureStore,
+        Action<ISubscriptionOptions>? configure)
+        where TSubscription : class, Subscriptions.ISubscription
+    {
+        switch (lifetime)
+        {
+            case ServiceLifetime.Singleton:
+                services.AddSingleton<TSubscription>();
+                configureStore(services, (s, options) =>
+                    options.Projections.Subscribe(s.GetRequiredService<TSubscription>(), configure));
+                break;
+
+            case ServiceLifetime.Scoped:
+            case ServiceLifetime.Transient:
+                services.AddScoped<TSubscription>();
+                configureStore(services, (s, options) =>
+                {
+                    var wrapper = new Subscriptions.ScopedSubscriptionWrapper<TSubscription>(s);
+                    configure?.Invoke(wrapper);
+
+                    options.Projections.Subscribe(wrapper);
+                });
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime,
+                    "Only Singleton, Scoped and Transient are meaningful for a subscription.");
+        }
+    }
+
+    /// <summary>
     ///     Apply every matching <see cref="IConfigureFisher" /> to a store's options.
     /// </summary>
     /// <remarks>
@@ -513,6 +665,30 @@ public sealed class FisherStoreConfigurationExpression<T> where T : class, IDocu
 
         return this;
     }
+
+    /// <inheritdoc cref="FisherServiceCollectionExtensions.AddProjectionWithServices{TProjection,TStore}" />
+    public FisherStoreConfigurationExpression<T> AddProjectionWithServices<TProjection>(ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime = ServiceLifetime.Scoped, Action<ProjectionBase>? configure = null)
+        where TProjection : class, IFisherRegistrable
+    {
+        TProjection.Register<TProjection, T>(_services, lifecycle, lifetime, configure);
+        return this;
+    }
+
+    /// <inheritdoc cref="FisherServiceCollectionExtensions.AddProjectionWithServices{TProjection,TStore}" />
+    public FisherStoreConfigurationExpression<T> AddProjectionWithServices<TProjection>(ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, string projectionName)
+        where TProjection : class, IFisherRegistrable
+        => AddProjectionWithServices<TProjection>(lifecycle, lifetime, x => x.Name = projectionName);
+
+    /// <inheritdoc cref="FisherServiceCollectionExtensions.AddSubscriptionWithServices{TSubscription,TStore}" />
+    public FisherStoreConfigurationExpression<T> AddSubscriptionWithServices<TSubscription>(
+        ServiceLifetime lifetime = ServiceLifetime.Scoped, Action<ISubscriptionOptions>? configure = null)
+        where TSubscription : class, Subscriptions.ISubscription
+    {
+        _services.AddSubscriptionWithServices<TSubscription, T>(lifetime, configure);
+        return this;
+    }
 }
 
 /// <summary>
@@ -688,6 +864,30 @@ public sealed class FisherConfigurationExpression
                 break;
         }
 
+        return this;
+    }
+
+    /// <inheritdoc cref="FisherServiceCollectionExtensions.AddProjectionWithServices{TProjection}" />
+    public FisherConfigurationExpression AddProjectionWithServices<TProjection>(ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime = ServiceLifetime.Scoped, Action<ProjectionBase>? configure = null)
+        where TProjection : class, IFisherRegistrable
+    {
+        TProjection.Register<TProjection>(_services, lifecycle, lifetime, configure);
+        return this;
+    }
+
+    /// <inheritdoc cref="FisherServiceCollectionExtensions.AddProjectionWithServices{TProjection}" />
+    public FisherConfigurationExpression AddProjectionWithServices<TProjection>(ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, string projectionName)
+        where TProjection : class, IFisherRegistrable
+        => AddProjectionWithServices<TProjection>(lifecycle, lifetime, x => x.Name = projectionName);
+
+    /// <inheritdoc cref="FisherServiceCollectionExtensions.AddSubscriptionWithServices{TSubscription}" />
+    public FisherConfigurationExpression AddSubscriptionWithServices<TSubscription>(
+        ServiceLifetime lifetime = ServiceLifetime.Scoped, Action<ISubscriptionOptions>? configure = null)
+        where TSubscription : class, Subscriptions.ISubscription
+    {
+        _services.AddSubscriptionWithServices<TSubscription>(lifetime, configure);
         return this;
     }
 }

--- a/src/Fisher/Projections/ContainerScopedRegistration.cs
+++ b/src/Fisher/Projections/ContainerScopedRegistration.cs
@@ -1,0 +1,166 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Core.Reflection;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Projections.ContainerScoped;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Fisher.Projections;
+
+/// <summary>
+///     The one implementation of "register this projection through the container" that every
+///     <see cref="IFisherRegistrable" /> implementation routes through (fisher#194).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Scope lifetime is the whole design, and it is settled by the shared wrappers rather than
+///         by Fisher.</b> A projection lives as long as the store; an async projection outlives every
+///         request scope in the process by construction, since the daemon is a hosted service with no
+///         request at all. So a container-scoped projection cannot be resolved once and held — the
+///         service graph behind it would be resolved from a scope that is disposed long before the
+///         daemon's next batch, and the first scoped dependency touched would throw
+///         <c>ObjectDisposedException</c>. Nor can the wrapper open a scope and keep it: that leaks one
+///         scope, and everything in it, per registration for the life of the process.
+///     </para>
+///     <para>
+///         The shared <c>ContainerScoped</c> wrappers answer this by opening and disposing an
+///         <see cref="IServiceScope" /> <em>per unit of work</em> — one per inline
+///         <c>ApplyAsync</c> (so per <c>SaveChangesAsync</c>), one per daemon page, and one per slicing
+///         pass — resolving the projection inside it and letting go of it before the scope closes.
+///         Nothing is captured across a batch boundary, so nothing can be resolved from a disposed
+///         provider and nothing accumulates. That is also why <see cref="ServiceLifetime.Transient" />
+///         is treated as <see cref="ServiceLifetime.Scoped" /> below rather than refused: the wrapper
+///         resolves afresh per batch either way, so the two lifetimes describe the same behaviour and
+///         a transient registration would only differ in disposing later.
+///     </para>
+///     <para>
+///         <b>The provider the scopes come from is the root provider</b>, which is what
+///         <c>IConfigureFisher</c> hands the callback and what the store is built from. A scope created
+///         from a scoped provider would be a child of something that gets disposed; a scope created
+///         from the root is not.
+///     </para>
+///     <para>
+///         <b>Both paths land on Fisher's own <c>Add(ProjectionBase, lifecycle)</c></b> rather than the
+///         base graph's <c>Add(IProjectionSource, ...)</c> that Marten's equivalent calls. That
+///         overload is what sweeps <c>PublishedTypes()</c> into the schema, so a container-scoped
+///         projection's document table is created with the rest of the schema exactly as a directly
+///         registered one's is. Going through the narrower overload would leave the projection working
+///         against a table that was never migrated — the silent half of fisher#111.
+///     </para>
+/// </remarks>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes CloseAndBuildAs, which reflects over a constructed generic "
+                    + "type. The projection type flows in from the caller's own "
+                    + "AddProjectionWithServices<T> registration and is preserved by the trimmer at that "
+                    + "boundary — the same reasoning JasperFx's own container-scoped wrappers carry.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: TConcrete is the caller's own projection type, registered into the "
+                    + "container by the caller, so its constructors are preserved at that boundary.")]
+internal static class ContainerScopedRegistration
+{
+    /// <summary>
+    ///     Register a projection resolved from the container, against whichever store
+    ///     <paramref name="configureStore" /> targets.
+    /// </summary>
+    /// <param name="services">The application's services.</param>
+    /// <param name="lifecycle">Fisher's projection lifecycle — Inline, Async or Live.</param>
+    /// <param name="lifetime">The IoC lifetime. Transient is treated as Scoped; see the remarks.</param>
+    /// <param name="configure">Optional configuration of the projection's name, version and filtering.</param>
+    /// <param name="configureStore">
+    ///     How to contribute to the target store's options — <c>ConfigureFisher</c> for the primary
+    ///     store, <c>ConfigureFisher&lt;TStore&gt;</c> for a secondary one. Passed as a delegate so the
+    ///     two differ in one line rather than in a duplicated body.
+    /// </param>
+    /// <param name="buildScopedWrapper">
+    ///     Builds the container-scoped wrapper for this <em>kind</em> of projection, which only the
+    ///     projection's own base class knows — an aggregation wrapper needs the document and identity
+    ///     types, a plain projection wrapper does not.
+    /// </param>
+    internal static void Register<TConcrete>(
+        IServiceCollection services,
+        ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime,
+        Action<ProjectionBase>? configure,
+        Action<IServiceCollection, Action<IServiceProvider, StoreOptions>> configureStore,
+        Func<IServiceProvider, ProjectionBase> buildScopedWrapper)
+        where TConcrete : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        switch (lifetime)
+        {
+            case ServiceLifetime.Singleton:
+                // A singleton projection has no scope problem to solve, so it is registered as itself
+                // and no wrapper is involved at all. The container still builds it, which is the point
+                // — its constructor dependencies are resolved rather than absent.
+                services.AddSingleton<TConcrete>();
+                configureStore(services, (s, options) =>
+                {
+                    var projection = s.GetRequiredService<TConcrete>();
+
+                    // A bare IProjection is not a ProjectionBase and carries none of the name, version
+                    // or filtering surface `configure` writes to, so it is wrapped here rather than at
+                    // the graph — which is where the non-DI Add(ProjectionBase, ...) would otherwise do
+                    // it, too late for the lambda to reach.
+                    var projectionBase = projection as ProjectionBase
+                                         ?? (projection is IProjection bare
+                                             ? new ProjectionWrapper<IDocumentSession, IQuerySession>(bare, lifecycle)
+                                             : throw new InvalidOperationException(
+                                                 $"'{typeof(TConcrete).FullNameInCode()}' is registered with "
+                                                 + "AddProjectionWithServices but is neither a projection base "
+                                                 + "class nor a Fisher.Projections.IProjection, so there is "
+                                                 + "nothing for the store to run."));
+
+                    configure?.Invoke(projectionBase);
+                    options.Projections.Add(projectionBase, lifecycle);
+                });
+                break;
+
+            case ServiceLifetime.Scoped:
+            case ServiceLifetime.Transient:
+                services.AddScoped<TConcrete>();
+                configureStore(services, (s, options) =>
+                {
+                    var wrapper = buildScopedWrapper(s);
+
+                    // Before configure, so a caller's lambda can override what the wrapper copied off
+                    // the projection it wraps rather than being overwritten by it.
+                    wrapper.Lifecycle = lifecycle;
+                    configure?.Invoke(wrapper);
+
+                    options.Projections.Add(wrapper, lifecycle);
+                });
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime,
+                    "Only Singleton, Scoped and Transient are meaningful for a projection.");
+        }
+    }
+
+    /// <summary>
+    ///     The scoped wrapper for an aggregation projection — single stream or multi stream.
+    /// </summary>
+    /// <remarks>
+    ///     Through the shared non-generic factory rather than by closing a wrapper type directly, so a
+    ///     single stream projection registered Scoped keeps its
+    ///     <c>IAggregatorSource</c> and stays usable from live aggregation and single stream rebuilds.
+    ///     See marten#5095, which is where that distinction was found.
+    /// </remarks>
+    internal static Func<IServiceProvider, ProjectionBase> Aggregation(Type concreteType, Type documentType,
+        Type identityType)
+        => s => ScopedAggregationWrapper.Build(s, concreteType, documentType, identityType,
+            typeof(IDocumentSession), typeof(IQuerySession));
+
+    /// <summary>
+    ///     The scoped wrapper for a projection that is not an aggregation — an
+    ///     <see cref="EventProjection" /> or a bare <see cref="IProjection" />.
+    /// </summary>
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Closes ScopedProjectionWrapper<,,> over the projection type and Fisher's session "
+                        + "pair through MakeGenericType. The projection type flows in from the caller's own "
+                        + "AddProjectionWithServices<T> registration and is preserved at that boundary — the "
+                        + "same reasoning JasperFx's own ScopedAggregationWrapper.Build carries.")]
+    internal static Func<IServiceProvider, ProjectionBase> Plain(Type concreteType)
+        => s => typeof(ScopedProjectionWrapper<,,>).CloseAndBuildAs<ProjectionBase>(s, concreteType,
+            typeof(IDocumentSession), typeof(IQuerySession));
+}

--- a/src/Fisher/Projections/EventProjection.cs
+++ b/src/Fisher/Projections/EventProjection.cs
@@ -1,4 +1,5 @@
 using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Fisher.Projections;
 
@@ -24,7 +25,22 @@ namespace Fisher.Projections;
 ///         their suite's generic parameters.
 ///     </para>
 /// </remarks>
-public abstract class EventProjection : JasperFxEventProjectionBase<IDocumentSession, IQuerySession>
+public abstract class EventProjection : JasperFxEventProjectionBase<IDocumentSession, IQuerySession>, IFisherRegistrable
 {
     protected sealed override void storeEntity<T>(IDocumentSession ops, T entity) => ops.Store(entity);
+
+    /// <inheritdoc />
+    public static void Register<TConcrete>(IServiceCollection services, ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, Action<ProjectionBase>? configure) where TConcrete : class
+        => ContainerScopedRegistration.Register<TConcrete>(services, lifecycle, lifetime, configure,
+            static (s, callback) => s.ConfigureFisher(callback),
+            ContainerScopedRegistration.Plain(typeof(TConcrete)));
+
+    /// <inheritdoc />
+    public static void Register<TConcrete, TStore>(IServiceCollection services, ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, Action<ProjectionBase>? configure)
+        where TStore : class, IDocumentStore where TConcrete : class
+        => ContainerScopedRegistration.Register<TConcrete>(services, lifecycle, lifetime, configure,
+            static (s, callback) => s.ConfigureFisher<TStore>(callback),
+            ContainerScopedRegistration.Plain(typeof(TConcrete)));
 }

--- a/src/Fisher/Projections/IFisherRegistrable.cs
+++ b/src/Fisher/Projections/IFisherRegistrable.cs
@@ -1,0 +1,43 @@
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Fisher.Projections;
+
+/// <summary>
+///     A projection type that knows how to register <em>itself</em> into an IoC container, so it can be
+///     resolved from the application's services rather than constructed by Fisher (fisher#194).
+/// </summary>
+/// <remarks>
+///     <para>
+///         The same static-abstract shape as Marten's <c>IMartenRegistrable</c>, and for the same
+///         reason: which container-scoped wrapper a projection needs depends on what <em>kind</em> of
+///         projection it is — an aggregation wrapper knows the document and identity types, a plain
+///         projection wrapper does not — and the projection base class is the only place that knows
+///         which it is. A static abstract member lets <c>AddProjectionWithServices&lt;T&gt;</c> dispatch
+///         to the right one from a bare type parameter, with no reflection over base types at the call
+///         site.
+///     </para>
+///     <para>
+///         <b>Fisher implements this interface and supplies nothing else.</b> Every wrapper the
+///         implementations reach for lives in <c>JasperFx.Events.Projections.ContainerScoped</c> and is
+///         already generic over the store's operations and query session types, so closing them over
+///         <see cref="IDocumentSession" /> and <see cref="IQuerySession" /> is the whole of Fisher's
+///         container-scoped projection support.
+///     </para>
+/// </remarks>
+public interface IFisherRegistrable
+{
+    /// <summary>
+    ///     Register <typeparamref name="TConcrete" /> against the primary store.
+    /// </summary>
+    static abstract void Register<TConcrete>(IServiceCollection services, ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, Action<ProjectionBase>? configure) where TConcrete : class;
+
+    /// <summary>
+    ///     Register <typeparamref name="TConcrete" /> against the secondary store
+    ///     <typeparamref name="TStore" />.
+    /// </summary>
+    static abstract void Register<TConcrete, TStore>(IServiceCollection services, ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, Action<ProjectionBase>? configure)
+        where TStore : class, IDocumentStore where TConcrete : class;
+}

--- a/src/Fisher/Projections/IProjection.cs
+++ b/src/Fisher/Projections/IProjection.cs
@@ -1,4 +1,5 @@
 using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Fisher.Projections;
 
@@ -6,6 +7,26 @@ namespace Fisher.Projections;
 ///     Marker for a Fisher projection, closing JasperFx's <see cref="IJasperFxProjection{TOperations}" />
 ///     over Fisher's write session. Mirrors Marten's and Polecat's <c>IProjection</c>.
 /// </summary>
-public interface IProjection : IJasperFxProjection<IDocumentSession>
+public interface IProjection : IJasperFxProjection<IDocumentSession>, IFisherRegistrable
 {
+    /// <summary>
+    ///     Register an implementation of this interface through the container (fisher#194).
+    /// </summary>
+    /// <remarks>
+    ///     Explicit implementations, so an implementing class carries no visible static surface it did
+    ///     not write — the registration is reached through the type parameter on
+    ///     <c>AddProjectionWithServices&lt;T&gt;</c>, which is the only caller.
+    /// </remarks>
+    static void IFisherRegistrable.Register<TConcrete>(IServiceCollection services, ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, Action<ProjectionBase>? configure)
+        => ContainerScopedRegistration.Register<TConcrete>(services, lifecycle, lifetime, configure,
+            static (s, callback) => s.ConfigureFisher(callback),
+            ContainerScopedRegistration.Plain(typeof(TConcrete)));
+
+    /// <inheritdoc cref="Register{TConcrete}" />
+    static void IFisherRegistrable.Register<TConcrete, TStore>(IServiceCollection services,
+        ProjectionLifecycle lifecycle, ServiceLifetime lifetime, Action<ProjectionBase>? configure)
+        => ContainerScopedRegistration.Register<TConcrete>(services, lifecycle, lifetime, configure,
+            static (s, callback) => s.ConfigureFisher<TStore>(callback),
+            ContainerScopedRegistration.Plain(typeof(TConcrete)));
 }

--- a/src/Fisher/Projections/MultiStreamProjection.cs
+++ b/src/Fisher/Projections/MultiStreamProjection.cs
@@ -1,4 +1,6 @@
 using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Fisher.Projections;
 
@@ -24,8 +26,22 @@ namespace Fisher.Projections;
 /// <typeparam name="TDoc">The aggregate document type.</typeparam>
 /// <typeparam name="TId">The identity events are grouped by, which need not be the stream identity.</typeparam>
 public abstract class MultiStreamProjection<TDoc, TId>
-    : JasperFxMultiStreamProjectionBase<TDoc, TId, IDocumentSession, IQuerySession>
+    : JasperFxMultiStreamProjectionBase<TDoc, TId, IDocumentSession, IQuerySession>, IFisherRegistrable
     where TDoc : notnull
     where TId : notnull
 {
+    /// <inheritdoc />
+    public static void Register<TConcrete>(IServiceCollection services, ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, Action<ProjectionBase>? configure) where TConcrete : class
+        => ContainerScopedRegistration.Register<TConcrete>(services, lifecycle, lifetime, configure,
+            static (s, callback) => s.ConfigureFisher(callback),
+            ContainerScopedRegistration.Aggregation(typeof(TConcrete), typeof(TDoc), typeof(TId)));
+
+    /// <inheritdoc />
+    public static void Register<TConcrete, TStore>(IServiceCollection services, ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, Action<ProjectionBase>? configure)
+        where TStore : class, IDocumentStore where TConcrete : class
+        => ContainerScopedRegistration.Register<TConcrete>(services, lifecycle, lifetime, configure,
+            static (s, callback) => s.ConfigureFisher<TStore>(callback),
+            ContainerScopedRegistration.Aggregation(typeof(TConcrete), typeof(TDoc), typeof(TId)));
 }

--- a/src/Fisher/Projections/SingleStreamProjection.cs
+++ b/src/Fisher/Projections/SingleStreamProjection.cs
@@ -1,4 +1,6 @@
 using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Fisher.Projections;
 
@@ -22,8 +24,22 @@ namespace Fisher.Projections;
 /// <typeparam name="TDoc">The aggregate document type.</typeparam>
 /// <typeparam name="TId">The aggregate's identity type, which must match the stream identity.</typeparam>
 public class SingleStreamProjection<TDoc, TId>
-    : JasperFxSingleStreamProjectionBase<TDoc, TId, IDocumentSession, IQuerySession>
+    : JasperFxSingleStreamProjectionBase<TDoc, TId, IDocumentSession, IQuerySession>, IFisherRegistrable
     where TDoc : notnull
     where TId : notnull
 {
+    /// <inheritdoc />
+    public static void Register<TConcrete>(IServiceCollection services, ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, Action<ProjectionBase>? configure) where TConcrete : class
+        => ContainerScopedRegistration.Register<TConcrete>(services, lifecycle, lifetime, configure,
+            static (s, callback) => s.ConfigureFisher(callback),
+            ContainerScopedRegistration.Aggregation(typeof(TConcrete), typeof(TDoc), typeof(TId)));
+
+    /// <inheritdoc />
+    public static void Register<TConcrete, TStore>(IServiceCollection services, ProjectionLifecycle lifecycle,
+        ServiceLifetime lifetime, Action<ProjectionBase>? configure)
+        where TStore : class, IDocumentStore where TConcrete : class
+        => ContainerScopedRegistration.Register<TConcrete>(services, lifecycle, lifetime, configure,
+            static (s, callback) => s.ConfigureFisher<TStore>(callback),
+            ContainerScopedRegistration.Aggregation(typeof(TConcrete), typeof(TDoc), typeof(TId)));
 }

--- a/src/Fisher/Subscriptions/ScopedSubscriptionWrapper.cs
+++ b/src/Fisher/Subscriptions/ScopedSubscriptionWrapper.cs
@@ -1,0 +1,97 @@
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Fisher.Subscriptions;
+
+/// <summary>
+///     Presents a container-resolved <see cref="ISubscription" /> to the daemon, opening a fresh IoC
+///     scope for each page of events (fisher#194).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Fisher writes this one rather than reusing a shared wrapper, and that is a gap rather
+///         than a choice.</b> <c>JasperFx.Events.Subscriptions</c> does carry a
+///         <c>ScopedSubscriptionServiceWrapper</c> generic over the store's session pair, but it is
+///         <c>internal</c> and nothing in the library references it, so no consumer can reach it —
+///         Marten carries its own copy for the same reason. The projection half of fisher#194 needed no
+///         such copy: every wrapper in <c>JasperFx.Events.Projections.ContainerScoped</c> is public and
+///         Fisher uses them unchanged.
+///     </para>
+///     <para>
+///         <b>The scope is per page, and nothing is held between pages.</b> A subscription shard runs
+///         for as long as the daemon does, which is longer than any scope in the process lives; the
+///         only way a scoped dependency can be valid when it is used is for the scope to be opened,
+///         used and disposed inside one <see cref="ProcessEventsAsync" /> call. That is the same
+///         boundary the shared projection wrappers use, and it is why <c>Transient</c> and
+///         <c>Scoped</c> register identically — the subscription is resolved afresh per page either
+///         way.
+///     </para>
+///     <para>
+///         The constructor's scope is separate and short: it exists only to read the inner
+///         subscription's own <c>Name</c>, <c>Version</c>, <c>Options</c> and event filtering, because
+///         it is <em>this wrapper</em> the daemon reads those from. Dropping them is how a scoped
+///         subscription silently loses a <c>SubscribeFromPresent()</c> or a batch size its constructor
+///         set — marten#4318, found the hard way over there.
+///     </para>
+/// </remarks>
+internal sealed class ScopedSubscriptionWrapper<T> : SubscriptionBase where T : ISubscription
+{
+    private readonly IServiceProvider _provider;
+
+    internal ScopedSubscriptionWrapper(IServiceProvider provider)
+    {
+        _provider = provider;
+        Name = typeof(T).Name;
+
+        var scope = _provider.CreateScope();
+        try
+        {
+            if (scope.ServiceProvider.GetRequiredService<T>() is SubscriptionBase inner)
+            {
+                IncludedEventTypes.AddRange(inner.IncludedEventTypes);
+                StreamType = inner.StreamType;
+                IncludeArchivedEvents = inner.IncludeArchivedEvents;
+
+                Options = inner.Options;
+                Name = inner.Name;
+                Version = inner.Version;
+            }
+        }
+        finally
+        {
+            scope.SafeDispose();
+        }
+    }
+
+    public override async Task<IDaemonChangeListener> ProcessEventsAsync(EventRange page,
+        ISubscriptionController controller, IDocumentSession operations, CancellationToken cancellationToken)
+    {
+        var scope = _provider.CreateScope();
+
+        try
+        {
+            var subscription = scope.ServiceProvider.GetRequiredService<T>();
+
+            return await subscription
+                .ProcessEventsAsync(page, controller, operations, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            // Awaited rather than fire-and-forget when the scope is async-disposable, because a scoped
+            // dependency's DisposeAsync may well be the thing that flushes whatever the subscription
+            // did — and the daemon commits the batch's progress the moment this returns.
+            if (scope is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                scope.SafeDispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #194.

`AddProjectionWithServices<T>(lifecycle, lifetime)` and `AddSubscriptionWithServices<T>(lifetime)`, on `FisherConfigurationExpression`, on `FisherStoreConfigurationExpression<T>` for a secondary store, and as bare `IServiceCollection` extensions so a module in a modular monolith can register its own projections long after `AddFisher` was consumed at the composition root. `IFisherRegistrable` is the static-abstract dispatch, mirroring `IMartenRegistrable` — which container-scoped wrapper a projection needs depends on what *kind* of projection it is, and only its base class knows.

## The scope-lifetime decision, and why it is the shared one

**A fresh `IServiceScope` per unit of work: one per inline `SaveChangesAsync`, one per daemon page, one per slicing pass. Nothing is held across a batch boundary.**

An async projection outlives every request scope in the process by construction — it runs from a hosted service where there is no request at all, for as long as the store lives. Two ways to get this wrong, and both are the failure modes the issue named:

- **Resolve once and hold.** The service graph behind the projection came from a scope disposed long before the daemon's next batch, so the first scoped dependency touched throws `ObjectDisposedException`. This passes every correctness test written against a single commit.
- **Open a scope and keep it.** One leaked scope, and everything in it, per registration for the life of the process.

**Fisher does not decide this — `JasperFx.Events.Projections.ContainerScoped` already had**, and adopting it rather than writing a wrapper is the answer to "check what is already shared". `ScopedProjectionWrapper<,,>`, `ScopedAggregationWrapper<,,,,>` / `ScopedSingleStreamAggregationWrapper<,,,,>` and the non-generic `ScopedAggregationWrapper.Build(...)` factory are all public and already generic over the store's operations and query session types, so Fisher closes them over `IDocumentSession` / `IQuerySession` and supplies **no projection wrapper of its own**. The scopes come from the root provider — what `IConfigureFisher` hands the callback and what the store is built from — because a scope created from a scoped provider is a child of something that gets disposed.

That is also why `ServiceLifetime.Transient` is treated as `Scoped` rather than refused: the wrapper resolves afresh per batch either way, so the two lifetimes describe the same behaviour.

**Polecat has no equivalent surface**, so Fisher is the second store to have this rather than the third.

## Two places Fisher does something of its own

**Both registration paths land on Fisher's `Add(ProjectionBase, lifecycle)`, where Marten's equivalent calls the base graph's narrower `Add(IProjectionSource, ...)`.** That overload is what sweeps `PublishedTypes()` into the schema, so a container-scoped projection's document table is created with the rest of the migration. Through the narrower one the projection would work against a table that was never migrated — the silent half of #111, reached from a new direction. `the_projected_document_type_is_mapped_into_the_schema` pins it.

**The subscription wrapper is written here, and that is a gap rather than a choice.** `JasperFx.Events.Subscriptions.ScopedSubscriptionServiceWrapper` exists and is generic over the session pair, but it is `internal` with nothing in the library referencing it — so no consumer can reach it, and Marten carries its own copy for the same reason. `Subscriptions/ScopedSubscriptionWrapper.cs` copies the inner subscription's `Name`, `Version`, `Options` and event filtering across at construction, because it is the *wrapper* the daemon reads those from; dropping them is how a scoped subscription silently loses a batch size or a `SubscribeFromPresent()` its constructor set (marten#4318).

A `Singleton` registration is the projection itself with no wrapper, which is correct whenever its dependencies are singletons too. A bare `IProjection` is wrapped in `ProjectionWrapper` at registration rather than at the graph, so the caller's `configure` lambda can reach the name and filtering surface a raw `IProjection` does not have.

## Tests

`container_scoped_projections`, 12 facts. **The load-bearing ones count scopes, not results** — a projection that merely works passes every assertion written against a single commit and then fails on the second daemon batch:

- `a_scoped_projection_gets_one_scope_per_unit_of_work` counts creations **and** disposals, so a wrapper that opened a scope per batch and kept it passes the first half and leaks.
- `a_scoped_projection_runs_under_the_async_daemon` deliberately commits a second batch after the daemon has already run one, which is the shape that catches a captured provider.
- `transient_behaves_as_scoped` pins the equivalence rather than leaving it implied.

Plus the round trip through an injected service on all three projection kinds, the schema mapping above, the singleton path, and a subscription keeping its own name and options.

## Validation

Full `Fisher.Tests` on both TFMs, plus both companion suites, run locally in Release:

| | net9.0 | net10.0 |
|---|---|---|
| `Fisher.Tests` | 1712 passed, 17 skipped | 1712 passed, 17 skipped |
| `Fisher.AspNetCore.Tests` | 36 passed | 36 passed |
| `Fisher.EntityFrameworkCore.Tests` | 19 passed | 19 passed |

`scripts/check_scoreboard.py` reconciled from that run on both TFMs — 1772 → 1784 total, 1717 → 1729 in `Fisher.Tests`, in `HANDOFF.md` and `README.md`. No compliance suite moved; all 50 suites and 516 compliance tests still green.

Docs: `docs/events/projections/container-scoped.md`, in the sidebar under Projections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
