### PR TITLE
gh-220: projected snippets and highlights over the FTS5 index

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**1997 tests green on net9.0 and net10.0** — 1942 in
+**2007 tests green on net9.0 and net10.0** — 1952 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 516 of
 them are shared cross-store compliance tests — 447 event sourcing and 69 document. On JasperFx **2.66.0** / Weasel **9.31.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 50 suites and 516 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,942.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,952.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/src/Fisher.Tests/Linq/full_text_extracts.cs
+++ b/src/Fisher.Tests/Linq/full_text_extracts.cs
@@ -1,0 +1,230 @@
+using Fisher.Linq;
+using JasperFx;
+
+namespace Fisher.Tests.Linq;
+
+/// <summary>
+///     Projected snippets and highlights over the FTS5 index — the second half of fisher#220.
+/// </summary>
+/// <remarks>
+///     <para>
+///         These read a value the match COMPUTES, so they are columns without being document members.
+///         <c>SelectProjection</c> already rewrites arbitrary sub-expressions into reads from the row's
+///         value array, so a snippet becomes a locator there exactly the way a member does and the rest
+///         of the projection machinery cannot tell the difference.
+///     </para>
+///     <para>
+///         <b>They work only because Fisher's FTS5 table uses external content.</b> A contentless FTS5
+///         table stores no text, and <c>snippet()</c> over one returns an empty string rather than an
+///         error — so this capability would have been silently useless on a different index design.
+///         Verified against SQLite directly before the code was written.
+///     </para>
+/// </remarks>
+public class full_text_extracts : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("fulltext-extract");
+    private DocumentStore _store = null!;
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<Report>().FullTextIndex(x => x.Title, x => x.Body);
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = _store.LightweightSession();
+        session.Store(new Report
+        {
+            Title = "Corrosion basics",
+            // Deliberately well past the 32-token default budget, so a snippet that comes back
+            // un-elided means the budget was ignored rather than that the text simply fitted.
+            Body = "An extended treatment of corrosion in structural steel, covering the "
+                   + "electrochemistry of the process, the role of chlorides and standing water, "
+                   + "the prevention of corrosion by coating and by cathodic protection, the "
+                   + "inspection regimes that catch it early, the repair techniques available "
+                   + "once it has taken hold, and the long service life of a structure that "
+                   + "nobody inspects often enough to notice any of it happening at all."
+        });
+        await session.SaveChangesAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _store.Dispose();
+        await _database.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task a_snippet_marks_the_matched_term_and_elides_the_rest()
+    {
+        await using var session = _store.QuerySession();
+
+        var extract = await session.Query<Report>()
+            .Where(x => x.Search("corrosion"))
+            .Select(x => x.Snippet())
+            .FirstAsync(Token);
+
+        extract.ShouldContain("<b>corrosion</b>");
+
+        // The body is far longer than the token budget, so an un-elided answer would mean the
+        // budget was ignored -- which is how a snippet silently becomes "the whole column". The
+        // comparison is against the stored text rather than a magic number, so it keeps meaning the
+        // same thing if the corpus is ever edited.
+        extract.ShouldContain("…");
+
+        await using var reading = _store.QuerySession();
+        var stored = await reading.Query<Report>().FirstAsync(Token);
+        extract.Length.ShouldBeLessThan(stored.Body.Length);
+    }
+
+    [Fact]
+    public async Task snippet_markers_and_budget_are_the_callers()
+    {
+        await using var session = _store.QuerySession();
+
+        var extract = await session.Query<Report>()
+            .Where(x => x.Search("corrosion"))
+            .Select(x => x.Snippet("[", "]", "...", 6))
+            .FirstAsync(Token);
+
+        extract.ShouldContain("[corrosion]");
+        extract.ShouldContain("...");
+        extract.ShouldNotContain("<b>");
+    }
+
+    [Fact]
+    public async Task a_highlight_returns_the_whole_named_column()
+    {
+        await using var session = _store.QuerySession();
+
+        var highlighted = await session.Query<Report>()
+            .Where(x => x.Search("corrosion"))
+            .Select(x => x.Highlight(nameof(Report.Title)))
+            .FirstAsync(Token);
+
+        highlighted.ShouldBe("<b>Corrosion</b> basics");
+    }
+
+    [Fact]
+    public async Task a_highlight_takes_the_callers_markers()
+    {
+        await using var session = _store.QuerySession();
+
+        var highlighted = await session.Query<Report>()
+            .Where(x => x.Search("corrosion"))
+            .Select(x => x.Highlight(nameof(Report.Title), "<em>", "</em>"))
+            .FirstAsync(Token);
+
+        highlighted.ShouldBe("<em>Corrosion</em> basics");
+    }
+
+    /// <summary>
+    ///     The shape the ruling asked for: an extract sitting beside ordinary members in one anonymous
+    ///     type, which is what "a snippet is a projection member" has to mean to be worth anything.
+    /// </summary>
+    [Fact]
+    public async Task an_extract_projects_alongside_document_members()
+    {
+        await using var session = _store.QuerySession();
+
+        var row = await session.Query<Report>()
+            .Where(x => x.Search("corrosion"))
+            .Select(x => new { x.Title, Extract = x.Snippet(), Whole = x.Highlight(nameof(Report.Body)) })
+            .FirstAsync(Token);
+
+        row.Title.ShouldBe("Corrosion basics");
+        row.Extract.ShouldContain("<b>corrosion</b>");
+        row.Whole.ShouldContain("<b>corrosion</b>");
+        row.Whole.ShouldContain("nobody inspects often enough");
+    }
+
+    [Fact]
+    public async Task an_extract_composes_with_relevance_ordering()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new Report { Title = "Bridges", Body = "corrosion is mentioned once" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = _store.QuerySession();
+
+        var rows = await query.Query<Report>()
+            .Where(x => x.Search("corrosion"))
+            .OrderByRelevance()
+            .Select(x => new { x.Title, Extract = x.Snippet() })
+            .ToListAsync(Token);
+
+        rows.Count.ShouldBe(2);
+        rows.ShouldAllBe(r => r.Extract.Contains("<b>corrosion</b>"));
+    }
+
+    /// <summary>
+    ///     A marker carrying a quote must not be able to close the literal it is rendered into. These
+    ///     go into the SELECT list as SQL literals rather than as parameters, so the escaping is the
+    ///     only thing between a caller's string and the statement.
+    /// </summary>
+    [Fact]
+    public async Task a_marker_containing_a_quote_is_escaped_rather_than_injected()
+    {
+        await using var session = _store.QuerySession();
+
+        var extract = await session.Query<Report>()
+            .Where(x => x.Search("corrosion"))
+            .Select(x => x.Snippet("o'brien'", "'", "...", 6))
+            .FirstAsync(Token);
+
+        extract.ShouldContain("o'brien'corrosion'");
+    }
+
+    // ---- refusals ----
+
+    [Fact]
+    public async Task an_unknown_highlight_column_is_refused_with_the_indexed_members_named()
+    {
+        await using var session = _store.QuerySession();
+
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await session.Query<Report>()
+                .Where(x => x.Search("corrosion"))
+                .Select(x => x.Highlight("Nonexistent"))
+                .ToListAsync(Token));
+
+        ex.Message.ShouldContain("Nonexistent");
+        ex.Message.ShouldContain("Title");
+        ex.Message.ShouldContain("Body");
+    }
+
+    [Fact]
+    public async Task projecting_a_snippet_without_a_full_text_predicate_is_refused()
+    {
+        await using var session = _store.QuerySession();
+
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await session.Query<Report>().Select(x => x.Snippet()).ToListAsync(Token));
+
+        ex.Message.ShouldContain("full-text predicate");
+    }
+
+    [Fact]
+    public void calling_an_extract_outside_a_query_throws_rather_than_returning_a_plausible_value()
+    {
+        var report = new Report { Title = "x", Body = "y" };
+
+        Should.Throw<NotSupportedException>(() => report.Snippet());
+        Should.Throw<NotSupportedException>(() => report.Highlight("Title"));
+    }
+}
+
+public class Report
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+}

--- a/src/Fisher/Linq/FullTextSearchExtensions.cs
+++ b/src/Fisher/Linq/FullTextSearchExtensions.cs
@@ -157,6 +157,65 @@ public static class FullTextSearchExtensions
         => Rank(source, nameof(ThenByRelevanceDescending), columnWeights);
 
     /// <summary>
+    ///     The matching fragment of the indexed text, with the matched terms marked — FTS5's
+    ///     <c>snippet()</c> (<a href="https://github.com/JasperFx/fisher/issues/220">fisher#220</a>).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>Only inside a <c>Select</c>, on a query that carries a full-text predicate.</b> It is a
+    ///     projected column rather than a document member — the value is computed by the match, so
+    ///     there is nothing on the document to read it from, and no in-memory meaning to fall back to.
+    ///     </para>
+    ///     <code>
+    ///     session.Query&lt;Article&gt;()
+    ///         .Where(x =&gt; x.Search("corrosion"))
+    ///         .Select(x =&gt; new { x.Title, Extract = x.Snippet() })
+    ///     </code>
+    ///     <para>
+    ///     Takes the best-matching column, which is FTS5's own <c>-1</c>. Defaults are
+    ///     <c>&lt;b&gt;</c>/<c>&lt;/b&gt;</c> markers, <c>…</c> for the elision and 32 tokens.
+    ///     </para>
+    /// </remarks>
+    public static string Snippet<T>(this T document)
+        => throw OnlyInASelect(nameof(Snippet));
+
+    /// <inheritdoc cref="Snippet{T}(T)" />
+    /// <param name="document">The document being projected. Never read.</param>
+    /// <param name="startMarker">Written before each matched term.</param>
+    /// <param name="endMarker">Written after each matched term.</param>
+    /// <param name="ellipsis">Written where text was elided.</param>
+    /// <param name="maxTokens">Length budget, in tokens. FTS5 caps this at 64.</param>
+    public static string Snippet<T>(this T document, string startMarker, string endMarker,
+        string ellipsis, int maxTokens)
+        => throw OnlyInASelect(nameof(Snippet));
+
+    /// <summary>
+    ///     One indexed column in full, with the matched terms marked — FTS5's <c>highlight()</c>
+    ///     (<a href="https://github.com/JasperFx/fisher/issues/220">fisher#220</a>).
+    /// </summary>
+    /// <param name="document">The document being projected. Never read.</param>
+    /// <param name="column">
+    ///     Which indexed member to highlight, named as the member is. <b>Required, unlike
+    ///     <see cref="Snippet{T}(T)" />'s.</b> FTS5 accepts <c>-1</c> here and returns an EMPTY STRING
+    ///     for it rather than an error, so a default of "whichever column matched" would be a silent
+    ///     wrong answer, and a default of "the first one" would be a wrong answer whenever the match
+    ///     was elsewhere.
+    /// </param>
+    public static string Highlight<T>(this T document, string column)
+        => throw OnlyInASelect(nameof(Highlight));
+
+    /// <inheritdoc cref="Highlight{T}(T,string)" />
+    public static string Highlight<T>(this T document, string column, string startMarker,
+        string endMarker)
+        => throw OnlyInASelect(nameof(Highlight));
+
+    private static NotSupportedException OnlyInASelect(string name)
+        => new($"'{name}' is only meaningful inside a Fisher LINQ query's Select — "
+               + "session.Query<T>().Where(x => x.Search(\"…\")).Select(x => new { Value = x."
+               + name + "() }). It reads a value the full-text match computes, so it has no "
+               + "in-memory equivalent and nothing on the document to fall back to.");
+
+    /// <summary>
     ///     Rebuilds the call as an expression node the provider's parser sees, which is what makes
     ///     these ordinary members of the ordering chain rather than a terminal that has to be last.
     /// </summary>

--- a/src/Fisher/Linq/Parsing/LinqQueryParser.cs
+++ b/src/Fisher/Linq/Parsing/LinqQueryParser.cs
@@ -587,6 +587,13 @@ internal class LinqQueryParser
         }
 
         Projection = SelectProjection.For(UnwrapLambda(call), _memberFactory);
+
+        // fisher#220: a projected snippet or highlight reads a value the match computes, which needs
+        // the FTS5 table joined for the same reason bm25 does.
+        if (Projection.RequiresFullTextJoin)
+        {
+            RequiresFullTextJoin = true;
+        }
     }
 
     private void MarkSoftDelete(SoftDeleteScope scope)

--- a/src/Fisher/Linq/Parsing/SelectProjection.cs
+++ b/src/Fisher/Linq/Parsing/SelectProjection.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using Fisher.Linq.Members;
+using Fisher.Linq.SqlGeneration;
 
 namespace Fisher.Linq.Parsing;
 
@@ -33,12 +34,13 @@ namespace Fisher.Linq.Parsing;
 internal sealed class SelectProjection
 {
     private SelectProjection(string[] locators, Type[] columnTypes, Func<object?[], object?> build,
-        Type resultType)
+        Type resultType, bool requiresFullTextJoin)
     {
         Locators = locators;
         ColumnTypes = columnTypes;
         Build = build;
         ResultType = resultType;
+        RequiresFullTextJoin = requiresFullTextJoin;
     }
 
     /// <summary>The SQL locators to select, in order.</summary>
@@ -51,6 +53,13 @@ internal sealed class SelectProjection
     public Func<object?[], object?> Build { get; }
 
     public Type ResultType { get; }
+
+    /// <summary>
+    ///     True when the projection reads a value the FTS5 match COMPUTES — a snippet or a highlight —
+    ///     which is what makes the query's full-text predicate a join rather than a sub-select
+    ///     (fisher#220).
+    /// </summary>
+    public bool RequiresFullTextJoin { get; }
 
     public static SelectProjection For(LambdaExpression selector, IMemberResolver members)
     {
@@ -75,7 +84,8 @@ internal sealed class SelectProjection
             collector.Locators.ToArray(),
             collector.ColumnTypes.ToArray(),
             lambda.Compile(),
-            selector.ReturnType);
+            selector.ReturnType,
+            collector.RequiresFullTextJoin);
     }
 
     /// <summary>
@@ -103,6 +113,115 @@ internal sealed class SelectProjection
         public List<string> Locators { get; } = [];
 
         public List<Type> ColumnTypes { get; } = [];
+
+        /// <summary>Set when a snippet or highlight was projected -- fisher#220.</summary>
+        public bool RequiresFullTextJoin { get; private set; }
+
+        /// <summary>
+        ///     <c>Snippet()</c> and <c>Highlight()</c>, which are columns without being members.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///     They read a value the FTS5 match computes, so there is nothing on the document to
+        ///     resolve them to -- they become a locator here the same way a member does, and the rest
+        ///     of the projection machinery cannot tell the difference. That is the whole reason a
+        ///     projected snippet costs so little: the rewrite already replaces arbitrary sub-expressions
+        ///     with reads from the row's value array.
+        ///     </para>
+        ///     <para>
+        ///     Marker text is captured at translation time, like every other argument the full-text
+        ///     operators take. A marker that cannot be evaluated when the query is built is refused
+        ///     rather than deferred.
+        ///     </para>
+        /// </remarks>
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.DeclaringType != typeof(FullTextSearchExtensions))
+            {
+                return base.VisitMethodCall(node);
+            }
+
+            var method = node.Method.Name;
+
+            if (method is not ("Snippet" or "Highlight"))
+            {
+                throw new BadLinqExpressionException(
+                    $"'{method}' filters rows and belongs in a Where, not in a Select -- it answers "
+                    + "whether a document matched, which is not a value to project.");
+            }
+
+            var mapping = _members.Mapping
+                          ?? throw new BadLinqExpressionException(
+                              $"'{method}' can only be used against a document type.");
+
+            var index = mapping.FullTextIndex
+                        ?? throw new BadLinqExpressionException(
+                            $"'{mapping.DocumentType.Name}' declares no full-text index, so there is "
+                            + $"nothing for '{method}' to read.");
+
+            var table = Weasel.Sqlite.SchemaUtils.QuoteName(
+                Storage.FullText.FullTextSchema.TableNameFor(mapping).Name);
+
+            var locator = method == "Snippet"
+                ? SnippetLocator(node, table)
+                : HighlightLocator(node, table, index, mapping.DocumentType.Name);
+
+            RequiresFullTextJoin = true;
+
+            if (!_indexes.TryGetValue(locator, out var slot))
+            {
+                slot = Locators.Count;
+                _indexes[locator] = slot;
+                Locators.Add(locator);
+                ColumnTypes.Add(typeof(string));
+            }
+
+            return Expression.Convert(
+                Expression.ArrayIndex(Values, Expression.Constant(slot)), node.Type);
+        }
+
+        private static string SnippetLocator(MethodCallExpression node, string table)
+            => node.Arguments.Count == 1
+                ? FullTextExtract.Snippet(table, FullTextExtract.BestColumn, "<b>", "</b>", "\u2026", 32)
+                : FullTextExtract.Snippet(
+                    table,
+                    FullTextExtract.BestColumn,
+                    Argument<string>(node, 1, "startMarker"),
+                    Argument<string>(node, 2, "endMarker"),
+                    Argument<string>(node, 3, "ellipsis"),
+                    Argument<int>(node, 4, "maxTokens"));
+
+        private static string HighlightLocator(MethodCallExpression node, string table,
+            Storage.FullText.FullTextIndex index, string documentType)
+        {
+            var column = Argument<string>(node, 1, "column");
+            var ordinal = Array.FindIndex(index.MemberNames,
+                name => string.Equals(name, column, StringComparison.OrdinalIgnoreCase));
+
+            if (ordinal < 0)
+            {
+                throw new BadLinqExpressionException(
+                    $"'{column}' is not an indexed member of '{documentType}', so Highlight has no "
+                    + $"column to read. The index covers: {string.Join(", ", index.MemberNames)}.");
+            }
+
+            return node.Arguments.Count == 2
+                ? FullTextExtract.Highlight(table, ordinal, "<b>", "</b>")
+                : FullTextExtract.Highlight(table, ordinal,
+                    Argument<string>(node, 2, "startMarker"),
+                    Argument<string>(node, 3, "endMarker"));
+        }
+
+        private static T Argument<T>(MethodCallExpression node, int position, string name)
+        {
+            var value = WhereClauseParser.ExtractValue(node.Arguments[position]);
+
+            return value is T typed
+                ? typed
+                : throw new BadLinqExpressionException(
+                    $"'{node.Method.Name}' requires a '{name}' that can be evaluated when the query "
+                    + "is built.");
+        }
 
         protected override Expression VisitMember(MemberExpression node)
         {

--- a/src/Fisher/Linq/SqlGeneration/FullTextExtract.cs
+++ b/src/Fisher/Linq/SqlGeneration/FullTextExtract.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+
+namespace Fisher.Linq.SqlGeneration;
+
+/// <summary>
+///     The <c>snippet()</c> and <c>highlight()</c> projection locators — fisher#220.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Locator strings for the same reason <see cref="FullTextRank" /> is one: a projected column
+///         is a locator in <see cref="Statement" />'s select list, so building these as SQL text is
+///         what lets them travel through the projection machinery without it learning about full text.
+///     </para>
+///     <para>
+///         <b>Markers are rendered as SQL literals, not bound.</b> Every other caller value in a Fisher
+///         query is a parameter, so the exception needs its reason: these sit in the SELECT list, which
+///         is assembled as a locator string rather than as a fragment that could carry parameters. They
+///         are therefore escaped the only way a SQLite string literal can be — by doubling every single
+///         quote — which is complete for this grammar rather than a filter that hopes to catch the
+///         dangerous cases.
+///     </para>
+///     <para>
+///         The column index is never a caller string: it is resolved from the index's own declared
+///         columns, so an unknown name is refused before anything is rendered.
+///     </para>
+/// </remarks>
+internal static class FullTextExtract
+{
+    /// <summary>FTS5's "pick the best-matching column".</summary>
+    public const int BestColumn = -1;
+
+    public static string Snippet(string quotedTable, int column, string startMarker, string endMarker,
+        string ellipsis, int maxTokens)
+        => $"snippet({quotedTable}, {column.ToString(CultureInfo.InvariantCulture)}, "
+           + $"{Literal(startMarker)}, {Literal(endMarker)}, {Literal(ellipsis)}, "
+           + $"{maxTokens.ToString(CultureInfo.InvariantCulture)})";
+
+    public static string Highlight(string quotedTable, int column, string startMarker, string endMarker)
+        => $"highlight({quotedTable}, {column.ToString(CultureInfo.InvariantCulture)}, "
+           + $"{Literal(startMarker)}, {Literal(endMarker)})";
+
+    private static string Literal(string value)
+        => "'" + value.Replace("'", "''") + "'";
+}


### PR DESCRIPTION
Closes #220 — the second and last half. The relevance half (#225) added the FTS5 join; this rides on it, because `snippet()` and `highlight()` need exactly what `bm25()` needed: the table genuinely in scope rather than hidden inside the #215 sub-select.

```csharp
session.Query<Article>()
    .Where(x => x.Search("corrosion"))
    .Select(x => new { x.Title, Extract = x.Snippet() })
```

`Snippet()`, `Snippet(start, end, ellipsis, maxTokens)`, `Highlight(column)` and `Highlight(column, start, end)`.

## It cost far less than the issue estimated

The ruling was that these should be projection members, and `SelectProjection` turned out to be almost ready for it: it already rewrites arbitrary sub-expressions into reads from the row's value array, so a snippet becomes a locator there the same way a member does. **One `VisitMethodCall` override**, and nothing else in the projection machinery learns that full text exists.

## Three things found by running SQLite rather than reading about it

**Snippet and highlight only work because Fisher's index uses external content.** A contentless FTS5 table stores no text, and `snippet()` over one returns an **empty string rather than an error** — so on a different index design this whole capability would have been silently useless. `Fts5Table` declares `content=<view>` with `content_rowid`, so the text is retrievable. Worth stating plainly because it is a load-bearing property of that table nothing else depends on.

**`Highlight` requires an explicit column, unlike `Snippet`.** FTS5 accepts `-1` there and returns an empty string for it. So a default of "whichever column matched" would be a silent wrong answer, and a default of "the first one" would be wrong whenever the match was elsewhere. `Snippet` keeps `-1`, where it is the documented "best column" behaviour and does work.

**Markers are rendered as SQL literals rather than bound**, because they sit in the SELECT list, which is assembled as a locator string rather than as a fragment that can carry parameters. They are escaped by doubling single quotes — complete for SQLite's string grammar, not a filter hoping to catch the dangerous cases — and there is a test that a marker full of quotes comes back as data instead of closing the literal. The column index is never a caller string; it is resolved from the index's own declared members, so nothing else in the rendered SQL comes from user input.

## Refusals

| Refused | Why |
|---|---|
| An unknown `Highlight` column | Named against the index's own members; the message lists what is indexed |
| An extract with no full-text predicate | Same reason as ranking — nothing for it to read |
| One of the six filtering operators inside a `Select` | It answers "did this match", which is not a value to project |
| Calling either outside a query | No in-memory equivalent, and nothing on the document to fall back to |

## Tests

Fisher.Tests **1952**, AspNetCore **36**, EntityFrameworkCore **19** — **2007 green on both TFMs**. Scoreboard verified with `scripts/check_scoreboard.py` against a real Release run.

The snippet corpus is deliberately well past the 32-token budget, so an un-elided answer means the budget was ignored rather than that the text simply fitted — the first cut of that test had a body short enough to fit and would have passed whatever the budget did.

With this, all three of the issue's "worth settling here" items are settled: column weights and compose-vs-replace in #225, snippet-as-projection-member here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)