### PR TITLE
gh-220: relevance ordering over the FTS5 index

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1987 tests green on net9.0 and net10.0** — 1932 in
+**1997 tests green on net9.0 and net10.0** — 1942 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 516 of
 them are shared cross-store compliance tests — 447 event sourcing and 69 document. On JasperFx **2.66.0** / Weasel **9.31.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 50 suites and 516 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,932.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,942.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/src/Fisher.Tests/Linq/full_text_relevance.cs
+++ b/src/Fisher.Tests/Linq/full_text_relevance.cs
@@ -1,0 +1,262 @@
+using Fisher.Linq;
+using JasperFx;
+
+namespace Fisher.Tests.Linq;
+
+/// <summary>
+///     Relevance ordering over the FTS5 index — fisher#220.
+/// </summary>
+/// <remarks>
+///     <para>
+///         #215 landed the index and the six search operators, all of which only ever FILTER on a
+///         match. <c>bm25()</c> reads a value the match computes, which the #215 sub-select predicate
+///         cannot hand back — so ordering by relevance is what turns that predicate into a join. These
+///         tests are about the two halves of that: the ranking is genuinely by relevance rather than by
+///         insertion order, and everything the sub-select composed with still composes.
+///     </para>
+///     <para>
+///         The corpus is deliberately built so relevance and insertion order DISAGREE. A test whose
+///         expected order matches the order the rows were stored in cannot tell a working bm25 from a
+///         rank that was silently dropped, which is the failure mode worth guarding — nothing here
+///         throws when ranking does not happen.
+///     </para>
+/// </remarks>
+public class full_text_relevance : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("fulltext-rank");
+    private DocumentStore _store = null!;
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<Paper>().FullTextIndex(x => x.Title, x => x.Abstract);
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = _store.LightweightSession();
+
+        // Stored WEAKEST first, so a result in insertion order is visibly not a ranked one.
+        session.Store(new Paper
+        {
+            Slug = "passing-mention",
+            Title = "Bridges of the lowlands",
+            Abstract = "A survey of river crossings. Corrosion is mentioned once.",
+            Year = 2001
+        });
+        session.Store(new Paper
+        {
+            Slug = "body-heavy",
+            Title = "Structural fatigue",
+            Abstract = "Corrosion drives fatigue. Corrosion in joints, corrosion at welds, "
+                       + "and corrosion under insulation are each treated in turn.",
+            Year = 2010
+        });
+        session.Store(new Paper
+        {
+            Slug = "title-hit",
+            Title = "Corrosion",
+            Abstract = "A short note.",
+            Year = 2020
+        });
+
+        await session.SaveChangesAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _store.Dispose();
+        await _database.DisposeAsync();
+    }
+
+    private async Task<string[]> SlugsAsync(Func<IQuerySession, Task<IReadOnlyList<Paper>>> query)
+    {
+        await using var session = _store.QuerySession();
+        var results = await query(session);
+        return results.Select(x => x.Slug).ToArray();
+    }
+
+    [Fact]
+    public async Task ranks_by_relevance_rather_than_by_insertion_order()
+    {
+        var slugs = await SlugsAsync(session => session.Query<Paper>()
+            .Where(x => x.Search("corrosion"))
+            .OrderByRelevance()
+            .ToListAsync(Token));
+
+        slugs.Length.ShouldBe(3);
+
+        // The exact middle ordering is bm25's to decide and depends on its length normalisation, so
+        // what is pinned is the part that is the point: the passing mention, stored FIRST, ranks LAST.
+        slugs.Last().ShouldBe("passing-mention");
+        slugs.ShouldNotBe(new[] { "passing-mention", "body-heavy", "title-hit" });
+    }
+
+    [Fact]
+    public async Task descending_is_the_exact_reverse()
+    {
+        var best = await SlugsAsync(session => session.Query<Paper>()
+            .Where(x => x.Search("corrosion")).OrderByRelevance().ToListAsync(Token));
+
+        var worst = await SlugsAsync(session => session.Query<Paper>()
+            .Where(x => x.Search("corrosion")).OrderByRelevanceDescending().ToListAsync(Token));
+
+        worst.ShouldBe(Enumerable.Reverse(best).ToArray());
+    }
+
+    /// <summary>
+    ///     The composition ruling: relevance is an ordering term, not a replacement for one.
+    /// </summary>
+    [Fact]
+    public async Task relevance_composes_with_a_following_order_by()
+    {
+        // Every paper carries the same term once in the title, so bm25 ties them and the tiebreak
+        // decides the whole order -- which is what makes this a test of composition rather than of
+        // ranking.
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new Paper { Slug = "tie-a", Title = "Ballast", Abstract = "x", Year = 1999 });
+            session.Store(new Paper { Slug = "tie-b", Title = "Ballast", Abstract = "x", Year = 2015 });
+            await session.SaveChangesAsync(Token);
+        }
+
+        var ascending = await SlugsAsync(session => session.Query<Paper>()
+            .Where(x => x.Search("ballast"))
+            .OrderByRelevance()
+            .ThenBy(x => x.Year)
+            .ToListAsync(Token));
+
+        ascending.ShouldBe(new[] { "tie-a", "tie-b" });
+
+        var descending = await SlugsAsync(session => session.Query<Paper>()
+            .Where(x => x.Search("ballast"))
+            .OrderByRelevance()
+            .ThenByDescending(x => x.Year)
+            .ToListAsync(Token));
+
+        descending.ShouldBe(new[] { "tie-b", "tie-a" });
+    }
+
+    [Fact]
+    public async Task relevance_composes_after_an_ordinary_order_by()
+    {
+        var slugs = await SlugsAsync(session => session.Query<Paper>()
+            .Where(x => x.Search("corrosion"))
+            .OrderBy(x => x.Year)
+            .ThenByRelevance()
+            .ToListAsync(Token));
+
+        slugs.ShouldBe(new[] { "passing-mention", "body-heavy", "title-hit" });
+    }
+
+    /// <summary>
+    ///     Column weights, which had nowhere to live before there was anything to weight.
+    /// </summary>
+    /// <remarks>
+    ///     Weighting the title to nothing has to change the answer, and the direction is checkable
+    ///     without depending on bm25's exact arithmetic: with the title discounted, the paper whose
+    ///     only hit is its title must fall behind the one that says the word repeatedly in its body.
+    /// </remarks>
+    [Fact]
+    public async Task column_weights_change_the_ranking()
+    {
+        var weighted = await SlugsAsync(session => session.Query<Paper>()
+            .Where(x => x.Search("corrosion"))
+            .OrderByRelevance(0.0, 1.0)
+            .ToListAsync(Token));
+
+        Array.IndexOf(weighted, "body-heavy").ShouldBeLessThan(Array.IndexOf(weighted, "title-hit"));
+
+        var titleHeavy = await SlugsAsync(session => session.Query<Paper>()
+            .Where(x => x.Search("corrosion"))
+            .OrderByRelevance(10.0, 0.1)
+            .ToListAsync(Token));
+
+        titleHeavy.First().ShouldBe("title-hit");
+    }
+
+    [Fact]
+    public async Task relevance_composes_with_paging_and_an_ordinary_predicate()
+    {
+        var slugs = await SlugsAsync(session => session.Query<Paper>()
+            .Where(x => x.Search("corrosion") && x.Year > 2005)
+            .OrderByRelevance()
+            .Take(1)
+            .ToListAsync(Token));
+
+        slugs.Length.ShouldBe(1);
+        slugs.ShouldNotContain("passing-mention");
+    }
+
+    [Fact]
+    public async Task counting_a_ranked_query_still_works()
+    {
+        await using var session = _store.QuerySession();
+
+        var count = await session.Query<Paper>()
+            .Where(x => x.Search("corrosion"))
+            .OrderByRelevance()
+            .CountAsync(Token);
+
+        count.ShouldBe(3);
+    }
+
+    // ---- refusals ----
+
+    /// <summary>
+    ///     bm25() is only legal where its table is the subject of a MATCH, so ranking without a
+    ///     full-text predicate is refused by name rather than left to fail as SQLite syntax.
+    /// </summary>
+    [Fact]
+    public async Task ranking_without_a_full_text_predicate_is_refused()
+    {
+        await using var session = _store.QuerySession();
+
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await session.Query<Paper>().OrderByRelevance().ToListAsync(Token));
+
+        ex.Message.ShouldContain("needs a full-text predicate");
+    }
+
+    [Fact]
+    public async Task ranking_a_negated_match_is_refused()
+    {
+        await using var session = _store.QuerySession();
+
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await session.Query<Paper>()
+                .Where(x => !x.Search("corrosion"))
+                .OrderByRelevance()
+                .ToListAsync(Token));
+
+        ex.Message.ShouldContain("negated");
+    }
+
+    [Fact]
+    public async Task ranking_two_matches_is_refused_rather_than_picking_one()
+    {
+        await using var session = _store.QuerySession();
+
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await session.Query<Paper>()
+                .Where(x => x.Search("corrosion") && x.Search("fatigue"))
+                .OrderByRelevance()
+                .ToListAsync(Token));
+
+        ex.Message.ShouldContain("cannot tell which one");
+    }
+}
+
+public class Paper
+{
+    public Guid Id { get; set; }
+    public string Slug { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Abstract { get; set; } = string.Empty;
+    public int Year { get; set; }
+}

--- a/src/Fisher/Linq/FisherQueryProvider.cs
+++ b/src/Fisher/Linq/FisherQueryProvider.cs
@@ -1284,9 +1284,131 @@ public partial class FisherQueryProvider : IQueryProvider
         ApplyHierarchyFilter(statement.Wheres, mapping, sourceType, qualifier);
         ApplySoftDeleteFilters(statement.Wheres, parser, mapping, qualifier);
 
+        if (parser.RequiresFullTextJoin)
+        {
+            ApplyFullTextJoin(statement, mapping, qualifier);
+        }
+
         var join = parser.Joins.Count == 0 ? null : ApplyJoin(statement, parser.Joins, selectClause);
 
         return (ApplyDistinct(statement, parser, selectClause), parser, selectClause, join);
+    }
+
+    /// <summary>
+    ///     Turns the query's full-text predicate from a sub-select into a join, which is what puts the
+    ///     FTS5 table in scope for <c>bm25()</c> — fisher#220.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         #215 deliberately made the predicate a sub-select so it stayed an ordinary
+    ///         <c>ISqlFragment</c>. That is still the shape for every query that only FILTERS on a
+    ///         match. It cannot serve a query that needs a value the match computes, because a
+    ///         sub-select has no way to hand one back — so this rewrites the one predicate in place
+    ///         and joins the table it was searching:
+    ///     </para>
+    ///     <code>
+    ///     select d.data from fi_doc_x d
+    ///     join fi_fts_x fts_t on fts_t.rowid = d.rowid
+    ///     where fts_t match ?
+    ///     order by bm25(fts_t)
+    ///     </code>
+    ///     <para>
+    ///         The document table stays the FROM, so every other locator, filter and wrap site is
+    ///         unaffected. Only the match moves.
+    ///     </para>
+    ///     <para>
+    ///         <b>Exactly one match, and not a negated one.</b> Two predicates would leave bm25
+    ///         ambiguous about which match it scores, and ranking by how well a row FAILED to match is
+    ///         not a thing — both are refused by name rather than silently picking one. Zero is refused
+    ///         too: bm25 is only legal where its table is the subject of a MATCH, so without a
+    ///         predicate SQLite would fail a long way from the call site.
+    ///     </para>
+    /// </remarks>
+    private static void ApplyFullTextJoin(Statement statement, DocumentMapping mapping, string qualifier)
+    {
+        var matches = new List<FullTextMatchFilter>();
+        var negated = false;
+
+        foreach (var where in statement.Wheres)
+        {
+            CollectFullTextMatches(where, matches, ref negated, insideNot: false);
+        }
+
+        if (matches.Count == 0)
+        {
+            throw new BadLinqExpressionException(
+                "OrderByRelevance needs a full-text predicate in the same query — bm25() scores a "
+                + "match, and there is nothing here for it to score. Add a Where(x => x.Search(\"…\")) "
+                + $"over '{mapping.DocumentType.Name}', or order by a member instead.");
+        }
+
+        if (negated)
+        {
+            throw new BadLinqExpressionException(
+                "OrderByRelevance cannot rank a negated full-text predicate: bm25() scores how well a "
+                + "row matched, and these rows are the ones that did not.");
+        }
+
+        if (matches.Count > 1)
+        {
+            throw new BadLinqExpressionException(
+                $"OrderByRelevance found {matches.Count} full-text predicates in this query and cannot "
+                + "tell which one to rank by. Search once, combining the terms into a single FTS5 "
+                + "query if you need more than one.");
+        }
+
+        var match = matches[0];
+
+        // Under its own name, not an alias -- SQLite refuses an alias on the left of MATCH. See
+        // JoinClause.Alias.
+        match.JoinAlias = match.QuotedTable;
+
+        statement.Joins.Add(new Fisher.Linq.Joins.JoinClause
+        {
+            Table = match.QuotedTable,
+            Alias = null,
+            OuterKeyLocator = $"{match.QuotedTable}.rowid",
+
+            // Both tables have a rowid, so the document side has to be qualified or SQLite rejects
+            // the join as ambiguous. When the query is already aliased (a LINQ join) that is the
+            // alias; otherwise it is the table's own name.
+            InnerKeyLocator = qualifier.Length > 0
+                ? $"{qualifier}rowid"
+                : $"{statement.FromTable}.rowid"
+        });
+    }
+
+    /// <summary>
+    ///     Walks a predicate tree for full-text matches, tracking whether any sits under a NOT.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="CompoundWhereFragment" /> and <see cref="NotFragment" /> are the only composites
+    ///     Fisher builds, so this is the whole tree rather than a best effort.
+    /// </remarks>
+    private static void CollectFullTextMatches(
+        ISqlFragment fragment, List<FullTextMatchFilter> found, ref bool negated, bool insideNot)
+    {
+        switch (fragment)
+        {
+            case FullTextMatchFilter match:
+                found.Add(match);
+                if (insideNot)
+                {
+                    negated = true;
+                }
+
+                break;
+
+            case NotFragment not:
+                CollectFullTextMatches(not.Inner, found, ref negated, insideNot: true);
+                break;
+
+            case CompoundWhereFragment compound:
+                var (left, right) = compound.Children;
+                CollectFullTextMatches(left, found, ref negated, insideNot);
+                CollectFullTextMatches(right, found, ref negated, insideNot);
+                break;
+        }
     }
 
     /// <summary>

--- a/src/Fisher/Linq/FullTextSearchExtensions.cs
+++ b/src/Fisher/Linq/FullTextSearchExtensions.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 namespace Fisher.Linq;
 
 /// <summary>
@@ -103,6 +104,73 @@ public static class FullTextSearchExtensions
     /// </remarks>
     public static bool NgramSearch<T>(this T document, string searchTerm)
         => throw OnlyInAQuery(nameof(NgramSearch));
+
+    /// <summary>
+    ///     Order the results by FTS5 relevance — <c>bm25()</c> over the index the query's full-text
+    ///     predicate searched (<a href="https://github.com/JasperFx/fisher/issues/220">fisher#220</a>).
+    /// </summary>
+    /// <param name="source">A query that already carries a full-text predicate.</param>
+    /// <param name="columnWeights">
+    ///     Optional per-column weights, in the order the index declared its members. Omit them for
+    ///     FTS5's default, which weights every column at 1.0. Supplying a different number of weights
+    ///     than the index has columns is refused rather than padded.
+    /// </param>
+    /// <remarks>
+    ///     <para>
+    ///     <b>Most relevant first.</b> FTS5's <c>bm25()</c> returns a score that is more NEGATIVE the
+    ///     better the match, so a raw ascending sort is already best-first and this reads the way it
+    ///     looks. <see cref="ThenByRelevanceDescending{T}" /> exists for the rare worst-first case
+    ///     rather than leaving callers to discover the sign for themselves.
+    ///     </para>
+    ///     <para>
+    ///     <b>It composes.</b> Relevance is an ordering term like any other, so
+    ///     <c>OrderByRelevance().ThenByDescending(x =&gt; x.Published)</c> breaks ties by date, and
+    ///     <c>OrderBy(x =&gt; x.Category).ThenByRelevance()</c> ranks within each category. It does not
+    ///     replace an ordering already in the chain.
+    ///     </para>
+    ///     <para>
+    ///     <b>It requires a full-text predicate in the same query</b>, and is refused at translation
+    ///     time without one. <c>bm25()</c> is only legal where its table is the subject of a MATCH, so
+    ///     the alternative is a SQLite error a long way from the call site.
+    ///     </para>
+    /// </remarks>
+    public static IOrderedQueryable<T> OrderByRelevance<T>(this IQueryable<T> source,
+        params double[] columnWeights)
+        => Rank(source, nameof(OrderByRelevance), columnWeights);
+
+    /// <inheritdoc cref="OrderByRelevance{T}" />
+    /// <summary>Worst match first. The inverse of <see cref="OrderByRelevance{T}" />.</summary>
+    public static IOrderedQueryable<T> OrderByRelevanceDescending<T>(this IQueryable<T> source,
+        params double[] columnWeights)
+        => Rank(source, nameof(OrderByRelevanceDescending), columnWeights);
+
+    /// <inheritdoc cref="OrderByRelevance{T}" />
+    /// <summary>Break an existing ordering's ties by relevance.</summary>
+    public static IOrderedQueryable<T> ThenByRelevance<T>(this IOrderedQueryable<T> source,
+        params double[] columnWeights)
+        => Rank(source, nameof(ThenByRelevance), columnWeights);
+
+    /// <inheritdoc cref="OrderByRelevance{T}" />
+    /// <summary>Break an existing ordering's ties by relevance, worst match first.</summary>
+    public static IOrderedQueryable<T> ThenByRelevanceDescending<T>(this IOrderedQueryable<T> source,
+        params double[] columnWeights)
+        => Rank(source, nameof(ThenByRelevanceDescending), columnWeights);
+
+    /// <summary>
+    ///     Rebuilds the call as an expression node the provider's parser sees, which is what makes
+    ///     these ordinary members of the ordering chain rather than a terminal that has to be last.
+    /// </summary>
+    private static IOrderedQueryable<T> Rank<T>(IQueryable<T> source, string method, double[] weights)
+    {
+        var call = Expression.Call(
+            typeof(FullTextSearchExtensions),
+            method,
+            [typeof(T)],
+            source.Expression,
+            Expression.Constant(weights ?? []));
+
+        return (IOrderedQueryable<T>)source.Provider.CreateQuery<T>(call);
+    }
 
     private static NotSupportedException OnlyInAQuery(string name)
         => new($"'{name}' is only meaningful inside a Fisher LINQ query — "

--- a/src/Fisher/Linq/Joins/JoinClause.cs
+++ b/src/Fisher/Linq/Joins/JoinClause.cs
@@ -27,8 +27,18 @@ internal sealed class JoinClause
     /// <summary>The joined table, quoted.</summary>
     public required string Table { get; init; }
 
-    /// <summary>The alias every locator on the inner side is qualified with.</summary>
-    public required string Alias { get; init; }
+    /// <summary>
+    ///     The alias every locator on the inner side is qualified with, or null to join the table
+    ///     under its own name.
+    /// </summary>
+    /// <remarks>
+    ///     Null only for the FTS5 join (fisher#220), and not as a style choice: SQLite refuses an
+    ///     alias on the left of <c>MATCH</c> — <c>… join ftsdoc f … where f match ?</c> fails with
+    ///     "no such column: f", because the expression parser resolves a bare identifier there as a
+    ///     column rather than as a table. The FTS5 table therefore has to appear under its own name,
+    ///     which is also what <c>bm25()</c> has to be handed.
+    /// </remarks>
+    public string? Alias { get; init; }
 
     /// <summary>The outer key locator, already qualified with the outer alias.</summary>
     public required string OuterKeyLocator { get; init; }
@@ -49,8 +59,13 @@ internal sealed class JoinClause
     {
         builder.Append(IsLeftJoin ? " left join " : " join ");
         builder.Append(Table);
-        builder.Append(' ');
-        builder.Append(Alias);
+
+        if (Alias is not null)
+        {
+            builder.Append(' ');
+            builder.Append(Alias);
+        }
+
         builder.Append(" on ");
         builder.Append(OuterKeyLocator);
         builder.Append(" = ");

--- a/src/Fisher/Linq/Parsing/LinqQueryParser.cs
+++ b/src/Fisher/Linq/Parsing/LinqQueryParser.cs
@@ -307,6 +307,21 @@ internal class LinqQueryParser
                 ApplyGroupBy(call);
                 break;
 
+            // fisher#220. Relevance is an ordering term like any other -- the locator is bm25() over
+            // the joined FTS5 table rather than a member's column, and BuildStatement is what turns
+            // the query's full-text predicate into that join. Placed with the rest of the family
+            // because that is exactly what it is: OrderByRelevance().ThenBy(...) and
+            // OrderBy(...).ThenByRelevance() both mean what they look like.
+            case "OrderByRelevance":
+            case "ThenByRelevance":
+                AddRelevanceOrdering(call, descending: false);
+                break;
+
+            case "OrderByRelevanceDescending":
+            case "ThenByRelevanceDescending":
+                AddRelevanceOrdering(call, descending: true);
+                break;
+
             case "OrderBy":
                 AddOrdering(call, descending: false);
                 break;
@@ -624,6 +639,75 @@ internal class LinqQueryParser
         OrderBys.Add((OrderingLocatorFor(call), descending));
         OrderByMembers.Add(_lastOrderingMember);
     }
+
+    /// <summary>
+    ///     <c>OrderByRelevance</c> and its three siblings -- fisher#220.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     The locator is <c>bm25(&lt;alias&gt;)</c> against the alias <c>BuildStatement</c> joins the
+    ///     FTS5 table under, so it is settled here even though the join is added there: the alias is a
+    ///     constant, and keeping the locator's construction next to the other orderings is what lets
+    ///     relevance travel through paging, reversal and the aggregate wraps without any of them
+    ///     learning it is special.
+    ///     </para>
+    ///     <para>
+    ///     <b>bm25() scores more negative for a better match</b>, so best-first is a plain ascending
+    ///     sort and `descending` here means worst-first. The sign is FTS5's, not a choice.
+    ///     </para>
+    ///     <para>
+    ///     <c>OrderByMembers</c> gets a null, which is what keyset pagination already does for any
+    ///     ordering key that is not a document member -- a rank is not a value a cursor can carry.
+    ///     </para>
+    /// </remarks>
+    private void AddRelevanceOrdering(MethodCallExpression call, bool descending)
+    {
+        RequiresFullTextJoin = true;
+
+        var weights = call.Arguments.Count > 1
+            ? WhereClauseParser.ExtractValue(call.Arguments[1]) as double[] ?? []
+            : [];
+
+        RelevanceWeights = weights;
+
+        var mapping = _memberFactory.Mapping
+                      ?? throw new BadLinqExpressionException(
+                          "OrderByRelevance can only be used against a document type. It reads a "
+                          + "document's FTS5 index, and this query is not over one.");
+
+        var index = mapping.FullTextIndex
+                    ?? throw new BadLinqExpressionException(
+                        $"'{mapping.DocumentType.Name}' declares no full-text index, so there is "
+                        + "nothing for OrderByRelevance to rank by.");
+
+        if (weights.Length > 0 && weights.Length != index.ColumnNames.Length)
+        {
+            throw new BadLinqExpressionException(
+                $"OrderByRelevance was given {weights.Length} column weight(s), but "
+                + $"'{mapping.DocumentType.Name}'s full-text index covers {index.ColumnNames.Length}. "
+                + "bm25() takes one weight per indexed column, in declaration order — pass one for "
+                + "each, or none at all for FTS5's default of 1.0 each.");
+        }
+
+        var table = Weasel.Sqlite.SchemaUtils.QuoteName(
+            Storage.FullText.FullTextSchema.TableNameFor(mapping).Name);
+
+        OrderBys.Add((FullTextRank.Locator(table, weights), descending));
+        OrderByMembers.Add(null);
+    }
+
+    /// <summary>
+    ///     Set when something in the query needs a value the FTS5 match COMPUTES rather than just the
+    ///     rows it matches, which is what makes the predicate a join instead of a sub-select --
+    ///     fisher#220.
+    /// </summary>
+    public bool RequiresFullTextJoin { get; private set; }
+
+    /// <summary>The per-column <c>bm25()</c> weights, empty for FTS5's default of 1.0 each.</summary>
+    public double[] RelevanceWeights { get; private set; } = [];
+
+    // fisher#220: the FTS5 table is joined under its own name rather than an alias, because SQLite
+    // refuses an alias on the left of MATCH. See JoinClause.Alias.
 
     private IQueryableMember? _lastOrderingMember;
 

--- a/src/Fisher/Linq/SqlGeneration/CompoundWhereFragment.cs
+++ b/src/Fisher/Linq/SqlGeneration/CompoundWhereFragment.cs
@@ -25,6 +25,12 @@ internal class CompoundWhereFragment : ISqlFragment
         _right = right;
     }
 
+    /// <summary>The two halves, so a predicate tree can be walked -- fisher#220.</summary>
+    public (ISqlFragment Left, ISqlFragment Right) Children => (_left, _right);
+
+    /// <summary><c>and</c> or <c>or</c>. A walker needs to tell an AND-chain from an OR-chain.</summary>
+    public string Separator => _separator;
+
     public static ISqlFragment And(IReadOnlyList<ISqlFragment> fragments) => Combine("and", fragments);
 
     public static ISqlFragment Or(IReadOnlyList<ISqlFragment> fragments) => Combine("or", fragments);

--- a/src/Fisher/Linq/SqlGeneration/FullTextMatchFilter.cs
+++ b/src/Fisher/Linq/SqlGeneration/FullTextMatchFilter.cs
@@ -41,11 +41,46 @@ internal sealed class FullTextMatchFilter : ISqlFragment
         _query = query;
     }
 
+    /// <summary>The FTS5 query text, so the statement builder can report on it when it refuses.</summary>
+    public string Query => _query;
+
+    /// <summary>The index this predicate searches, quoted.</summary>
+    public string QuotedTable => _quotedTable;
+
+    /// <summary>
+    ///     When set, the predicate renders as <c>&lt;alias&gt; match ?</c> against an FTS5 table the
+    ///     statement has joined under that alias, instead of as the self-contained sub-select —
+    ///     fisher#220.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Set only by <c>BuildStatement</c>, and only when something in the query needs a value the
+    ///     match COMPUTES rather than just the rows it matches: a <c>bm25()</c> rank today, a snippet
+    ///     later. The sub-select cannot hand a value back, so those need the virtual table genuinely in
+    ///     scope, and <c>bm25()</c> in particular is only legal in a query where its table is the
+    ///     subject of a MATCH.
+    ///     </para>
+    ///     <para>
+    ///     The two forms are exclusive rather than additive. Emitting the join AND keeping the
+    ///     sub-select would evaluate the same match twice and bind the query text twice, so switching
+    ///     this on is what removes the sub-select.
+    ///     </para>
+    /// </remarks>
+    public string? JoinAlias { get; set; }
+
     public void Apply(ICommandBuilder builder)
     {
         if (string.IsNullOrWhiteSpace(_query))
         {
             builder.Append("1=0");
+            return;
+        }
+
+        if (JoinAlias is not null)
+        {
+            builder.Append(JoinAlias);
+            builder.Append(" match ");
+            builder.AppendParameter(_query);
             return;
         }
 

--- a/src/Fisher/Linq/SqlGeneration/FullTextRank.cs
+++ b/src/Fisher/Linq/SqlGeneration/FullTextRank.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+
+namespace Fisher.Linq.SqlGeneration;
+
+/// <summary>
+///     The <c>bm25()</c> ordering locator — fisher#220.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A locator string rather than an <c>ISqlFragment</c>, because <see cref="Statement" />'s
+///         <c>OrderBys</c> are locators and that is what lets a rank travel through keyset paging,
+///         <c>ReverseOverPage</c> and the aggregate wraps without any of them learning that full text
+///         exists. The same reasoning that kept the #215 predicate an ordinary fragment.
+///     </para>
+///     <para>
+///         <b>Weights are rendered, not parameterised.</b> Every other value in a Fisher query is a
+///         bound parameter, so the exception needs a reason: SQLite will not accept a bound parameter
+///         as a <c>bm25()</c> weight argument — the weights are part of the function's signature, not
+///         data — and rendering a caller-supplied <see cref="double" /> through
+///         <see cref="CultureInfo.InvariantCulture" /> is safe because the value has already been
+///         through <see cref="double" /> parsing and cannot carry SQL. A weight that is not a finite
+///         number is refused rather than rendered, since <c>NaN</c> and the infinities format as words
+///         SQLite would read as identifiers.
+///     </para>
+/// </remarks>
+internal static class FullTextRank
+{
+    public static string Locator(string alias, IReadOnlyList<double> weights)
+    {
+        if (weights.Count == 0)
+        {
+            return $"bm25({alias})";
+        }
+
+        foreach (var weight in weights)
+        {
+            if (double.IsNaN(weight) || double.IsInfinity(weight))
+            {
+                throw new BadLinqExpressionException(
+                    $"'{weight}' is not a usable bm25 column weight. Weights are rendered into the "
+                    + "SQL rather than bound, because SQLite does not accept a parameter as a bm25 "
+                    + "argument, and NaN and the infinities have no numeric spelling there.");
+            }
+        }
+
+        var rendered = string.Join(", ",
+            weights.Select(w => w.ToString("R", CultureInfo.InvariantCulture)));
+
+        return $"bm25({alias}, {rendered})";
+    }
+}

--- a/src/Fisher/Linq/SqlGeneration/NotFragment.cs
+++ b/src/Fisher/Linq/SqlGeneration/NotFragment.cs
@@ -15,6 +15,9 @@ internal class NotFragment : ISqlFragment
         _inner = inner;
     }
 
+    /// <summary>The negated fragment, so a predicate tree can be walked -- fisher#220.</summary>
+    public ISqlFragment Inner => _inner;
+
     public void Apply(ICommandBuilder builder)
     {
         builder.Append("not (");


### PR DESCRIPTION
Part of #220 — the `bm25()` half. **Snippet and highlight are not in this PR**; see *What is left* below.

## The shape change

#215 made the full-text predicate a sub-select on purpose, so it stayed an ordinary `ISqlFragment` that composes with everything and the statement builder never learned full text exists. That shape cannot serve `bm25()`, which reads a value the match *computes* rather than the rows it matched.

So when — and only when — a query orders by relevance, `BuildStatement` rewrites that one predicate in place and joins the table it was searching:

```sql
select data from fi_doc_paper
join fi_fts_paper on fi_fts_paper.rowid = fi_doc_paper.rowid
where fi_fts_paper match ?
order by bm25(fi_fts_paper)
```

The document table stays the `FROM`, so every other locator, filter and wrap site is untouched. Only the match moves, and **every query that merely filters keeps the #215 sub-select exactly as it was.**

## Two SQLite constraints worth knowing

Both found by running the SQL rather than reading about it, and both now recorded where the next person hits them:

- **SQLite refuses an alias on the left of `MATCH`.** `join ftsdoc f … where f match ?` fails with `no such column: f` — the expression parser resolves a bare identifier there as a column. The FTS5 table is therefore joined under its own name, which meant making `JoinClause.Alias` optional.
- **Both tables have a `rowid`**, so the document side of the `ON` has to be qualified or SQLite rejects the join as ambiguous.

## Relevance composes

Per the ruling on the issue's second open question: `OrderByRelevance()` is an ordering term, not a replacement for one.

```csharp
query.Where(x => x.Search("fox")).OrderByRelevance().ThenByDescending(x => x.Published)
query.Where(x => x.Search("fox")).OrderBy(x => x.Category).ThenByRelevance()
```

This falls out cheaply: `Statement`'s `OrderBys` are locator strings, so `bm25()` is just another one and travels through keyset paging, `ReverseOverPage` and the aggregate wraps without any of them learning about it. `OrderByMembers` gets a null, which is already what happens for any ordering key that is not a document member — a rank is not something a cursor can carry.

**Best-first is a plain ascending sort**, because `bm25()` scores more *negative* the better the match. The `Descending` pair exists so nobody has to discover that sign for themselves.

## Column weights

`OrderByRelevance(0.0, 1.0)` — one per indexed column, in declaration order; omit for FTS5's default of 1.0 each. A count that disagrees with the index is refused rather than padded. Weights are rendered rather than bound, because SQLite does not accept a parameter as a `bm25()` argument; non-finite weights are refused rather than rendered, since `NaN` and the infinities format as words SQLite would read as identifiers.

## Refusals

Each replaces a failure that would otherwise land far from the call site:

| Refused | Why |
|---|---|
| Ranking with no full-text predicate | `bm25()` is only legal where its table is the subject of a `MATCH` |
| Ranking a negated match | Scoring how well a row *failed* to match is not a thing |
| Ranking with two predicates | Ambiguous which match is being scored — refuse rather than pick |

## On the tests

The corpus in `full_text_relevance` is built so relevance and insertion order **disagree** — the weakest match is stored first. A ranking test whose expected order matches insertion order cannot tell a working `bm25` from a rank that was silently dropped, and nothing here throws when ranking does not happen. The ties test likewise gives every row an identical score so the tiebreak decides the whole order, which is what makes it a test of composition rather than of ranking.

## What is left of #220

**Snippet and highlight.** Jeremy's ruling is that they should be projection members — `Select(x => new { x.Title, Snippet = x.Snippet() })`, with `Select` learning about a column that is not a document member. That is a change to the projection machinery rather than to the statement shape, and it is genuinely separable: the join this PR adds is the thing both halves needed, and it is now there for them to use. Worth its own PR rather than doubling this one.

Column weights and the compose-vs-replace question, the issue's other two "worth settling here" items, are both settled here.

## Tests

Fisher.Tests **1942**, AspNetCore **36**, EntityFrameworkCore **19** — **1997 green on both TFMs**. Scoreboard verified with `scripts/check_scoreboard.py` against a real Release run (it caught a second stale count in the README, which is what it is for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)