### PR TITLE
gh-195: measure the compiled-query question, and name the Marten gaps honestly

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1341,6 +1341,16 @@ run generated locators against genuinely stored documents:
 
 Each of these is a decision with a reason, not an oversight:
 
+> ⚠️ **This section is not the whole gap list, and the README no longer claims it is.** Everything
+> below is a *decision*; there is a separate set of Marten features that are simply **absent** —
+> `Include()`, full-text search, a session logging seam, `MatchesSql`, `Stats(out QueryStatistics)`,
+> `ToAsyncEnumerable()`, and child-collection LINQ only partly. They were missing from this section for
+> a structural reason worth knowing: **Fisher's parity baseline was drawn against Polecat**
+> (`polecat-gaps.md`), so a feature Marten has and Polecat does not never entered the tracking at all.
+> The Marten-facing list lives in `docs/migration-guide.md` under "Marten features Fisher does not
+> have" and is the one to keep current. Compiled queries are the one member of that set that *has* been
+> decided, on a measurement — [fisher#195](https://github.com/JasperFx/fisher/issues/195).
+
 - **Exclusive appends are the optimistic ones.** `AppendExclusive`, `FetchForExclusiveWriting` and
   `WriteExclusivelyToAggregate` do not lock. SQLite has no row lock; the faithful equivalent would
   hold `BEGIN IMMEDIATE` from fetch to commit, blocking every other writer for as long as a caller

--- a/README.md
+++ b/README.md
@@ -36,11 +36,18 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > lists them, which is also why Fisher is not a drop-in test double for a Marten or Polecat
 > application.
 >
-> 1.0 means the API is stable and the semantics above are settled — not that Fisher is
-> feature-complete against Marten. The gaps that remain are **decisions**, documented in
-> [HANDOFF.md](HANDOFF.md) rather than filed as issues.
+> 1.0 means the API is stable and the semantics above are settled — **not** that Fisher is
+> feature-complete against Marten. Several Marten features are genuinely missing, and until recently
+> they were missing from this list too: Fisher's parity baseline was drawn against *Polecat*, so
+> anything Marten has and Polecat does not was invisible to its tracking. `Include()`, compiled
+> queries, full-text search, a session logging seam, `MatchesSql`, `Stats(out QueryStatistics)` and
+> `ToAsyncEnumerable()` are all absent; child-collection LINQ is partly landed; and `CreateBatchQuery`
+> lives on `session.Events` rather than on the session. The
+> [migration guide](https://fisher.jasperfx.net/migration-guide#marten-features-fisher-does-not-have)
+> names each one, says what to use instead, and marks which are settled decisions rather than unbuilt
+> work.
 >
-> The one thing that is *not* there is deliberate and permanent: **no message bus.** The projection
+> One absence is deliberate and permanent rather than a gap: **no message bus.** The projection
 > side-effect seam exists and the default outbox drops every message, because delivery is a bus
 > integration's job here as it is on both siblings.
 

--- a/docs/documents/querying/linq/operators.md
+++ b/docs/documents/querying/linq/operators.md
@@ -199,3 +199,14 @@ rather than through a slow query:
 - Inside a collection predicate: outer-scope references, member access on scalar elements, and bare
   element comparisons — see [Collections](#collections)
 - A soft-delete or tenancy operator against a type that has no such column
+
+## Marten operators that are absent
+
+Not refused by name — these simply do not exist, so a ported file naming one will not compile:
+`Include()`, `MatchesSql(…)`, `Stats(out QueryStatistics)`, `ToAsyncEnumerable()`, and the full-text
+operators (`Search`, `PlainTextSearch`, `PhraseSearch`, `WebStyleSearch`, `NgramSearch`). Compiled
+queries (`ICompiledQuery<T>`) are absent too, on a
+[measurement](https://github.com/JasperFx/fisher/issues/195) rather than by omission.
+
+The [migration guide](/migration-guide#marten-features-fisher-does-not-have) lists each with what to
+use instead.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -44,7 +44,62 @@ opts.DatabaseSchemaName = "reporting";   // reporting_fi_doc_order, not reportin
 SQLite has no schemas. Nothing renders as qualified SQL, and the prefix is what isolates two logical
 stores in one file.
 
+## Marten features Fisher does not have
+
+These are absent rather than different, so a ported file naming one will not compile. They are listed
+here because **Fisher's parity work was measured against Polecat, not Marten** — a feature Marten has
+and Polecat does not was invisible to that tracking, which is exactly the set below and exactly the set
+a migrating Marten user hits first.
+
+| Marten | Status on Fisher | Instead |
+| :--- | :--- | :--- |
+| `Include()` / `Include<T>()` | **Absent.** No related-document loading of any kind. | A [join](/documents/querying/linq/joins) — `Join` and `GroupJoin(…).SelectMany(…)` across document tables, chained. Cheaper here than on either sibling, since a join between two document tables needs no `OPENJSON` and no lateral join. Or two queries; there is no round trip to save. |
+| Compiled queries — `ICompiledQuery<T>`, `ICompiledListQuery<T>`, `ICompiledQuery<TDoc,TOut>` | **Absent, and decided** — see [fisher#195](https://github.com/JasperFx/fisher/issues/195) for the measurement. | Nothing. Building the SQL is 4–11% of an ordinary Fisher query and 22.5% of the cheapest one it can run; the work is real but the absolute saving is ~2 µs. A filter-shape query plan cache would collect nearly all of it with no public API, which is the move that comes first. |
+| Full-text search — `Search`, `PlainTextSearch`, `PhraseSearch`, `WebStyleSearch`, `NgramSearch`, and full-text indexes | **Absent.** Nothing is built over SQLite's FTS5. | `Contains` / `StartsWith` / `EndsWith`, which are ordinal and case-sensitive (see below) and can be served by a [declared index](/documents/indexing/indexes). Not a substitute for ranked search. |
+| A session logging seam — `IMartenLogger` / `IMartenSessionLogger`, `StoreOptions.Logger(…)`, `session.Logger` | **Absent.** There is no per-command or per-session logging hook. | An `ActivitySource` named `Fisher` ([tracing](/diagnostics)), with spans for commits, queries and loads and a retry event that says a call waited on the write lock; and `IDocumentSessionListener` for bracketing the unit of work. Neither one gives you the SQL. |
+| `MatchesSql(…)` | **Absent.** No raw SQL composes into a `Where`. | `session.AdvancedSql.QueryAsync<T>(…)` for a typed raw read and `QueueSqlCommand` for a raw write that joins the unit of work — but as whole statements, not as a LINQ fragment. |
+| `Stats(out QueryStatistics)` | **Absent.** No `QueryStatistics`, no `TotalResults` out-param on an arbitrary query. | `ToPagedListAsync`, whose `IPagedList<T>` carries the total from a second statement, and `CountIgnoringPagingAsync` for the total alone. |
+| `ToAsyncEnumerable()` on a query | **Absent.** | Materialize with `ToListAsync`, or `IAdvancedSql.StreamAsync<T>` for raw SQL. Streaming is scarce here on purpose: a retried `SQLITE_BUSY` re-executes the whole delegate, so a live reader yielded to the caller would resume against a disposed connection. |
+| Child-collection LINQ | **Partly landed** ([fisher#166](https://github.com/JasperFx/fisher/issues/166)). | See the [operators page](/documents/querying/linq/operators) — the shipped and missing halves are below. |
+| `IQuerySession.CreateBatchQuery()` | **Present, on `session.Events`** rather than on the session. | `session.Events.CreateBatchQuery()`. `Fisher.Batching.IBatchedQuery` is wider than its home suggests — `Load`, `LoadMany`, `CheckExists`, `Query`, `QueryByPlan` and the DCB reads — and exists for API parity, not speed: SQLite is embedded, so there are no round trips to collapse. |
+
+### Child collections: what ships and what does not
+
+Querying *into* a document's own collection members works over correlated `json_each` sub-queries:
+
+- `Contains(value)` over **scalar** element collections — strings, numbers, Guids, enums, bools.
+- `Any()`, and `Any(c => …)` with a predicate over a complex element's own members.
+- `All(c => …)`, vacuously true over an absent, empty or JSON-null collection.
+- `Count()` compared to a value in either operand order, the `.Count` property, an array's `.Length`,
+  and `Count(c => …)`.
+- Nesting — `x.Stops.Any(s => s.Cargo.Contains("fuel"))` — one alias deeper per level.
+
+Still missing against Marten, and refused by name rather than answered wrongly:
+
+- **Dictionary members.** `IDictionary<,>` and `IReadOnlyDictionary<,>` are excluded outright, so
+  querying a dictionary member is not expressible at all.
+- **`SelectMany` over a child collection**, and therefore anything that flattens elements into the
+  result — including ordering or projecting by a child element's member.
+- **`Select` projecting a child collection.**
+- A predicate inside `Any` / `All` / `Count` follows **SQL null semantics**, not C#'s: a predicate that
+  evaluates to NULL is not satisfied.
+
+::: tip
+The one to check in ported code is the last bullet, because it compiles either way. The rest are
+`BadLinqExpressionException` at the call, naming the operator — Fisher's LINQ surface refuses rather
+than falling back to client-side evaluation, which is the invariant, not the size of the surface.
+:::
+
+### A note on string ordering
+
+Marten's string-named ordering — `OrderBy(string property, StringComparer)` — exists **only on its
+batched queryable**, not on `IQueryable`, so it is a narrower difference than it looks. Fisher's
+batched query takes a lambda instead (`Query<T>(session => session.Query<T>().OrderBy(x => x.Name))`),
+which expresses the same thing with the member checked at compile time.
+
 ## What is not here, and will not be
+
+Unlike the list above, these are settled decisions rather than unbuilt features.
 
 | | Why |
 | :--- | :--- |

--- a/polecat-gaps.md
+++ b/polecat-gaps.md
@@ -1,5 +1,13 @@
 # Polecat Features Not Yet in Fisher
 
+> ⚠️ **This is a Polecat comparison, not a Marten parity statement, and it is dated.** Everything
+> below was established against Polecat on 2026-08-08, on JasperFx 2.45.0. **A feature Marten has and
+> Polecat does not is invisible to it** — `Include()`, full-text search, compiled queries and
+> `IMartenLogger` are all absent from Fisher *and* absent from this file, because Polecat does not have
+> them either. Do not read a clean row here as parity with Marten. The Marten-facing list lives in
+> [the migration guide](docs/migration-guide.md#marten-features-fisher-does-not-have) and is the one to
+> keep current; the README points at it.
+
 Everything [Polecat](https://github.com/JasperFx/polecat) (SQL Server) has that Fisher (SQLite) does
 not, as of 2026-08-08, on JasperFx 2.45.0. Polecat is the comparison rather than Marten because
 Fisher mirrors Polecat's internals by design — CLAUDE.md's rule is "mirror Marten's public API surface
@@ -154,4 +162,4 @@ Recorded so they are not rediscovered as omissions. None of these has an issue.
 | A message bus / durable outbox | [fisher#8](https://github.com/JasperFx/fisher/issues/8), closed wontfix. `NulloMessageOutbox` is the intended end state; delivery is a bus integration's job here as on both siblings. |
 | `IChangeListener` (Polecat's local spelling) | Fisher uses JasperFx's lifted `IDaemonChangeListener`. Polecat's is the older spelling of the same thing; new code should not copy it. |
 | An inline equivalent of subscriptions | "Inline" would be code in the caller's own unit of work. A subscription needs the daemon. |
-| Compiled queries | Polecat declines them too. |
+| Compiled queries | Declined on a measurement — [fisher#195](https://github.com/JasperFx/fisher/issues/195). **This row used to read "Polecat declines them too", which was not a reason and inherited a wrong one**: Polecat's own note says SQL Server's query plan caching handles it natively, and that conflates two different costs. A plan cache saves the *server* re-planning SQL it has seen; a compiled query saves the *client* walking an expression tree and rendering SQL, which the database never sees. Measured on Fisher, that client-side half is 4–11% of an ordinary query, 22.5% of the cheapest one, and 35–78% of a query's allocations — real, but ~2 µs, and a filter-shape plan cache collects nearly all of it with no public API. |

--- a/src/Fisher.Benchmarks/Program.cs
+++ b/src/Fisher.Benchmarks/Program.cs
@@ -108,7 +108,10 @@ switch (command)
         // Everything after `bdn` is handed to BenchmarkDotNet unaltered, so its own filters and
         // job overrides work: `-- bdn --filter *DocSave*`, `-- bdn --job medium`.
         BenchmarkSwitcher
-            .FromTypes([typeof(DocSaveBenchmarks), typeof(EventAppendBenchmarks), typeof(QueryBenchmarks)])
+            .FromTypes([
+                typeof(DocSaveBenchmarks), typeof(EventAppendBenchmarks), typeof(QueryBenchmarks),
+                typeof(QueryConstructionBenchmarks)
+            ])
             .Run(args.Skip(1).ToArray());
         break;
 
@@ -129,7 +132,8 @@ switch (command)
 
             Micro-benchmarks (BenchmarkDotNet + MemoryDiagnoser):
               bdn [BenchmarkDotNet args...]     e.g. bdn --filter *DocSave*
-                                                DocSave, EventAppend, Query
+                                                DocSave, EventAppend, Query,
+                                                QueryConstruction
 
             See src/Fisher.Benchmarks/README.md and Results.md.
             """);

--- a/src/Fisher.Benchmarks/QueryConstructionBenchmarks.cs
+++ b/src/Fisher.Benchmarks/QueryConstructionBenchmarks.cs
@@ -1,0 +1,157 @@
+using BenchmarkDotNet.Attributes;
+using Fisher.Linq;
+using Fisher.TestUtils;
+
+namespace Fisher.Benchmarks;
+
+/// <summary>
+///     Splits a LINQ query into its two halves — <b>construct</b> (walk the expression tree, resolve
+///     members, build a <c>Statement</c>, render the SQL) and <b>execute</b> (bind, run, materialize)
+///     — so the compiled-query question can be answered with a number rather than an argument.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A compiled query removes the construct half and nothing else. On Marten that half sits in
+///         front of a network round trip to a PostgreSQL server, so it is a small fraction of the call;
+///         Fisher's database is a file inside the same process, so there is no round trip for it to be
+///         a fraction of, and the ratio has to be measured rather than inherited. <b>Note the
+///         database-side plan cache is a different thing entirely</b> and answers neither half: it
+///         saves the *server* from re-planning SQL it has already seen, which is not the cost a
+///         compiled query removes.
+///     </para>
+///     <para>
+///         <b>Both halves run on one warm session</b>, created in <c>GlobalSetup</c> and used for
+///         every invocation. That is what makes the pair comparable: a session per invocation would
+///         charge the execute half for opening a pooled connection, which a compiled query would not
+///         have saved either. <c>Construct</c> is <c>session.ToSql(...)</c>, which is
+///         <c>BuildStatement</c> + <c>Statement.Apply</c> + <c>CommandBuilder.Compile</c> — the same
+///         three calls <c>FisherQueryProvider.CommandFor</c> makes, minus the ensured-table cache hit
+///         and setting the command's transaction.
+///     </para>
+///     <para>
+///         <b>The table is deliberately tiny (200 rows, at most 10 returned)</b>, for the reason
+///         <see cref="QueryBenchmarks" /> gives: a large result set puts deserialization in front of
+///         everything and hides the very thing being measured. <c>Count</c> materializes nothing at
+///         all, so it is the shape where construct cost is largest as a share — the ceiling on what a
+///         compiled query could ever be worth here.
+///     </para>
+/// </remarks>
+[Config(typeof(MicroBenchmarkConfig))]
+public class QueryConstructionBenchmarks
+{
+    private TemporaryDatabase _database = null!;
+    private DocumentStore _store = null!;
+    private IDocumentSession _session = null!;
+    private Guid _knownId;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _database = TemporaryDatabase.Create("bdn-query-construction");
+        _store = Scenarios.Harness.BuildStore(_database);
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using (var seed = _store.LightweightSession())
+        {
+            for (var i = 0; i < 200; i++)
+            {
+                var doc = new BenchDoc
+                {
+                    Id = Guid.NewGuid(),
+                    Name = $"doc-{i}",
+                    Number = i,
+                    Timestamp = DateTimeOffset.UtcNow
+                };
+
+                if (i == 42)
+                {
+                    _knownId = doc.Id;
+                }
+
+                seed.Store(doc);
+            }
+
+            await seed.SaveChangesAsync();
+        }
+
+        _session = _store.LightweightSession();
+
+        // Pay the first-use table ensure, the lazily-built mappings, the storage provider and the
+        // connection open here rather than inside the first measured invocation.
+        _ = _session.ToSql(_session.Query<BenchDoc>().Where(x => x.Number > 0));
+        await _session.Query<BenchDoc>().Where(x => x.Number > 0).Take(10).ToListAsync();
+        await _session.Query<BenchDoc>().Where(x => x.Number > 0).CountAsync();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _session.DisposeAsync();
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    // ---- A filtered, ordered page: the ordinary read shape --------------------------------------
+
+    /// <summary>Parse and render only, no database contact.</summary>
+    [Benchmark]
+    public string PageConstruct()
+        => _session.ToSql(_session.Query<BenchDoc>()
+            .Where(x => x.Number > 100 && x.Name != "missing")
+            .OrderBy(x => x.Number)
+            .Take(10));
+
+    /// <summary>The same query end to end: construct, execute, materialize ten documents.</summary>
+    [Benchmark]
+    public async Task<IReadOnlyList<BenchDoc>> PageFull()
+        => await _session.Query<BenchDoc>()
+            .Where(x => x.Number > 100 && x.Name != "missing")
+            .OrderBy(x => x.Number)
+            .Take(10)
+            .ToListAsync();
+
+    // ---- The same predicate counted: nothing materialized ---------------------------------------
+
+    [Benchmark]
+    public string CountConstruct()
+        => _session.ToSql(_session.Query<BenchDoc>()
+            .Where(x => x.Number > 100 && x.Name != "missing"));
+
+    /// <remarks>
+    ///     The count wraps the statement rather than replacing it, so the construct half is the
+    ///     <c>Where</c> chain above plus the wrap — close enough to <see cref="CountConstruct" /> to
+    ///     read the pair as one comparison.
+    /// </remarks>
+    [Benchmark]
+    public async Task<long> CountFull()
+        => await _session.Query<BenchDoc>()
+            .Where(x => x.Number > 100 && x.Name != "missing")
+            .CountAsync();
+
+    // ---- The shortest chain there is: one document by one member --------------------------------
+
+    [Benchmark]
+    public string FirstConstruct()
+        => _session.ToSql(_session.Query<BenchDoc>().Where(x => x.Name == "doc-42"));
+
+    [Benchmark]
+    public async Task<BenchDoc?> FirstFull()
+        => await _session.Query<BenchDoc>().Where(x => x.Name == "doc-42").FirstOrDefaultAsync();
+
+    // ---- The cheapest execution there is: one row off the primary key ---------------------------
+
+    /// <remarks>
+    ///     <b>This is the shape most favourable to a compiled query</b>, and it is here for that
+    ///     reason. Every other shape scans 200 rows through <c>json_extract</c>, so execution
+    ///     dominates by construction; a predicate on <c>id</c> is an index seek returning one row, so
+    ///     whatever share construction holds here is the ceiling on what caching it could ever be
+    ///     worth on this store.
+    /// </remarks>
+    [Benchmark]
+    public string ByIdConstruct()
+        => _session.ToSql(_session.Query<BenchDoc>().Where(x => x.Id == _knownId));
+
+    [Benchmark]
+    public async Task<BenchDoc?> ByIdFull()
+        => await _session.Query<BenchDoc>().Where(x => x.Id == _knownId).FirstOrDefaultAsync();
+}

--- a/src/Fisher.Benchmarks/README.md
+++ b/src/Fisher.Benchmarks/README.md
@@ -73,7 +73,14 @@ every change. For a publishable number, scale up:
    touching T document types, which pays the first-use table-ensure migration once per type (the
    O(types × objects) migration finding). The second, identical commit is the warm contrast, so
    the report can isolate "table-ensure overhead" and "overhead per type".
-6. **`QueryBenchmarks`** (BDN only) — one LINQ query end to end over a deliberately tiny table, so
+6. **`QueryConstructionBenchmarks`** (BDN only) — the same query shapes split into **construct**
+   (`session.ToSql(...)`: walk the expression tree, resolve members, build the `Statement`, render the
+   SQL) and **full** (construct, execute, materialize), on one warm session so the pair is comparable.
+   This is the harness for the compiled-query question: a compiled query removes the construct half
+   and nothing else, so the construct/full ratio *is* the answer. `ByIdConstruct`/`ByIdFull` is the
+   ceiling — an index seek returning one row, the cheapest execution there is, so the largest share
+   construction can hold. See `Results.md` for the numbers and fisher#195 for what they decided.
+7. **`QueryBenchmarks`** (BDN only) — one LINQ query end to end over a deliberately tiny table, so
    parsing the chain and rendering the SQL rather than materializing rows is what the number is
    about. The harness for the query-construction work: allocations are the signal, since the SQLite
    round trip is in-process and the same before and after. The `FilteredCount` and `FirstByMember`

--- a/src/Fisher.Benchmarks/Results.md
+++ b/src/Fisher.Benchmarks/Results.md
@@ -261,3 +261,61 @@ Notes:
   command 22 ms, 250 per command 59 ms) and **every chunk size measured is worse than a command per
   operation**, so there is no sweet spot to tune to. See `FisherSession.ExecuteBatchAsync`'s remarks
   for that and for why the `NextResult` walk it needs could not be made safe on this provider anyway.
+
+---
+
+## Query construction vs execution — the compiled-query measurement (fisher#195)
+
+`QueryConstructionBenchmarks`, macOS 26 / Apple Silicon (Arm64), .NET 10.0.1, in-process toolchain,
+10 warmup + 25 measured iterations, one warm session shared by both halves of each pair.
+
+**Construct** is `session.ToSql(query)` — `BuildStatement` + `Statement.Apply` +
+`CommandBuilder.Compile`, the same three calls `FisherQueryProvider.CommandFor` makes minus the
+ensured-table cache hit. It is exactly the work a compiled query would skip, and if anything a slight
+over-count of it (a compiled query would still bind parameter values). **Full** is the ordinary LINQ
+terminal on the same session.
+
+```
+| Method         |      Mean |   StdDev | Allocated |
+|--------------- |----------:|---------:|----------:|
+| PageConstruct  |  3.838 us | 0.132 us |    8.9 KB |
+| PageFull       | 92.481 us | 1.148 us |  25.58 KB |
+| CountConstruct |  3.124 us | 0.151 us |   5.85 KB |
+| CountFull      | 70.861 us | 2.021 us |   7.47 KB |
+| FirstConstruct |  2.222 us | 0.101 us |    4.3 KB |
+| FirstFull      | 20.337 us | 0.393 us |  10.08 KB |
+| ByIdConstruct  |  2.176 us | 0.062 us |   3.87 KB |
+| ByIdFull       |  9.668 us | 0.202 us |    9.1 KB |
+```
+
+Read as shares — the construct half as a fraction of the whole call:
+
+```
+shape                              time      allocations
+filtered ordered page (10 docs)     4.1%          34.8%
+filtered count (0 rows read)        4.4%          78.3%
+first by member (200-row scan)     10.9%          42.7%
+first by id (index seek)           22.5%          42.5%
+```
+
+- **Wall clock says no and allocations say yes**, which is the whole result. Construction is 4-11% of
+  an ordinary query and **22.5% of the cheapest query the store can run** — an index seek returning
+  one row, which is the ceiling by construction. But it is **35-78% of every query's allocations**,
+  because the execute half of an embedded store allocates almost nothing: `CountFull` adds 1.6 KB to
+  `CountConstruct`'s 5.85 KB.
+- **The ratio really is much higher than Marten's, and that argument still does not carry.** On
+  PostgreSQL the construct half sits in front of a network round trip and is a low single-digit
+  percentage; here there is no round trip for it to be a fraction of, so it rises to 22.5% at the
+  ceiling. The absolute number is what decides it: 2.2 us saved off a 9.7 us call, against
+  `ICompiledQuery` / `ICompiledListQuery` and their AspNetCore streaming variants as new public API.
+- **This is the number fisher#181 deferred, and it confirms that note.** Caching the config-only
+  halves (select list per storage, `MemberFactory` per mapping) moved allocations ~1%, because what is
+  left is per-query: the expression walk, an `IQueryableMember` per referenced member, the `Statement`
+  and the render. That residue is the 35-78% above.
+- **A filter-shape plan cache (marten#5013) collects almost all of it with no public API.** Keyed on
+  the shape of the predicate, it removes member resolution, statement construction and the SQL render
+  for *every* query, leaving only a cheaper structural walk. A compiled query removes that walk too —
+  a fraction of an already-small 2-4 us — for a whole new API surface and a rewrite of each call site.
+- **What would change the answer**: a plan cache that lands and leaves a residue still worth 10%+ of a
+  query, or a workload dominated by trivially-executing queries at high rate. Re-run this class rather
+  than re-arguing it.


### PR DESCRIPTION
Two halves of one thing: the measurement that lets Fisher decline compiled queries for a real reason, and the docs correction that stops the README claiming the remaining gaps are all decisions. Records [#195](https://github.com/JasperFx/fisher/issues/195).

## The measurement

`src/Fisher.Benchmarks/QueryConstructionBenchmarks.cs` splits a query into **construct** (walk the expression tree, resolve members, build the `Statement`, render the SQL) and **execute**. Construct is `session.ToSql(query)` — the same three calls `FisherQueryProvider.CommandFor` makes minus the ensured-table cache hit, so it is exactly the work a compiled query would skip, and if anything a slight over-count of it since a compiled query would still bind parameter values. Both halves run on **one warm session**: a session per invocation would charge the execute half for a pooled connection open that a compiled query would not have saved either.

```
| Method         |      Mean |   StdDev | Allocated |
|--------------- |----------:|---------:|----------:|
| PageConstruct  |  3.838 us | 0.132 us |    8.9 KB |
| PageFull       | 92.481 us | 1.148 us |  25.58 KB |
| CountConstruct |  3.124 us | 0.151 us |   5.85 KB |
| CountFull      | 70.861 us | 2.021 us |   7.47 KB |
| FirstConstruct |  2.222 us | 0.101 us |    4.3 KB |
| FirstFull      | 20.337 us | 0.393 us |  10.08 KB |
| ByIdConstruct  |  2.176 us | 0.062 us |   3.87 KB |
| ByIdFull       |  9.668 us | 0.202 us |    9.1 KB |
```

Construct as a share of the whole call:

| shape | time | allocations |
|---|---|---|
| filtered ordered page (10 docs) | **4.1%** | 34.8% |
| filtered count (0 rows read) | **4.4%** | 78.3% |
| first by member (200-row scan) | **10.9%** | 42.7% |
| first by id (index seek) | **22.5%** | 42.5% |

`ByIdFull` is the ceiling by construction — an index seek returning one row is the cheapest execution the store can perform, so that is the most of a call construction can ever hold.

**Recommendation: defer behind a filter-shape plan cache; do not implement `ICompiledQuery`.**

Wall clock says no and allocations say yes. The ratio really is far higher than Marten's — there is no round trip here for parsing to be a fraction of, which cuts *for* compiled queries and is exactly why this needed measuring rather than reasoning — but the absolute number decides it: **2.2 µs off a 9.7 µs call**, against `ICompiledQuery<T>` / `ICompiledListQuery<T>`, their AspNetCore streaming variants, and a rewrite of every call site that wants the saving. A marten#5013-style plan cache collects nearly all the same work for **every** query with no public API at all; what a compiled query adds over it is the tree walk, a fraction of an already-small 2-4 µs.

This is the residue [#181](https://github.com/JasperFx/fisher/pull/181) deferred, and it confirms that note — caching the config-only halves moved allocations ~1% because what is left (the expression walk, an `IQueryableMember` per referenced member, the `Statement`, the render) is per-query by construction. That residue is the 35-78% above.

**The inherited rationale was about the wrong cost.** `polecat-gaps.md` declined compiled queries with "Polecat declines them too", pointing at Polecat's *"SQL Server query plan caching handles this natively"*. A plan cache saves the **server** re-planning SQL it has already seen; a compiled query saves the **client** walking an expression tree and rendering SQL the database never sees. That row now points at the measurement.

## The docs

The README claimed *"the gaps that remain are **decisions**, documented in HANDOFF.md rather than filed as issues"* and that the one absent thing is the message bus. Neither survives a Marten comparison, and the reason is structural rather than careless: **Fisher's parity baseline was drawn against Polecat**, so a feature Marten has and Polecat does not never entered the tracking at all.

Every claim verified against current `main` before writing, in both directions:

- **Absent**: `Include()`, compiled queries, full-text search (nothing over FTS5), a session logging seam (`IMartenLogger` / `IMartenSessionLogger`), `MatchesSql`, `Stats(out QueryStatistics)`, `ToAsyncEnumerable()`.
- **Partly landed**: child-collection LINQ. #166 shipped `Contains` over *scalar* elements, `Any()`, `Any(pred)`, `All(pred)`, the whole `Count` family and nesting; **dictionary members, `SelectMany` and `Select` over a child collection are still absent**, and predicates follow SQL null semantics rather than C#'s — which is the one that compiles either way and so is called out separately.
- **API shape**: `CreateBatchQuery` is on `session.Events`, not the session.
- **Dropped as overstated**: string-based `OrderBy`. Marten's string ordering exists only on its *batched* queryable, not on `IQueryable`, so it is recorded as the narrow difference it is rather than as a missing LINQ operator.
- **Not written, being present**: CLI integration (#176), AdvancedOperations parity (#180) and event upcasting (#192) all ship on main. Several gap claims had gone stale in that direction today and none of them made it into the list.

`polecat-gaps.md` gets a header saying plainly what it is — a dated Polecat comparison, blind by construction to Marten-only features — so a clean row there is not read as parity with Marten. `HANDOFF.md`'s deliberate-gaps section gets the same caveat, since the README no longer points there for the whole story.

## Validation

- Full suite green on both TFMs after merging `origin/main` (#196 landed mid-flight): **1729 Fisher.Tests, 36 AspNetCore, 19 EF Core, 0 failures.**
- Scoreboard reconciled against a real Release run: 1784 tests, 516 compliance across 50 suites (43 event / 7 document) — unchanged by this PR.
- `vitepress build docs` clean; a dead internal link would fail it.
- No NuGet package published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
