### PR TITLE
gh-213: a tenant registry, over Weasel 9.31.0's lifted MasterTableTenancy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,10 @@ Working, with tests:
   configured stores live in one container
 - **Database-per-tenant** — `ITenancy` and a SQLite file per tenant, with per-database migration, the
   async daemon routed per database, and tenants that appear, suspend and resume at runtime
+- **A tenant registry** — `MultiTenantedDatabasesInRegistry(...)`, Marten's master-table tenancy over
+  Weasel's lifted `MasterTableTenancyBase`: the tenant set held in a control table in a SQLite
+  registry database, durable across restarts and shared between processes, with tenants added,
+  suspended, resumed and removed at runtime — and never deleted
 - **Transaction participants** — `ITransactionParticipant`, so an application's own writes commit in
   Fisher's transaction rather than contending with it for the file's one write lock
 - **The store-agnostic document contract** — `JasperFx.Events.Documents`, implemented by Fisher's own
@@ -2786,6 +2790,90 @@ populates deliberately.
   nothing for eviction to reclaim. What costs is a tenant that has been *used* — see "Releasing pooled
   connections" below. `ForgetTenantAsync` is the explicit release for a tenant a process is finished
   with.
+
+#### The tenant registry — fisher#213
+
+`Storage/MasterTableTenantSource.cs` and `Storage/SqliteMasterTenantTableDialect.cs`, reached by
+`StoreOptions.MultiTenantedDatabasesInRegistry(...)`. Marten's **master-table** tenancy: tenant →
+connection string in a control table, with tenants added, suspended, resumed and removed at runtime.
+For a store whose tenants are files, the analogue of the master table is a **tenant-registry
+database** — one small SQLite file holding `fi_tenants`.
+
+**The fourth source, and the first where the tenant set is a *record*.** The other three each fail to
+be one for a different reason: `DirectoryTenantSource` resolves any tenant id at all — the point of
+it, and also why it can never say "that is not one of ours"; `InMemoryTenantSource` holds the set in
+one process's memory, so nothing survives a restart and two nodes disagree; a fixed
+`MultiTenantedDatabases` set is configuration.
+
+**Weasel's lifted `MasterTableTenancyBase` is adopted rather than reimplemented** (weasel#567, Weasel
+9.31.0). The control-table contract, the cache, provisioning-once, the seed list and the whole
+`IDynamicTenantSource<string>` lifecycle are its; Fisher supplies `IMasterTenantTableDialect` and one
+adapter. `SqliteDataSource` *is* a `DbDataSource`, so the lift's seam fits with nothing adapted, and
+Fisher gets the store-agnostic admin surface (`IDynamicTenantSource<string>`,
+`IMasterTableMultiTenancy`) for free — a surface it had no equivalent of.
+
+- ⚠️ **The base is closed over `TenantRegistration`, not over `FisherDatabase`, and that is the whole
+  design.** The base's own remarks say everything it does with a `TDatabase` is cache it, hand it back
+  and dispose it — so closing it over the *registration* makes its cache Fisher's synchronous snapshot
+  of the control table, which is exactly what `ITenantSource.TryFind` needs. Closing it over
+  `FisherDatabase` would have put a second database cache beside `DynamicTenancy`'s — two
+  `SqliteDataSource`s and two connection pools per tenant — and forced `DatabaseFor` to resolve
+  asynchronously. Going through `ITenantSource` instead is also what reuses `DynamicTenancy` whole:
+  the first-use migration, the daemon's tenant poller, `ForgetTenantAsync`, the cleaner, the CLI
+  database source and `DisabledTenantException` all work with nothing added.
+- ⚠️ **Marten's `GetTenant(string)` is `tryFindTenantDatabase(...).GetAwaiter().GetResult()`, and that
+  is the one thing not to copy.** `DatabaseFor` is reached from `OpenSession`, which has no `await` to
+  offer — the reason `TryFind` is synchronous and `AllAsync` is not. So the trade is stated rather
+  than hidden: **a tenant this process has not read does not resolve.** One added through
+  `AddTenantAsync` here is cached as it is written; one added by another process appears on the next
+  refresh (the daemon polls every minute, and every `RefreshAsync` caller refreshes on demand).
+- ⚠️ **The seed list is what makes a default tenant possible at all.** `DynamicTenancy.Default` is read
+  while the store is being *built*, before anything could have read the control table — so a registry
+  naming its tenants only in the table cannot answer for `*DEFAULT*` and the store refuses to
+  construct. `TryFind` therefore falls back to `SeedDatabases`, which is configuration rather than
+  data: known synchronously, and upserted into the table on the first refresh so the two agree. The
+  fallback is checked *after* the disabled set, so suspending a seeded tenant still suspends it.
+- **`tenant_id` is declared `collate nocase`.** The base compares cache keys with the comparer it is
+  handed and Fisher hands it `OrdinalIgnoreCase`, matching its other two tenancies; SQLite's default
+  collation is case-sensitive, so without the collation the cache and the table disagree about whether
+  `Acme` and `acme` are one tenant — a tenant that resolves through one and not the other, which reads
+  as an intermittent.
+- **The upsert does not clear the disabled flag.** The dialect contract explicitly leaves this to the
+  dialect and says the two shipped stores disagree — Polecat's `MERGE` re-enables, Marten's
+  `on conflict` does not. Fisher follows Marten: resuming a suspended tenant as a side effect of
+  correcting its connection string would silently undo a deliberate suspension.
+- **Control-plane reads and writes go through `StoreOptions.ResiliencePipeline`**, via the base's
+  `ExecuteAsync` hook. The registry is a SQLite file and takes one writer, so an operator adding a
+  tenant while a node reads the table is exactly the `SQLITE_BUSY` the pipeline exists for. Polecat
+  overrides the same hook; Marten leaves it on the default.
+- **The table name folds the logical schema in**, like every other Fisher table, so two logical stores
+  sharing one registry file keep separate tenant lists.
+
+**The deletion stance held with no guard, which is the useful finding.** Fisher deprovisions and never
+deletes — deleting a tenant here means deleting a *file*, and Fisher cannot know it is backed up — and
+the lifted base already draws the line in the same place: its `DeleteDatabaseRecordAsync` says the
+tenant's own database is left completely alone. So `SuspendTenantAsync` flips a flag,
+`ForgetTenantAsync` deletes the *row*, and neither touches the `.db`. There is deliberately no member
+on the source that removes one, and `the_source_offers_no_way_to_delete_a_tenants_database` pins that
+by reflection rather than by prose, because "we do not delete" is exactly the rule a later convenience
+method breaks without anybody noticing.
+
+**`ITenantSource.OnTenantRevoked` closes a gap the registry made sharp** — and it applies to all three
+sources. `DynamicTenancy` caches a `FisherDatabase` per tenant and `DatabaseFor` answers from that
+cache, so **suspending a tenant the store had already resolved used to do nothing**; the old
+`runtime_tenants` test said so in a comment and opened a *fresh store* to observe the refusal. That is
+tolerable for a directory convention an operator edits by hand and wrong for a control table, whose
+whole point is runtime effect. The tenancy now sets a revocation callback the source raises, and the
+cached database is evicted and disposed.
+
+- **A callback rather than a check on the resolution path**, because `TryFind` is on the session-open
+  hot path and `DirectoryTenantSource` builds a `SqliteConnectionStringBuilder` on every call —
+  consulting it per session would be a real per-session cost to make a rare event immediate.
+- **Default-implemented on the interface** (`get => null; set { }`), so it is additive: `ITenantSource`
+  is public and implementable outside this repo, and a source that never revokes needs no change.
+- Disposal is synchronous, because a source revokes from a synchronous method. The difference from
+  `ForgetTenantAsync`'s async path is only that a pooled connection's close is not awaited, and
+  clearing the pool leaves a checked-out connection working either way (fisher#59).
 
 ### Releasing pooled connections
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1883 tests green on net9.0 and net10.0** — 1828 in
+**1901 tests green on net9.0 and net10.0** — 1846 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 516 of
 them are shared cross-store compliance tests — 447 event sourcing and 69 document. On JasperFx **2.66.0** / Weasel **9.31.0**.
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1564,7 +1564,46 @@ Each of these is a decision with a reason, not an oversight:
   most irreversible, and Fisher cannot know whether that file is backed up. So the API suspends or
   forgets and an operator removes the file themselves. `DisabledTenantException` is distinct from
   `UnknownTenantException` because "switched off" and "never heard of it" are different operational
-  situations.
+  situations. **The tenant registry (#213) did not soften it either** — see below.
+
+## The tenant registry, and what adopting Weasel's lift cost
+
+fisher#213 added the fourth tenant source: `MultiTenantedDatabasesInRegistry(...)`, Marten's
+master-table tenancy over the runtime **Weasel 9.31.0 lifted out of Marten and Polecat** (weasel#567).
+Three things are worth knowing before touching it.
+
+**The lift was adopted, not reimplemented, and the seam fit with nothing adapted.**
+`MasterTableTenancyBase<TDatabase, TDataSource>` requires `TDataSource : DbDataSource` and
+`Weasel.Sqlite.SqliteDataSource` is one, so the control-table contract, the cache, provisioning-once,
+the seed list and the whole `IDynamicTenantSource<string>` lifecycle come from Weasel. What Fisher
+wrote is an `IMasterTenantTableDialect` and one adapter — and the store-agnostic admin surface
+(`IDynamicTenantSource<string>`, `IMasterTableMultiTenancy`), which Fisher had no equivalent of, comes
+free with it.
+
+**The base is closed over `TenantRegistration`, not `FisherDatabase`.** That is the decision the whole
+node turns on. The base's own remarks say all it does with a `TDatabase` is cache it, hand it back and
+dispose it — so closing it over the *row* makes its cache the synchronous snapshot
+`ITenantSource.TryFind` needs, and the source plugs into `DynamicTenancy` unchanged: the first-use
+migration, the daemon's tenant poller, `ForgetTenantAsync`, the cleaner, the CLI database source and
+`DisabledTenantException` all keep working. Closing it over `FisherDatabase` would have put a second
+database cache beside `DynamicTenancy`'s — two data sources and two pools per tenant — and forced
+`DatabaseFor` to resolve asynchronously, which is Marten's `GetAwaiter().GetResult()` and the one
+thing this node must not copy.
+
+**The deletion stance needed no guard, and that is the pleasant finding.** The lifted base's
+`DeleteDatabaseRecordAsync` already says the tenant's own database is left completely alone, so
+Fisher's rule and Weasel's agree: suspend flips a flag, forget deletes the *row*, the `.db` file stays
+where an operator can archive it. `tenant_registry.the_source_offers_no_way_to_delete_a_tenants_database`
+pins the absence by reflection, because "we do not delete" is exactly the rule a later convenience
+method breaks silently.
+
+**What the registry did make sharp is `ITenantSource.OnTenantRevoked`**, and it is a behaviour change
+to the *existing* sources rather than only to the new one. `DynamicTenancy` caches a `FisherDatabase`
+per tenant, so suspending a tenant the store had already resolved used to do nothing — the old
+`runtime_tenants` test said so in a comment and opened a fresh store to observe the refusal. Tolerable
+for a directory convention edited by hand; wrong for a control table, whose point is runtime effect.
+The member is default-implemented so `ITenantSource` stays implementable outside this repo, and it is
+a callback rather than a re-check on `DatabaseFor` because `TryFind` is on the session-open hot path.
 - **No hot-cold daemon coordination**, and `AddAsyncDaemon(DaemonMode.HotCold)` refuses rather than
   quietly running Solo. Failover means several nodes competing for a leadership lease through the
   database, and a Fisher store is a file SQLite does not make safe to share across nodes.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 50 suites and 516 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,815.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,846.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -111,6 +111,9 @@ public interface ITenantSource
 {
     bool TryFind(string tenantId, out TenantRegistration registration);
     ValueTask<IReadOnlyList<TenantRegistration>> AllAsync(CancellationToken token = default);
+
+    // Optional. Call it when a tenant stops being routable, so the tenancy drops its cached database.
+    Action<string>? OnTenantRevoked { get => null; set { } }
 }
 ```
 
@@ -120,12 +123,60 @@ opening a session — has to answer without I/O, which the directory convention 
 Enumerating every tenant is a startup and daemon concern, where an `await` is available.
 :::
 
-The two supplied sources differ deliberately:
+The three supplied sources differ deliberately:
 
-| Source | Unknown tenant id |
-| :--- | :--- |
-| `DirectoryTenantSource` | **Resolves it**, creating the file on first use. Enumeration reports only files that exist. |
-| `InMemoryTenantSource` | **Refuses it.** For an application pushing its own tenants list. |
+| Source | Unknown tenant id | The set is |
+| :--- | :--- | :--- |
+| `DirectoryTenantSource` | **Resolves it**, creating the file on first use. Enumeration reports only files that exist. | a convention |
+| `InMemoryTenantSource` | **Refuses it.** For an application pushing its own tenants list. | one process's memory |
+| `MasterTableTenantSource` | **Refuses it.** | a record — see below |
+
+### The tenant registry
+
+The durable form: one small SQLite database holding a `fi_tenants` table that names every tenant and
+where its data lives. Marten's master-table tenancy, for a store whose tenants are files.
+
+```cs
+var tenants = opts.MultiTenantedDatabasesInRegistry(x =>
+{
+    x.ConnectionString = "Data Source=/var/lib/app/tenants.db";
+
+    // A registry store has no store-level file, so the default tenant has to be named here — it is
+    // read while the store is being built, before anything could have read the table.
+    x.SeedDatabases.RegisterDefault("Data Source=/var/lib/app/tenants/main.db");
+});
+
+// …and at any time afterwards, from anywhere
+await tenants.AddTenantAsync("acme", "Data Source=/var/lib/app/tenants/acme.db");
+await tenants.SuspendTenantAsync("acme");
+await tenants.ResumeTenantAsync("acme");
+await tenants.ForgetTenantAsync("acme");
+```
+
+Reach it later through `((DynamicTenancy)store.Tenancy).Source`.
+
+Unlike the other two, the set **survives a restart and is shared between processes** — which is the
+whole reason to reach for it. A tenant added through this instance is usable by the very next
+session; one added to the registry by *another* process appears on the next refresh.
+
+::: warning
+**A tenant this process has not read does not resolve.** `ITenancy.DatabaseFor` is reached from the
+synchronous `OpenSession` and has no `await` to offer, so Fisher will not read the control table on
+the session path — Marten answers the same question with `GetAwaiter().GetResult()` and Fisher
+deliberately does not. The async daemon refreshes every minute;
+`ApplyAllConfiguredChangesToDatabaseAsync`, `db-apply` and `source.RefreshAsync()` all refresh on
+demand.
+:::
+
+::: tip
+SQLite has no schemas, so `SchemaName` folds into the table name as it does everywhere else in
+Fisher: `fi_tenants`, or `reporting_fi_tenants` under a logical schema called `reporting`. Two
+logical stores can therefore share one registry file and keep separate tenant lists.
+:::
+
+**Re-adding a suspended tenant does not resume it.** The upsert corrects the connection string and
+leaves the disabled flag alone, matching Marten — resuming as a side effect of correcting a
+connection string would silently undo a deliberate suspension.
 
 ### Migration per tenant
 
@@ -162,7 +213,15 @@ source.Resume("acme");
 ```
 
 `InMemoryTenantSource` spells the same thing `SetActive(id, false)`, and `Remove(id)` drops it
-entirely.
+entirely; `MasterTableTenantSource` spells them `SuspendTenantAsync` / `ResumeTenantAsync` /
+`ForgetTenantAsync`, and those changes are written to the registry rather than held in memory.
+
+::: tip
+Suspending takes effect **immediately**, including for a tenant this store has already opened a
+session for. That is not free — the tenancy caches a database per tenant — so a source tells it
+through `ITenantSource.OnTenantRevoked`, which the tenancy sets and which every supplied source
+raises.
+:::
 
 Forgetting a tenant a process is finished with — which releases its pooled connections and their file
 handles — is on the tenancy:
@@ -176,6 +235,10 @@ await tenancy.ForgetTenantAsync("acme");
 **Fisher suspends; it never deletes.** Deleting a tenant here means deleting a file — the cheapest
 deprovisioning of any Critter Stack store, and the most irreversible — and Fisher cannot know whether
 that file is backed up. Remove the file yourself.
+
+That holds for the registry too: `ForgetTenantAsync` removes the tenant's **row**, and the `.db` file
+stays exactly where it was. Re-registering the tenant finds its data again. To erase a tenant's rows
+and keep the file, use `store.Advanced.DeleteAllTenantDataAsync(id)`.
 :::
 
 `DisabledTenantException` is distinct from `UnknownTenantException` on purpose: "switched off" and

--- a/src/Fisher.Tests/Configuration/runtime_tenants.cs
+++ b/src/Fisher.Tests/Configuration/runtime_tenants.cs
@@ -180,8 +180,14 @@ public class runtime_tenants : IAsyncLifetime
 
         source.Suspend("seasonal");
 
-        // Already-resolved databases are cached, so a fresh store is what proves the refusal rather
-        // than a stale cache hiding it.
+        // On THIS store, whose cache already holds the tenant's database. That used to need a fresh
+        // store — a suspension only reached a tenant nothing had resolved yet, which is the opposite
+        // of what switching a tenant off means and made "restart the process" part of the procedure.
+        // fisher#213's ITenantSource.OnTenantRevoked is what evicts it.
+        Should.Throw<DisabledTenantException>(() => store.LightweightSession("seasonal"))
+            .TenantId.ShouldBe("seasonal");
+
+        // And on a fresh store too, since the suspension is the source's rather than the cache's.
         await using var reopened = StoreFor(source);
 
         Should.Throw<DisabledTenantException>(() => reopened.LightweightSession("seasonal"))
@@ -189,8 +195,7 @@ public class runtime_tenants : IAsyncLifetime
 
         source.Resume("seasonal");
 
-        await using var resumed = StoreFor(source);
-        await using var query = resumed.LightweightSession("seasonal");
+        await using var query = store.LightweightSession("seasonal");
 
         (await query.LoadAsync<Sighting>(id, Token)).ShouldNotBeNull();
     }

--- a/src/Fisher.Tests/Configuration/tenant_registry.cs
+++ b/src/Fisher.Tests/Configuration/tenant_registry.cs
@@ -1,0 +1,557 @@
+using Fisher.Storage;
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.MultiTenancy;
+using Microsoft.Data.Sqlite;
+using Weasel.Core.MultiTenancy;
+using Weasel.Sqlite;
+
+namespace Fisher.Tests.Configuration;
+
+/// <summary>
+///     fisher#213 — the tenant registry: Marten's master-table tenancy, over the runtime Weasel 9.31.0
+///     lifted out of Marten and Polecat (weasel#567).
+/// </summary>
+/// <remarks>
+///     <para>
+///         The property that distinguishes this from Fisher's other three tenant sources is that the
+///         set is <em>a record</em>: durable across restarts, shared between processes, and editable
+///         while the store runs. <c>DirectoryTenantSource</c> resolves any tenant id at all and so can
+///         never refuse one; <c>InMemoryTenantSource</c> forgets everything on restart.
+///     </para>
+///     <para>
+///         <b>The deletion stance is what these tests are most careful about.</b> Fisher deprovisions
+///         and never deletes: suspending and forgetting both leave the tenant's <c>.db</c> file exactly
+///         where it was, and every lifecycle test here asserts the file is still on disk afterwards.
+///     </para>
+/// </remarks>
+public class tenant_registry : IAsyncLifetime
+{
+    private readonly string _directory =
+        Path.Combine(Path.GetTempPath(), "fisher-registry-" + Guid.NewGuid().ToString("n")[..8]);
+
+    private readonly TemporaryDatabase _registry = TemporaryDatabase.Create("registry");
+
+    public ValueTask InitializeAsync()
+    {
+        Directory.CreateDirectory(_directory);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _registry.Dispose();
+
+        if (Directory.Exists(_directory))
+        {
+            try
+            {
+                Directory.Delete(_directory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A tenant file still held by a pooled connection; the directory is under temp.
+            }
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private string PathFor(string tenantId) => Path.Combine(_directory, $"{tenantId}.db");
+
+    private string ConnectionStringFor(string tenantId)
+        => new SqliteConnectionStringBuilder { DataSource = PathFor(tenantId) }.ToString();
+
+    private DocumentStore StoreFor(out MasterTableTenantSource source,
+        Action<MasterTableTenancyOptions<SqliteDataSource>>? configure = null)
+    {
+        MasterTableTenantSource? built = null;
+
+        var store = DocumentStore.For(options =>
+        {
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<Sighting>();
+
+            built = options.MultiTenantedDatabasesInRegistry(x =>
+            {
+                x.ConnectionString = _registry.ConnectionString;
+
+                // A registry store has no store-level file, so the default tenant has to come from
+                // somewhere the store can read synchronously while it is being built. See
+                // MasterTableTenantSource.TryFind.
+                x.SeedDatabases.RegisterDefault(ConnectionStringFor("default"));
+
+                configure?.Invoke(x);
+            });
+        });
+
+        source = built!;
+
+        return store;
+    }
+
+    // ---- the control table ----
+
+    [Fact]
+    public async Task the_control_table_is_provisioned_on_first_use_and_is_idempotent()
+    {
+        await using var store = StoreFor(out var source);
+
+        (await TableExistsAsync("fi_tenants")).ShouldBeFalse();
+
+        await source.AddTenantAsync("one", ConnectionStringFor("one"), Token);
+
+        (await TableExistsAsync("fi_tenants")).ShouldBeTrue();
+
+        // A second instance over the same registry file provisions again, and must not fail — the
+        // base's semaphore guards one process and a deployment has several, so the DDL itself has to
+        // be idempotent.
+        await using var second = StoreFor(out var other);
+        await other.RefreshAsync(Token);
+
+        (await TenantRowCountAsync()).ShouldBe(1);
+    }
+
+    /// <remarks>
+    ///     SQLite has no schemas, so a logical schema name folds into the table prefix as it does for
+    ///     every other Fisher table — which is what keeps two logical stores sharing one registry file
+    ///     from sharing one tenant list.
+    /// </remarks>
+    [Fact]
+    public async Task the_logical_schema_folds_into_the_table_name()
+    {
+        await using var store = StoreFor(out var source, x => x.SchemaName = "reporting");
+        await source.AddTenantAsync("one", ConnectionStringFor("one"), Token);
+
+        (await TableExistsAsync("reporting_fi_tenants")).ShouldBeTrue();
+        (await TableExistsAsync("fi_tenants")).ShouldBeFalse();
+    }
+
+    /// <remarks>
+    ///     The cache compares tenant ids with <c>OrdinalIgnoreCase</c>, matching Fisher's other two
+    ///     tenancies. SQLite's default collation is case-sensitive, so the control table's
+    ///     <c>tenant_id</c> is declared <c>collate nocase</c> — without it the cache and the table
+    ///     disagree, and a tenant resolves through one and not the other.
+    /// </remarks>
+    [Fact]
+    public async Task tenant_ids_are_case_insensitive_in_the_table_as_well_as_the_cache()
+    {
+        await using var store = StoreFor(out var source);
+
+        await source.AddTenantAsync("Acme", ConnectionStringFor("acme"), Token);
+        await source.AddTenantAsync("ACME", ConnectionStringFor("acme"), Token);
+
+        // One tenant, not two — which is only true if the upsert's conflict target matched.
+        (await TenantRowCountAsync()).ShouldBe(1);
+
+        source.TryFind("acme", out _).ShouldBeTrue();
+
+        // And a fresh process reading the table back agrees.
+        await using var second = StoreFor(out var other);
+        await other.RefreshAsync(Token);
+        other.TryFind("aCmE", out _).ShouldBeTrue();
+    }
+
+    // ---- resolution ----
+
+    [Fact]
+    public async Task a_registered_tenant_resolves_and_its_file_is_migrated_on_first_use()
+    {
+        await using var store = StoreFor(out var source);
+        await source.AddTenantAsync("acme", ConnectionStringFor("acme"), Token);
+
+        store.Tenancy.ShouldBeOfType<DynamicTenancy>().Source.ShouldBeSameAs(source);
+        store.Tenancy.Cardinality.ShouldBe(DatabaseCardinality.DynamicMultiple);
+
+        var id = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession("acme"))
+        {
+            session.Store(new Sighting { Id = id, Species = "Manta" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = store.LightweightSession("acme");
+        (await query.LoadAsync<Sighting>(id, Token)).ShouldNotBeNull();
+
+        File.Exists(PathFor("acme")).ShouldBeTrue();
+    }
+
+    /// <remarks>
+    ///     The difference from <c>DirectoryTenantSource</c>, and the reason a registry is worth having:
+    ///     a convention source answers for every tenant id there could ever be, so it cannot tell an
+    ///     unknown tenant from a real one. A record can.
+    /// </remarks>
+    [Fact]
+    public async Task an_unregistered_tenant_is_refused()
+    {
+        await using var store = StoreFor(out var source);
+        await source.AddTenantAsync("acme", ConnectionStringFor("acme"), Token);
+
+        Should.Throw<UnknownTenantException>(() => store.LightweightSession("nobody"));
+    }
+
+    /// <remarks>
+    ///     Two tenants, two files, and neither can see the other's rows — the property
+    ///     database-per-tenant exists for, checked here because the registry is a new way of arriving
+    ///     at it.
+    /// </remarks>
+    [Fact]
+    public async Task two_registered_tenants_keep_their_data_apart()
+    {
+        await using var store = StoreFor(out var source);
+        await source.AddTenantAsync("one", ConnectionStringFor("one"), Token);
+        await source.AddTenantAsync("two", ConnectionStringFor("two"), Token);
+
+        var id = Guid.NewGuid();
+
+        await using (var first = store.LightweightSession("one"))
+        {
+            first.Store(new Sighting { Id = id, Species = "Manta" });
+            await first.SaveChangesAsync(Token);
+        }
+
+        await using var second = store.LightweightSession("two");
+        (await second.LoadAsync<Sighting>(id, Token)).ShouldBeNull();
+    }
+
+    /// <remarks>
+    ///     The seed list writes tenants that should exist from the first start, upserted rather than
+    ///     inserted so a changed connection string is corrected on the next boot.
+    /// </remarks>
+    [Fact]
+    public async Task seeded_tenants_are_written_on_the_first_read()
+    {
+        await using var store = StoreFor(out var source, x =>
+        {
+            x.SeedDatabases.Register("seeded-one", ConnectionStringFor("seeded-one"));
+            x.SeedDatabases.Register("seeded-two", ConnectionStringFor("seeded-two"));
+        });
+
+        var all = await source.AllAsync(Token);
+
+        all.Select(x => x.TenantId).Where(x => x != StorageConstants.DefaultTenantId)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ShouldBe(["seeded-one", "seeded-two"]);
+    }
+
+    // ---- the runtime lifecycle, and the deletion stance ----
+
+    /// <remarks>
+    ///     The headline: a tenant registered while the store is running is usable by the very next
+    ///     session, with no refresh and no restart, because <c>AddTenantAsync</c> caches as it writes.
+    /// </remarks>
+    [Fact]
+    public async Task a_tenant_added_at_runtime_is_usable_immediately()
+    {
+        await using var store = StoreFor(out var source);
+
+        Should.Throw<UnknownTenantException>(() => store.LightweightSession("late"));
+
+        await source.AddTenantAsync("late", ConnectionStringFor("late"), Token);
+
+        await using var session = store.LightweightSession("late");
+        session.Store(new Sighting { Id = Guid.NewGuid(), Species = "Wahoo" });
+        await session.SaveChangesAsync(Token);
+    }
+
+    /// <remarks>
+    ///     <b>Suspension, never deletion.</b> The tenant stops resolving and its file is untouched —
+    ///     which is the whole of Fisher's deprovisioning stance, and the reason the last assertion is
+    ///     here rather than implied.
+    /// </remarks>
+    [Fact]
+    public async Task suspending_a_tenant_refuses_sessions_and_leaves_its_file_alone()
+    {
+        await using var store = StoreFor(out var source);
+        await source.AddTenantAsync("acme", ConnectionStringFor("acme"), Token);
+
+        await using (var session = store.LightweightSession("acme"))
+        {
+            session.Store(new Sighting { Id = Guid.NewGuid(), Species = "Manta" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await source.SuspendTenantAsync("acme", Token);
+
+        // Suspended, not forgotten: a distinct exception, because "switched off" and "never heard of
+        // it" are different operational situations.
+        Should.Throw<DisabledTenantException>(() => store.LightweightSession("acme"));
+
+        File.Exists(PathFor("acme")).ShouldBeTrue();
+        (await TenantRowCountAsync()).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task resuming_a_suspended_tenant_brings_it_back_with_its_data()
+    {
+        await using var store = StoreFor(out var source);
+        await source.AddTenantAsync("acme", ConnectionStringFor("acme"), Token);
+
+        var id = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession("acme"))
+        {
+            session.Store(new Sighting { Id = id, Species = "Manta" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await source.SuspendTenantAsync("acme", Token);
+        (await source.AllSuspendedAsync(Token)).ShouldBe(["acme"]);
+
+        await source.ResumeTenantAsync("acme", Token);
+        (await source.AllSuspendedAsync(Token)).ShouldBeEmpty();
+
+        await using var query = store.LightweightSession("acme");
+        (await query.LoadAsync<Sighting>(id, Token)).ShouldNotBeNull();
+    }
+
+    /// <remarks>
+    ///     ⚠️ <b>The decision the dialect contract says the two shipped stores disagree about.</b>
+    ///     Polecat's <c>MERGE</c> re-enables on upsert; Marten's <c>on conflict</c> does not, and
+    ///     Fisher follows Marten — re-enabling as a side effect of correcting a connection string
+    ///     would silently undo a deliberate suspension.
+    /// </remarks>
+    [Fact]
+    public async Task re_adding_a_suspended_tenant_does_not_resume_it()
+    {
+        await using var store = StoreFor(out var source);
+        await source.AddTenantAsync("acme", ConnectionStringFor("acme"), Token);
+        await source.SuspendTenantAsync("acme", Token);
+
+        await source.AddTenantAsync("acme", ConnectionStringFor("acme"), Token);
+
+        Should.Throw<DisabledTenantException>(() => store.LightweightSession("acme"));
+        (await source.AllSuspendedAsync(Token)).ShouldBe(["acme"]);
+    }
+
+    /// <remarks>
+    ///     <b>Forgetting removes the registry row and never the file.</b> The lifted Weasel base already
+    ///     draws the line in the same place — its <c>DeleteDatabaseRecordAsync</c> leaves the tenant's
+    ///     own database completely alone — so Fisher's standing rule cost no guard. The data is still on
+    ///     disk for an operator to archive, and re-registering the tenant finds it.
+    /// </remarks>
+    [Fact]
+    public async Task forgetting_a_tenant_removes_its_record_and_leaves_its_data_on_disk()
+    {
+        await using var store = StoreFor(out var source);
+        await source.AddTenantAsync("acme", ConnectionStringFor("acme"), Token);
+
+        var id = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession("acme"))
+        {
+            session.Store(new Sighting { Id = id, Species = "Manta" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await source.ForgetTenantAsync("acme", Token);
+
+        (await TenantRowCountAsync()).ShouldBe(0);
+        Should.Throw<UnknownTenantException>(() => store.LightweightSession("acme"));
+
+        // The file is there, and so is everything in it.
+        File.Exists(PathFor("acme")).ShouldBeTrue();
+
+        await source.AddTenantAsync("acme", ConnectionStringFor("acme"), Token);
+
+        await using var query = store.LightweightSession("acme");
+        (await query.LoadAsync<Sighting>(id, Token)).ShouldNotBeNull();
+    }
+
+    /// <remarks>
+    ///     There is deliberately no member on the source that deletes a tenant's database file, and
+    ///     nothing about deprovisioning one goes near it. Pinned by reflection rather than by prose,
+    ///     because "we do not delete" is exactly the kind of rule a later convenience method breaks
+    ///     without anybody noticing.
+    /// </remarks>
+    [Fact]
+    public void the_source_offers_no_way_to_delete_a_tenants_database()
+    {
+        var suspicious = typeof(MasterTableTenantSource)
+            .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+            .Select(x => x.Name)
+            .Where(x => x.Contains("Drop", StringComparison.OrdinalIgnoreCase)
+                        || (x.Contains("Delete", StringComparison.OrdinalIgnoreCase)
+                            && !x.Contains("Record", StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+
+        suspicious.ShouldBeEmpty();
+    }
+
+    // ---- across processes ----
+
+    /// <remarks>
+    ///     <b>The trade the synchronous session path imposes, stated rather than hidden.</b>
+    ///     <c>ITenancy.DatabaseFor</c> is reached from <c>OpenSession</c> and has no <c>await</c> to
+    ///     offer, so a tenant this instance has never read does not resolve — Marten answers the same
+    ///     question with <c>GetAwaiter().GetResult()</c> and Fisher will not. A refresh is what makes it
+    ///     visible, and the daemon does one every minute.
+    /// </remarks>
+    [Fact]
+    public async Task a_tenant_added_by_another_process_appears_on_the_next_refresh()
+    {
+        await using var writer = StoreFor(out var writing);
+        await using var reader = StoreFor(out var reading);
+
+        await writing.AddTenantAsync("elsewhere", ConnectionStringFor("elsewhere"), Token);
+
+        // The second store has not read the table since, so it does not know.
+        reading.TryFind("elsewhere", out _).ShouldBeFalse();
+
+        await reading.RefreshAsync(Token);
+
+        reading.TryFind("elsewhere", out var found).ShouldBeTrue();
+        found.IsActive.ShouldBeTrue();
+
+        await using var session = reader.LightweightSession("elsewhere");
+        session.Store(new Sighting { Id = Guid.NewGuid(), Species = "Opah" });
+        await session.SaveChangesAsync(Token);
+    }
+
+    /// <remarks>
+    ///     A suspension made elsewhere has to arrive as a suspension, not as an absence — otherwise the
+    ///     second process reports <c>UnknownTenantException</c> for a tenant that is registered and
+    ///     merely switched off. Weasel's base collapses the two on purpose (a disabled tenant is not
+    ///     routable, which is what disabling means); Fisher keeps them apart because fisher#58 decided
+    ///     they are different operational situations.
+    /// </remarks>
+    [Fact]
+    public async Task a_suspension_made_elsewhere_arrives_as_a_suspension()
+    {
+        await using var writer = StoreFor(out var writing);
+        await using var reader = StoreFor(out var reading);
+
+        await writing.AddTenantAsync("acme", ConnectionStringFor("acme"), Token);
+        await reading.RefreshAsync(Token);
+
+        await writing.SuspendTenantAsync("acme", Token);
+        await reading.RefreshAsync(Token);
+
+        reading.TryFind("acme", out var found).ShouldBeTrue();
+        found.IsActive.ShouldBeFalse();
+
+        Should.Throw<DisabledTenantException>(() => reader.LightweightSession("acme"));
+    }
+
+    // ---- the store-level operations ----
+
+    /// <remarks>
+    ///     <c>ApplyAllConfiguredChangesToDatabaseAsync</c> refreshes the tenancy first, so it reaches
+    ///     every registered tenant's file rather than only the ones a session happened to touch — the
+    ///     omission <c>db-apply</c> had to close for the directory source, met again here.
+    /// </remarks>
+    [Fact]
+    public async Task applying_the_schema_reaches_every_registered_tenant()
+    {
+        await using (var first = StoreFor(out var seeding))
+        {
+            await seeding.AddTenantAsync("one", ConnectionStringFor("one"), Token);
+            await seeding.AddTenantAsync("two", ConnectionStringFor("two"), Token);
+        }
+
+        await using var store = StoreFor(out _);
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        store.Tenancy.AllDatabases().Select(x => x.Identifier)
+            .Where(x => x != StorageConstants.DefaultTenantId)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ShouldBe(["one", "two"]);
+
+        (await TableExistsInAsync(ConnectionStringFor("one"), "fi_events")).ShouldBeTrue();
+        (await TableExistsInAsync(ConnectionStringFor("two"), "fi_events")).ShouldBeTrue();
+    }
+
+    /// <remarks>
+    ///     A suspended tenant is not migrated, because it is not routable — and refreshing must not
+    ///     build a database for it, which would put a file back into rotation the operator switched
+    ///     off.
+    /// </remarks>
+    [Fact]
+    public async Task a_suspended_tenant_is_left_out_of_the_stores_databases()
+    {
+        await using var store = StoreFor(out var source);
+        await source.AddTenantAsync("one", ConnectionStringFor("one"), Token);
+        await source.AddTenantAsync("two", ConnectionStringFor("two"), Token);
+        await source.SuspendTenantAsync("two", Token);
+
+        await using var fresh = StoreFor(out _);
+        await fresh.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        fresh.Tenancy.AllDatabases().Select(x => x.Identifier)
+            .Where(x => x != StorageConstants.DefaultTenantId)
+            .ShouldBe(["one"]);
+    }
+
+    // ---- the store-agnostic admin surface, inherited from the lift ----
+
+    /// <remarks>
+    ///     <c>IDynamicTenantSource&lt;string&gt;</c> and <c>IMasterTableMultiTenancy</c> come free from
+    ///     the lifted base, which is a surface Fisher had no equivalent of before — it is how a
+    ///     monitoring console administers tenants without naming the store. Worth pinning because it is
+    ///     inherited rather than written, so nothing local would fail if a future base stopped
+    ///     declaring it.
+    /// </remarks>
+    [Fact]
+    public async Task the_shared_dynamic_tenant_source_surface_is_implemented()
+    {
+        await using var store = StoreFor(out var source);
+
+        var dynamicSource = source.ShouldBeAssignableTo<IDynamicTenantSource<string>>()!;
+
+        await dynamicSource.AddTenantAsync("acme", ConnectionStringFor("acme"));
+        (await dynamicSource.FindAsync("acme")).ShouldNotBeNullOrEmpty();
+
+        // Deliberately the tenant ids and not the connection strings, which would put credentials on
+        // an admin dashboard.
+        dynamicSource.AllActive().ShouldContain("acme");
+
+        await dynamicSource.DisableTenantAsync("acme");
+        (await dynamicSource.AllDisabledAsync()).ShouldBe(["acme"]);
+
+        // Disabling evicts, and enabling deliberately does not refill — the base loads lazily, which
+        // is also what makes enabling a tenant that was never added a no-op rather than a phantom.
+        dynamicSource.AllActive().ShouldNotContain("acme");
+
+        await dynamicSource.EnableTenantAsync("acme");
+        (await dynamicSource.AllDisabledAsync()).ShouldBeEmpty();
+
+        await dynamicSource.RefreshAsync();
+        dynamicSource.AllActive().ShouldContain("acme");
+    }
+
+    // ---- helpers ----
+
+    private Task<bool> TableExistsAsync(string name) => TableExistsInAsync(_registry.ConnectionString, name);
+
+    private async Task<bool> TableExistsInAsync(string connectionString, string name)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "select count(*) from sqlite_master where type = 'table' and name = $name";
+        command.Parameters.AddWithValue("$name", name);
+
+        return Convert.ToInt64(await command.ExecuteScalarAsync(Token)) > 0;
+    }
+
+    /// <remarks>
+    ///     Excludes the default tenant, which every store in this class seeds so that it can be built
+    ///     at all — see StoreFor.
+    /// </remarks>
+    private async Task<long> TenantRowCountAsync()
+    {
+        await using var connection = new SqliteConnection(_registry.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "select count(*) from fi_tenants where tenant_id <> $default";
+        command.Parameters.AddWithValue("$default", StorageConstants.DefaultTenantId);
+
+        return Convert.ToInt64(await command.ExecuteScalarAsync(Token));
+    }
+}

--- a/src/Fisher/Storage/ITenancy.cs
+++ b/src/Fisher/Storage/ITenancy.cs
@@ -194,7 +194,27 @@ public sealed class DynamicTenancy : ITenancy
     {
         _options = options;
         _source = source;
+
+        // Without this a suspension only takes effect for a tenant nothing has resolved yet, because
+        // DatabaseFor answers from the cache below and never asks the source again — see
+        // ITenantSource.OnTenantRevoked. Disposed synchronously rather than through
+        // ForgetTenantAsync's async path, because a source revokes from a synchronous method; the
+        // difference is only that a pooled connection's close is not awaited, and clearing the pool
+        // leaves a checked-out connection working either way.
+        source.OnTenantRevoked = tenantId =>
+        {
+            if (_databases.TryRemove(tenantId, out var database))
+            {
+                database.Dispose();
+            }
+        };
     }
+
+    /// <summary>
+    ///     The source this tenancy asks. Exposed so an application can reach a source it did not keep a
+    ///     reference to — <see cref="MasterTableTenantSource" />'s runtime lifecycle in particular.
+    /// </summary>
+    public ITenantSource Source => _source;
 
     public DatabaseCardinality Cardinality => DatabaseCardinality.DynamicMultiple;
 
@@ -227,7 +247,9 @@ public sealed class DynamicTenancy : ITenancy
                 $"This store's ITenantSource does not know the default tenant '{StorageConstants.DefaultTenantId}', "
                 + "and a database-per-tenant store has no store-level file to fall back on — so there is "
                 + "nothing for an operation that names no tenant to run against. Register it "
-                + $"(source.Add(\"{StorageConstants.DefaultTenantId}\", connectionString)), or use "
+                + $"(source.Add(\"{StorageConstants.DefaultTenantId}\", connectionString)), seed it "
+                + "under MultiTenantedDatabasesInRegistry(...) with "
+                + "SeedDatabases.RegisterDefault(connectionString), or use "
                 + "MultiTenantedDatabasesInDirectory(...), whose convention answers for any tenant id.");
         }
     }

--- a/src/Fisher/Storage/ITenantSource.cs
+++ b/src/Fisher/Storage/ITenantSource.cs
@@ -54,6 +54,36 @@ public interface ITenantSource
     ///     that have appeared since.
     /// </summary>
     ValueTask<IReadOnlyList<TenantRegistration>> AllAsync(CancellationToken token = default);
+
+    /// <summary>
+    ///     Set by <see cref="DynamicTenancy" />, for a source to call when a tenant stops being
+    ///     routable — suspended, or dropped from the source (fisher#213).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Without it, suspending a tenant the store has already resolved does nothing.</b>
+    ///         <see cref="DynamicTenancy" /> caches a <see cref="FisherDatabase" /> per tenant and
+    ///         <see cref="ITenancy.DatabaseFor" /> answers from that cache, so a suspension used to take
+    ///         effect only for a tenant nothing had opened yet — which is the opposite of what an
+    ///         operator switching a tenant off means, and it made "restart the process" part of the
+    ///         procedure.
+    ///     </para>
+    ///     <para>
+    ///         <b>A callback rather than a check on the resolution path</b>, because
+    ///         <see cref="TryFind" /> is on the session-open hot path and the convention source builds
+    ///         a connection string on every call — consulting it per session would be a real cost to
+    ///         make a rare event immediate. Revocation is rare, so it pays for itself.
+    ///     </para>
+    ///     <para>
+    ///         Default-implemented as a no-op pair, so a source written before this — or one that
+    ///         genuinely never revokes — needs no change.
+    ///     </para>
+    /// </remarks>
+    Action<string>? OnTenantRevoked
+    {
+        get => null;
+        set { }
+    }
 }
 
 /// <summary>
@@ -85,10 +115,21 @@ public sealed class DirectoryTenantSource : ITenantSource
         Directory.CreateDirectory(directory);
     }
 
+    /// <inheritdoc />
+    public Action<string>? OnTenantRevoked { get; set; }
+
     /// <summary>
     ///     Suspend a tenant. Its file is untouched; sessions for it are refused until it is resumed.
     /// </summary>
-    public void Suspend(string tenantId) => _suspended[tenantId] = true;
+    /// <remarks>
+    ///     Takes effect immediately, including for a tenant the store has already resolved — see
+    ///     <see cref="ITenantSource.OnTenantRevoked" />.
+    /// </remarks>
+    public void Suspend(string tenantId)
+    {
+        _suspended[tenantId] = true;
+        OnTenantRevoked?.Invoke(tenantId);
+    }
 
     /// <inheritdoc cref="Suspend" />
     public void Resume(string tenantId) => _suspended.TryRemove(tenantId, out _);
@@ -150,13 +191,27 @@ public sealed class InMemoryTenantSource : ITenantSource
         if (_tenants.TryGetValue(tenantId, out var existing))
         {
             _tenants[tenantId] = existing with { IsActive = isActive };
+
+            if (!isActive)
+            {
+                OnTenantRevoked?.Invoke(tenantId);
+            }
         }
     }
 
     /// <summary>
     ///     Stop resolving a tenant. Its file is not deleted — see <see cref="ITenantSource" />.
     /// </summary>
-    public void Remove(string tenantId) => _tenants.TryRemove(tenantId, out _);
+    public void Remove(string tenantId)
+    {
+        if (_tenants.TryRemove(tenantId, out _))
+        {
+            OnTenantRevoked?.Invoke(tenantId);
+        }
+    }
+
+    /// <inheritdoc />
+    public Action<string>? OnTenantRevoked { get; set; }
 
     public bool TryFind(string tenantId, out TenantRegistration registration)
         => _tenants.TryGetValue(tenantId, out registration!);

--- a/src/Fisher/Storage/MasterTableTenantSource.cs
+++ b/src/Fisher/Storage/MasterTableTenantSource.cs
@@ -1,0 +1,326 @@
+using System.Collections.Concurrent;
+using JasperFx;
+using Weasel.Core.MultiTenancy;
+using Weasel.Sqlite;
+
+namespace Fisher.Storage;
+
+/// <summary>
+///     Tenants read from a control table in a <b>tenant-registry database</b> — Marten's master-table
+///     tenancy, over Weasel's lifted runtime (fisher#213, over weasel#567).
+/// </summary>
+/// <remarks>
+///     <para>
+///         The fourth way to say database-per-tenant, and the first where the tenant set is
+///         <em>durable, shared and editable at runtime</em>. <see cref="DirectoryTenantSource" />
+///         resolves any tenant id at all, which is the point of it and also why it can never say "that
+///         is not one of ours"; its connection strings are a convention rather than data.
+///         <see cref="InMemoryTenantSource" /> holds the set in one process's memory, so nothing
+///         survives a restart and two nodes disagree. A registry file is the analogue of Marten's
+///         master table for a store whose tenants are files: one small SQLite database naming every
+///         tenant and where its data lives.
+///     </para>
+///     <para>
+///         <b>What Fisher supplies is a dialect and this adapter.</b> The control-table contract, the
+///         cache, provisioning it exactly once, the seed list and the entire
+///         <see cref="JasperFx.MultiTenancy.IDynamicTenantSource{T}" /> lifecycle are
+///         <see cref="MasterTableTenancyBase{TDatabase,TDataSource}" />'s — the runtime Marten's
+///         <c>MasterTableTenancy</c> and Polecat's each carried a copy of until weasel#567 lifted it
+///         over a <see cref="System.Data.Common.DbDataSource" /> seam. <see cref="SqliteDataSource" />
+///         <em>is</em> a <c>DbDataSource</c>, so the seam fits with nothing adapted.
+///     </para>
+///     <para>
+///         ⚠️ <b>The base is closed over <see cref="TenantRegistration" />, not over
+///         <see cref="FisherDatabase" />, and that is the whole design.</b> The base's own remarks say
+///         everything it does with a <c>TDatabase</c> is cache it, hand it back and dispose it — so
+///         closing it over the registration makes its cache Fisher's <em>synchronous snapshot of the
+///         control table</em>, which is exactly what <see cref="ITenantSource.TryFind" /> needs.
+///         Closing it over <see cref="FisherDatabase" /> instead would have put a second database cache
+///         beside <see cref="DynamicTenancy" />'s — two <c>SqliteDataSource</c>s and two connection
+///         pools per tenant — and would have forced <see cref="ITenancy.DatabaseFor" /> to resolve
+///         asynchronously.
+///     </para>
+///     <para>
+///         ⚠️ <b>Which is the one thing Marten's version does that Fisher must not copy.</b>
+///         <c>MasterTableTenancy.GetTenant(string)</c> is
+///         <c>tryFindTenantDatabase(...).GetAwaiter().GetResult()</c>. <c>DatabaseFor</c> is reached
+///         from <c>OpenSession</c>, which has no <c>await</c> to offer, and the whole reason
+///         <see cref="ITenantSource.TryFind" /> is synchronous and <see cref="ITenantSource.AllAsync" />
+///         is not is to keep sync-over-async off the session path. So the trade is stated rather than
+///         hidden: <b>a tenant this process has not read yet does not resolve.</b> One added through
+///         <see cref="AddTenantAsync" /> is cached eagerly and usable immediately; one added to the
+///         registry by <em>another</em> process appears on the next refresh — which the async daemon
+///         does every minute, <c>ApplyAllConfiguredChangesToDatabaseAsync</c>, <c>db-apply</c> and
+///         every other <c>DynamicTenancy.RefreshAsync</c> caller do on demand, and
+///         <see cref="RefreshAsync" /> does when an application wants it now.
+///     </para>
+///     <para>
+///         <b>Deprovisioning is disable or forget, never delete</b> — Fisher's standing rule, and the
+///         lifted base already agrees with it. <see cref="DisableTenantAsync" /> flips a flag and
+///         <see cref="RemoveTenantAsync" /> deletes the control-table <em>row</em>; neither touches the
+///         tenant's <c>.db</c> file, which is the cheapest deprovisioning any Critter Stack store could
+///         offer and the most irreversible, and which Fisher cannot know is backed up. There is
+///         deliberately no member here that removes one. To erase a tenant's <em>rows</em> and keep the
+///         file, use <c>store.Advanced.DeleteAllTenantDataAsync</c>.
+///     </para>
+/// </remarks>
+public sealed class MasterTableTenantSource
+    : MasterTableTenancyBase<TenantRegistration, SqliteDataSource>, ITenantSource
+{
+    private readonly StoreOptions _options;
+
+    // The connection string last seen for each tenant, so a *disabled* tenant can still be described.
+    // The control table's reads are scoped to enabled rows by contract (see IMasterTenantTableDialect
+    // .SelectConnectionString), so once a tenant is disabled there is no supported way to read its
+    // connection string back — and nothing needs it, because DatabaseFor refuses a disabled tenant
+    // before it would use one. This is what keeps TryFind able to answer "disabled" rather than
+    // "unknown" for a tenant this process has seen.
+    private readonly ConcurrentDictionary<string, string> _lastKnown =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private volatile HashSet<string> _disabled = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public Action<string>? OnTenantRevoked { get; set; }
+
+    // The seed list, readable without I/O. See TryFind for why that matters.
+    private readonly Dictionary<string, string> _seeded;
+
+    internal MasterTableTenantSource(StoreOptions options,
+        MasterTableTenancyOptions<SqliteDataSource> tenancyOptions)
+        : base(tenancyOptions, SqliteMasterTenantTableDialect.TableName,
+            SqliteMasterTenantTableDialect.Instance, StringComparer.OrdinalIgnoreCase)
+    {
+        _options = options;
+        _seeded = tenancyOptions.SeedDatabases.AllActiveByTenant()
+            .ToDictionary(x => x.TenantId, x => x.Value, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    ///     The registry's own connection string, or the data source it was handed.
+    /// </summary>
+    /// <remarks>
+    ///     Its PRAGMAs are the store's, so a registry file gets the same WAL, busy timeout and foreign
+    ///     key settings every other Fisher database does — it is a SQLite file taking a write lock like
+    ///     any other, and an operator adding a tenant while the store is running is a writer.
+    /// </remarks>
+    protected override SqliteDataSource BuildDataSource(string connectionString)
+        => new(connectionString, _options.PragmaSettings);
+
+    /// <remarks>
+    ///     A row, not a database. See the class remarks for why the base is closed over this type.
+    /// </remarks>
+    protected override TenantRegistration BuildDatabase(string tenantId, string connectionString)
+    {
+        _lastKnown[tenantId] = connectionString;
+
+        return new TenantRegistration(tenantId, connectionString);
+    }
+
+    /// <summary>
+    ///     Every control-plane read and write runs through the store's Polly pipeline.
+    /// </summary>
+    /// <remarks>
+    ///     The registry is a SQLite file and SQLite takes one writer per file, so a tenant being added
+    ///     while another node reads the table is exactly the <c>SQLITE_BUSY</c> the pipeline exists
+    ///     for — the same reason every other database call in Fisher goes through it. Polecat overrides
+    ///     this hook for the same purpose; Marten leaves it on the default.
+    /// </remarks>
+    protected override Task<T> ExecuteAsync<T>(Func<CancellationToken, Task<T>> operation,
+        CancellationToken token)
+        => _options.ResiliencePipeline.ExecuteAsync(
+            async ct => await operation(ct).ConfigureAwait(false), token).AsTask();
+
+    // ---- ITenantSource ----
+
+    /// <inheritdoc />
+    /// <remarks>
+    ///     <para>
+    ///         Answered from the base's cache, with no I/O — which is what the session path requires.
+    ///         A tenant this process has never read is reported as <b>unknown</b>; see the class
+    ///         remarks for when that can happen and what refreshes it.
+    ///     </para>
+    ///     <para>
+    ///         <b>A disabled tenant is reported as inactive rather than as unknown</b>, so
+    ///         <see cref="DynamicTenancy" /> raises <see cref="DisabledTenantException" /> for it.
+    ///         Weasel's base deliberately collapses the two — a disabled tenant is not routable, which
+    ///         is what disabling means — and its own remarks say a caller turning that into an
+    ///         exception should decide which. Fisher decided in fisher#58: "switched off" and "never
+    ///         heard of it" are different operational situations and an application handling one should
+    ///         not have to guess which it got.
+    ///     </para>
+    ///     <para>
+    ///         ⚠️ <b>The seed list is the last resort, and it is what makes the default tenant work at
+    ///         all.</b> <see cref="DynamicTenancy.Default" /> is read while the store is being *built*,
+    ///         before anything could have read the control table — so a registry naming its tenants
+    ///         only in the table cannot answer for <c>*DEFAULT*</c> and the store refuses to construct.
+    ///         A seeded tenant is configuration rather than data: it is known synchronously, and it is
+    ///         upserted into the table on the first refresh, so the two never disagree for long.
+    ///         <c>SeedDatabases.RegisterDefault(connectionString)</c> is therefore how a registry store
+    ///         gets a default tenant. A seed is checked <em>after</em> the disabled set, so suspending
+    ///         a seeded tenant still suspends it.
+    ///     </para>
+    /// </remarks>
+    public bool TryFind(string tenantId, out TenantRegistration registration)
+    {
+        var cached = FindCachedDatabase(tenantId);
+        if (cached is not null)
+        {
+            // Disabling evicts from the base's cache, so reaching here means enabled — but check
+            // anyway rather than relying on eviction order, since the two are refreshed separately.
+            registration = _disabled.Contains(tenantId) ? cached with { IsActive = false } : cached;
+
+            return true;
+        }
+
+        if (_disabled.Contains(tenantId))
+        {
+            registration = new TenantRegistration(tenantId,
+                _lastKnown.GetValueOrDefault(tenantId, string.Empty), IsActive: false);
+
+            return true;
+        }
+
+        if (_seeded.TryGetValue(tenantId, out var seeded))
+        {
+            registration = new TenantRegistration(tenantId, Options.CorrectConnectionString(seeded));
+
+            return true;
+        }
+
+        registration = null!;
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    ///     Reads the control table — the enabled rows through
+    ///     <see cref="MasterTableTenancyBase{TDatabase,TDataSource}.BuildDatabasesAsync" />, which also
+    ///     provisions the table on first use and writes the seed list, and the disabled ids beside them
+    ///     so a suspended tenant stays distinguishable from an unknown one.
+    /// </remarks>
+    public async ValueTask<IReadOnlyList<TenantRegistration>> AllAsync(CancellationToken token = default)
+    {
+        var enabled = await BuildDatabasesAsync(token).ConfigureAwait(false);
+        var disabled = await AllDisabledAsync(token).ConfigureAwait(false);
+
+        _disabled = new HashSet<string>(disabled, StringComparer.OrdinalIgnoreCase);
+
+        if (disabled.Count == 0)
+        {
+            return enabled;
+        }
+
+        // Reported alongside, and inactive, so a caller enumerating tenants sees a suspended one exists
+        // rather than concluding it was removed. DynamicTenancy.RefreshAsync skips inactive entries, so
+        // no database is built for one.
+        return enabled
+            .Concat(disabled.Select(id => new TenantRegistration(id,
+                _lastKnown.GetValueOrDefault(id, string.Empty), IsActive: false)))
+            .ToList();
+    }
+
+    /// <summary>
+    ///     Re-read the control table now, rather than waiting for the daemon's poll.
+    /// </summary>
+    /// <remarks>
+    ///     For an application that added or disabled a tenant through a <em>different</em> process and
+    ///     wants this one to see it immediately. A tenant added through <see cref="AddTenantAsync" />
+    ///     on this instance needs nothing — it is cached as it is written.
+    /// </remarks>
+    public async Task RefreshAsync(CancellationToken token = default)
+        => await AllAsync(token).ConfigureAwait(false);
+
+    // ---- the runtime lifecycle, named the way an application reads it ----
+
+    /// <summary>
+    ///     Register a tenant, or correct an existing tenant's connection string.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The tenant is cached as it is written, so the very next session for it resolves — no
+    ///         refresh, no restart. Its file and schema are created the first time anything connects
+    ///         to it, exactly as under <see cref="DirectoryTenantSource" />, which is what makes
+    ///         provisioning a tenant a file plus a migration here rather than a <c>CREATE DATABASE</c>.
+    ///     </para>
+    ///     <para>
+    ///         ⚠️ <b>This does not re-enable a suspended tenant.</b> The upsert leaves the disabled
+    ///         flag alone — Marten's does the same and Polecat's <c>MERGE</c> does not, and the shared
+    ///         dialect contract leaves the choice to the dialect for exactly that reason. Re-enabling
+    ///         as a side effect of correcting a connection string would silently undo a deliberate
+    ///         suspension; <see cref="EnableTenantAsync" /> is one call away and says what it means.
+    ///     </para>
+    /// </remarks>
+    public Task AddTenantAsync(string tenantId, string connectionString, CancellationToken token = default)
+        => AddDatabaseRecordAsync(tenantId, connectionString, token);
+
+    /// <summary>
+    ///     Suspend a tenant. Sessions for it are refused until it is resumed; <b>its file is
+    ///     untouched.</b>
+    /// </summary>
+    /// <remarks>
+    ///     The base evicts the tenant from its cache, which is what makes suspension take effect
+    ///     without a refresh — a cached row would otherwise go on resolving a tenant that is switched
+    ///     off. <see cref="DynamicTenancy" /> still holds the tenant's <see cref="FisherDatabase" />;
+    ///     call <c>ForgetTenantAsync</c> to release its pooled connections as well.
+    /// </remarks>
+    public async Task SuspendTenantAsync(string tenantId, CancellationToken token = default)
+    {
+        await DisableTenantAsync(tenantId, token).ConfigureAwait(false);
+
+        _disabled = new HashSet<string>(_disabled, StringComparer.OrdinalIgnoreCase) { tenantId };
+
+        // The base evicts from its own cache; this is what evicts the tenant's FisherDatabase, so the
+        // suspension takes effect for a tenant the store has already opened a session for.
+        OnTenantRevoked?.Invoke(tenantId);
+    }
+
+    /// <summary>Resume a suspended tenant. It resolves again on next access.</summary>
+    public async Task ResumeTenantAsync(string tenantId, CancellationToken token = default)
+    {
+        await EnableTenantAsync(tenantId, token).ConfigureAwait(false);
+
+        var next = new HashSet<string>(_disabled, StringComparer.OrdinalIgnoreCase);
+        next.Remove(tenantId);
+        _disabled = next;
+
+        // Enabling does not refill the cache — the base loads lazily, which is also what makes
+        // enabling a tenant that was never added a no-op rather than a phantom. Refresh so the
+        // synchronous TryFind can answer for it again without waiting for the daemon's poll.
+        await RefreshAsync(token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Remove a tenant's <b>registry row</b>. <b>Its database file is not deleted.</b>
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Fisher deprovisions and never deletes, and this is that rule at the registry: the row
+    ///         goes, the tenant stops resolving, and the file stays where an operator can archive it,
+    ///         copy it, or remove it themselves. Deleting it here would be the cheapest deprovisioning
+    ///         of any Critter Stack store and the most irreversible, and Fisher cannot know whether it
+    ///         is backed up.
+    ///     </para>
+    ///     <para>
+    ///         The lifted base already draws the line in the same place — its
+    ///         <c>DeleteDatabaseRecordAsync</c> says "the tenant's own database is left completely
+    ///         alone" — so adopting it cost no guard.
+    ///     </para>
+    /// </remarks>
+    public async Task ForgetTenantAsync(string tenantId, CancellationToken token = default)
+    {
+        await DeleteDatabaseRecordAsync(tenantId, token).ConfigureAwait(false);
+
+        var next = new HashSet<string>(_disabled, StringComparer.OrdinalIgnoreCase);
+        next.Remove(tenantId);
+        _disabled = next;
+        _lastKnown.TryRemove(tenantId, out _);
+
+        OnTenantRevoked?.Invoke(tenantId);
+    }
+
+    /// <summary>The tenant ids currently suspended.</summary>
+    public Task<IReadOnlyList<string>> AllSuspendedAsync(CancellationToken token = default)
+        => AllDisabledAsync(token);
+}

--- a/src/Fisher/Storage/SqliteMasterTenantTableDialect.cs
+++ b/src/Fisher/Storage/SqliteMasterTenantTableDialect.cs
@@ -1,0 +1,110 @@
+using Weasel.Core.MultiTenancy;
+using Weasel.Sqlite;
+
+namespace Fisher.Storage;
+
+/// <summary>
+///     The SQL half of Fisher's tenant registry — Weasel's <see cref="IMasterTenantTableDialect" />
+///     for SQLite (fisher#213, over weasel#567).
+/// </summary>
+/// <remarks>
+///     <para>
+///         Everything that is not dialect-specific — the cache, the guarded provisioning, the runtime
+///         add/disable/enable/remove lifecycle, the seed list — is
+///         <see cref="MasterTableTenancyBase{TDatabase,TDataSource}" />'s, which weasel#567 lifted out
+///         of Marten's <c>MasterTableTenancy</c> (515 lines) and Polecat's (434). This is the part that
+///         has to know that SQLite spells an upsert <c>on conflict … do update</c> and a boolean
+///         <c>0</c> / <c>1</c>.
+///     </para>
+///     <para>
+///         <b>The table name folds the logical schema in, as every other Fisher table does.</b> SQLite
+///         has no schemas, so <see cref="StoreOptions.DatabaseSchemaName" /> becomes a table prefix
+///         (<see cref="FisherTableNaming" />) — <c>fi_tenants</c> under the default, and
+///         <c>reporting_fi_tenants</c> under a logical schema called <c>reporting</c>. Two logical
+///         stores sharing one registry file therefore keep separate registries, which is the same
+///         isolation the prefix buys everywhere else.
+///     </para>
+///     <para>
+///         ⚠️ <b><c>tenant_id</c> is declared <c>collate nocase</c>, and that is load-bearing rather
+///         than a nicety.</b> The base compares cache keys with the comparer it is handed and Fisher
+///         hands it <see cref="StringComparer.OrdinalIgnoreCase" />, matching
+///         <see cref="SeparateDatabaseTenancy" /> and <see cref="DynamicTenancy" />. SQLite's default
+///         collation is case-sensitive, so without this the cache and the table would disagree about
+///         whether <c>Acme</c> and <c>acme</c> are one tenant — a tenant that resolves through the
+///         cache and not through a lookup, which reads as an intermittent. NOCASE folds ASCII only,
+///         which is the same reach <see cref="StringComparer.OrdinalIgnoreCase" /> has for the
+///         identifier shapes a tenant id realistically takes.
+///     </para>
+///     <para>
+///         <b>The upsert does not clear the disabled flag</b>, which the dialect contract explicitly
+///         leaves to the dialect and on which the two shipped stores disagree — Polecat's <c>MERGE</c>
+///         re-enables, Marten's <c>on conflict</c> does not. Fisher follows Marten: re-enabling a
+///         suspended tenant as a side effect of correcting its connection string would silently undo a
+///         deliberate suspension, and <c>EnableTenantAsync</c> is one call away.
+///     </para>
+/// </remarks>
+internal sealed class SqliteMasterTenantTableDialect : IMasterTenantTableDialect
+{
+    public static SqliteMasterTenantTableDialect Instance { get; } = new();
+
+    /// <summary>
+    ///     The registry's unqualified table name before the logical schema is folded in.
+    /// </summary>
+    public const string TableName = FisherTableNaming.FamilyPrefix + "tenants";
+
+    /// <remarks>
+    ///     Never actually qualified — the schema is folded into the name, so what comes back is one
+    ///     quoted identifier. Same rule <c>FisherTableNaming.ObjectFor</c> follows for every other
+    ///     table, and the reason nothing Fisher emits ever renders as <c>schema.table</c>.
+    /// </remarks>
+    public string QualifiedTableName(string schemaName, string tableName)
+        => SchemaUtils.QuoteName(FisherTableNaming.UserTableName(schemaName, tableName));
+
+    /// <remarks>
+    ///     <c>if not exists</c> rather than a prior existence check, because the base's semaphore
+    ///     guards one process and a deployment has several.
+    /// </remarks>
+    public string CreateControlTable(string schemaName, string tableName, string qualifiedTableName)
+        => $"""
+            create table if not exists {qualifiedTableName} (
+                tenant_id text not null collate nocase primary key,
+                connection_string text not null,
+                disabled integer not null default 0
+            )
+            """;
+
+    public string SelectEnabledTenants(string qualifiedTableName)
+        => $"select tenant_id, connection_string from {qualifiedTableName} where disabled = 0";
+
+    public string SelectDisabledTenantIds(string qualifiedTableName)
+        => $"select tenant_id from {qualifiedTableName} where disabled <> 0";
+
+    /// <remarks>
+    ///     The <c>and disabled = 0</c> half is not optional: without it a suspended tenant resolves and
+    ///     opens sessions, which is the one thing suspending is for — silently, because everything else
+    ///     about the tenant is intact.
+    /// </remarks>
+    public string SelectConnectionString(string qualifiedTableName)
+        => $"select connection_string from {qualifiedTableName} where tenant_id = @id and disabled = 0";
+
+    public string UpsertTenant(string qualifiedTableName)
+        => $"""
+            insert into {qualifiedTableName} (tenant_id, connection_string, disabled)
+            values (@id, @connection, 0)
+            on conflict (tenant_id) do update set connection_string = excluded.connection_string
+            """;
+
+    /// <remarks>
+    ///     Removes the <em>record</em>. The tenant's database file is not touched — see
+    ///     <see cref="MasterTableTenantSource" /> for why Fisher will not delete one.
+    /// </remarks>
+    public string DeleteTenant(string qualifiedTableName)
+        => $"delete from {qualifiedTableName} where tenant_id = @id";
+
+    /// <inheritdoc cref="DeleteTenant" />
+    public string DeleteAllTenants(string qualifiedTableName)
+        => $"delete from {qualifiedTableName}";
+
+    public string SetTenantDisabled(string qualifiedTableName, bool disabled)
+        => $"update {qualifiedTableName} set disabled = {(disabled ? 1 : 0)} where tenant_id = @id";
+}

--- a/src/Fisher/StoreOptions.cs
+++ b/src/Fisher/StoreOptions.cs
@@ -10,6 +10,7 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Fetching;
 using JasperFx.Events.Tags;
 using Polly;
+using Weasel.Core.MultiTenancy;
 using Weasel.Core;
 
 namespace Fisher;
@@ -297,6 +298,63 @@ public class StoreOptions
     /// <param name="directory">Where the tenant files live, named <c>&lt;tenantId&gt;.db</c>.</param>
     public void MultiTenantedDatabasesInDirectory(string directory)
         => MultiTenantedDatabasesFrom(new Storage.DirectoryTenantSource(directory));
+
+    /// <summary>
+    ///     A database file per tenant, with the tenant set held in a <b>registry database</b> and
+    ///     editable at runtime (fisher#213). Marten's master-table tenancy, for a store whose tenants
+    ///     are files.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The durable form of <see cref="MultiTenantedDatabasesFrom" />: one small SQLite database
+    ///         holds a <c>fi_tenants</c> table naming every tenant and where its data lives, so the set
+    ///         survives a restart, is shared across processes, and can be added to, suspended, resumed
+    ///         and removed while the store runs. <see cref="Storage.DirectoryTenantSource" /> is the
+    ///         convention form and resolves any tenant id at all;
+    ///         <see cref="Storage.InMemoryTenantSource" /> lives in one process's memory. This is the
+    ///         one that is a record.
+    ///     </para>
+    ///     <para>
+    ///         The returned <see cref="Storage.MasterTableTenantSource" /> is the runtime handle —
+    ///         <c>AddTenantAsync</c>, <c>SuspendTenantAsync</c>, <c>ResumeTenantAsync</c>,
+    ///         <c>ForgetTenantAsync</c>. Keep it, or reach it later through
+    ///         <see cref="Storage.DynamicTenancy.Source" />.
+    ///     </para>
+    ///     <para>
+    ///         <b>Forgetting a tenant removes its registry row and never its file.</b> See
+    ///         <see cref="Storage.MasterTableTenantSource" /> and <see cref="Storage.ITenantSource" />
+    ///         for why Fisher deprovisions and does not delete.
+    ///     </para>
+    /// </remarks>
+    /// <param name="configure">
+    ///     The registry's own <c>ConnectionString</c> or <c>DataSource</c>, plus the shared knobs —
+    ///     <c>SchemaName</c>, <c>AutoCreate</c> and <c>SeedDatabases</c> for tenants that should exist
+    ///     from the first start.
+    /// </param>
+    public Storage.MasterTableTenantSource MultiTenantedDatabasesInRegistry(
+        Action<MasterTableTenancyOptions<Weasel.Sqlite.SqliteDataSource>> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var tenancyOptions =
+            new MasterTableTenancyOptions<Weasel.Sqlite.SqliteDataSource>(Weasel.Sqlite.SqliteProvider
+                .Instance);
+        configure(tenancyOptions);
+
+        var source = new Storage.MasterTableTenantSource(this, tenancyOptions);
+        MultiTenantedDatabasesFrom(source);
+
+        return source;
+    }
+
+    /// <inheritdoc cref="MultiTenantedDatabasesInRegistry(Action{MasterTableTenancyOptions{Weasel.Sqlite.SqliteDataSource}})" />
+    /// <param name="connectionString">The registry database's connection string.</param>
+    public Storage.MasterTableTenantSource MultiTenantedDatabasesInRegistry(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        return MultiTenantedDatabasesInRegistry(x => x.ConnectionString = connectionString);
+    }
 
     internal Storage.ITenantSource? TenantSource { get; private set; }
 


### PR DESCRIPTION
Closes #213.

Marten's **master-table tenancy** — tenant → connection string in a control table, with tenants added, suspended, resumed and removed at runtime — for a store whose tenants are files. The analogue of the master table here is a **tenant-registry database**: one small SQLite file holding `fi_tenants`.

```cs
var tenants = opts.MultiTenantedDatabasesInRegistry(x =>
{
    x.ConnectionString = "Data Source=/var/lib/app/tenants.db";
    x.SeedDatabases.RegisterDefault("Data Source=/var/lib/app/tenants/main.db");
});

await tenants.AddTenantAsync("acme", "Data Source=/var/lib/app/tenants/acme.db");
await tenants.SuspendTenantAsync("acme");
await tenants.ResumeTenantAsync("acme");
await tenants.ForgetTenantAsync("acme");
```

The fourth tenant source, and the first where the set is **a record**. The other three each fail to be one for a different reason: `DirectoryTenantSource` resolves any tenant id at all — the point of it, and also why it can never say "that is not one of ours"; `InMemoryTenantSource` lives in one process's memory; a fixed `MultiTenantedDatabases` set is configuration.

## Weasel's lift is adopted, not reimplemented

`Weasel.Sqlite.SqliteDataSource` **is** a `DbDataSource`, so `MasterTableTenancyBase<TDatabase, TDataSource>`'s seam fits with nothing adapted. The control-table contract, the resolved cache, provisioning-once, the seed list and the whole `IDynamicTenantSource<string>` lifecycle are Weasel's; Fisher writes an `IMasterTenantTableDialect` (~110 lines, mostly why-comments) and one adapter. Fisher also gets the store-agnostic admin surface — `IDynamicTenantSource<string>`, `IMasterTableMultiTenancy` — which it had no equivalent of, for free.

**⚠️ The base is closed over `TenantRegistration`, not over `FisherDatabase`, and that is the decision the whole node turns on.** The base's own remarks say everything it does with a `TDatabase` is cache it, hand it back and dispose it — so closing it over the *row* makes its cache Fisher's synchronous snapshot of the control table, which is exactly what `ITenantSource.TryFind` needs. The source then plugs into `DynamicTenancy` unchanged: the first-use migration, the daemon's tenant poller, `ForgetTenantAsync`, the cleaner, the CLI `IDatabaseSource` and `DisabledTenantException` all keep working with nothing added.

Closing it over `FisherDatabase` instead would have put a second database cache beside `DynamicTenancy`'s — two `SqliteDataSource`s and two connection pools per tenant — and forced `DatabaseFor` to resolve asynchronously.

**⚠️ Which is the one thing Marten's version does that Fisher must not copy.** `MasterTableTenancy.GetTenant(string)` is `tryFindTenantDatabase(...).GetAwaiter().GetResult()`; `DatabaseFor` is reached from `OpenSession`, which has no `await` to offer, and that is the whole reason `TryFind` is synchronous and `AllAsync` is not. So the trade is stated rather than hidden: **a tenant this process has not read does not resolve.** One added through `AddTenantAsync` is cached as it is written; one added by another process appears on the next refresh — the daemon polls every minute, and `ApplyAllConfiguredChangesToDatabaseAsync` / `db-apply` / `source.RefreshAsync()` all refresh on demand.

## The no-deletion stance

**It held with no guard, which is the pleasant finding.** Fisher deprovisions and never deletes — deleting a tenant here means deleting a *file*, the cheapest deprovisioning of any Critter Stack store and the most irreversible, and Fisher cannot know it is backed up — and the lifted base already draws the line in the same place: its `DeleteDatabaseRecordAsync` says the tenant's own database is left completely alone.

So `SuspendTenantAsync` flips a flag, `ForgetTenantAsync` deletes the **row**, and neither touches the `.db`. Both are pinned by tests that assert the file is still on disk afterwards, and `forgetting_a_tenant_removes_its_record_and_leaves_its_data_on_disk` re-registers the tenant and reads the document back. `the_source_offers_no_way_to_delete_a_tenants_database` pins the *absence* by reflection, because "we do not delete" is exactly the rule a later convenience method breaks without anybody noticing.

## The one behaviour change to existing sources

`ITenantSource.OnTenantRevoked`, default-implemented so the interface stays implementable outside this repo.

`DynamicTenancy` caches a `FisherDatabase` per tenant and `DatabaseFor` answers from that cache, so **suspending a tenant the store had already resolved used to do nothing** — the old `runtime_tenants` test said so in a comment and opened a *fresh store* to observe the refusal. Tolerable for a directory convention an operator edits by hand; wrong for a control table, whose whole point is runtime effect. The tenancy now sets a revocation callback that every supplied source raises, and the cached database is evicted and disposed.

A callback rather than a re-check inside `DatabaseFor`, because `TryFind` is on the session-open hot path and `DirectoryTenantSource` builds a `SqliteConnectionStringBuilder` on every call — consulting it per session would be a real per-session cost to make a rare event immediate. `runtime_tenants.a_suspended_tenant_is_refused_and_its_data_survives` now asserts on the store that already resolved the tenant *and* on a fresh one.

## Other decisions

- **`tenant_id` is `collate nocase`.** The base compares cache keys with the comparer it is handed and Fisher hands it `OrdinalIgnoreCase`, matching its other tenancies; SQLite's default collation is case-sensitive, so without it the cache and the table disagree about whether `Acme` and `acme` are one tenant.
- **The upsert does not clear the disabled flag.** The dialect contract leaves this to the dialect and says the two shipped stores disagree — Polecat's `MERGE` re-enables, Marten's `on conflict` does not. Fisher follows Marten: resuming as a side effect of correcting a connection string would silently undo a deliberate suspension. `re_adding_a_suspended_tenant_does_not_resume_it` pins it.
- **The seed list is what makes a default tenant possible.** `DynamicTenancy.Default` is read while the store is being *built*, before anything could have read the table — so `TryFind` falls back to `SeedDatabases`, which is configuration rather than data. Checked *after* the disabled set, so suspending a seeded tenant still suspends it.
- **Control-plane calls go through `StoreOptions.ResiliencePipeline`** via the base's `ExecuteAsync` hook. The registry is a SQLite file and takes one writer.
- **The table name folds the logical schema in**, so two logical stores sharing one registry file keep separate tenant lists.

## Validation

`src/Fisher.Tests/Configuration/tenant_registry.cs`, 18 tests — the control table's provisioning and idempotence, case folding in the table as well as the cache, resolution and isolation, the whole runtime lifecycle with the file-still-on-disk assertions, cross-process visibility in both directions (added elsewhere, suspended elsewhere), the store-level operations, and the inherited `IDynamicTenantSource<string>` surface.

**1901 tests green on net9.0 and net10.0**, locally, both TFMs, run sequentially. Scoreboard reconciled and `scripts/check_scoreboard.py` agrees on both. VitePress builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)