### PR TITLE
Bump JasperFx to 2.66.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.66.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.66.0" />
+        <PackageVersion Include="JasperFx" Version="2.66.1" />
+        <PackageVersion Include="JasperFx.Events" Version="2.66.1" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.66.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.66.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.66.1" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.66.1" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,9 +12,9 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2007 tests green on net9.0 and net10.0** — 1952 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 516 of
-them are shared cross-store compliance tests — 447 event sourcing and 69 document. On JasperFx **2.66.0** / Weasel **9.31.0**.
+**2008 tests green on net9.0 and net10.0** — 1953 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 517 of
+them are shared cross-store compliance tests — 448 event sourcing and 69 document. On JasperFx **2.66.1** / Weasel **9.31.0**.
 
 ## The high-water opt-out, audited (#199)
 
@@ -662,8 +662,8 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.66.0 ships 52 suites; Fisher enrolls **50 of them, 516 tests**.
-Fisher passes **516 of them, across all
+`JasperFx.Events.ComplianceTests` 2.66.1 ships 52 suites; Fisher enrolls **50 of them, 517 tests**.
+Fisher passes **517 of them, across all
 50 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
 pass on the 2.65.0 pin were the upstream ones described at the top of this file, and 2.66.0 closed
 all five.
@@ -699,7 +699,7 @@ shape: `DocumentLoadAndStoreCompliance` gained three tests for `LoadAsync<T>(obj
 fisher#89) and `DocumentComplianceConfig` gained `ValueTypes`. Diffing the suite *list* would have
 reported a clean bump — diff the contents.
 
-The library is now two halves. The **event sourcing** half is 43 enrolled suites and 447 tests, and the
+The library is now two halves. The **event sourcing** half is 43 enrolled suites and 448 tests, and the
 upstream backlog it emptied in 2.45.0 refilled in 2.64.0 — see "Wave 13" below. The
 **document** half arrived in 2.47.0 (jasperfx#647) and is now seven suites, 69 tests, over the
 store-agnostic document contract Fisher implements for fisher#68. Every suite added since 2.49.0 has
@@ -719,7 +719,7 @@ been built to the sibling's shape:
 | `FlatTableProjectionCompliance` | 2.41.0 | A real feature: `Projections/Flattened/`, ~700 lines. See CLAUDE.md. |
 | `StrongTypedIdentityCompliance` | 2.42.0 | A real feature, fisher#14: `Storage/StrongTypedId.cs` and `StrongTypedIdentification`. No new seam was needed — `IIdentification<TDoc,TId>` had already reserved the three members for it. |
 | `EventDataMaskingCompliance` | 2.43.0 | Three seam members, no production change. 10 tests green on the bump. |
-| `StreamCompactingCompliance` | 2.43.0 | Nothing at all. 11 tests green on the bump; the member was already on the shared operations surface. |
+| `StreamCompactingCompliance` | 2.43.0 | Nothing at all. 12 tests green on the bump; the member was already on the shared operations surface. The twelfth arrived with jasperfx#796 in 2.66.1, which is also the fix for fisher#203. |
 | `RebuildAndCatchUpCompliance` | 2.44.0 | Nothing at all. 11 tests green on the bump; the whole rebuild surface is on `IProjectionDaemon`. |
 | `DeadLetterCompliance` | 2.44.0 | Nothing at all. 6 tests green on the bump; `ContinuousErrors` and `QueryDeadLetterEventsAsync` were already there for the daemon. |
 | `ConjoinedEventTenancyCompliance` | 2.45.0 | One seam member, no production change. 8 tests green on the bump — and the first suite to test a Fisher feature nothing cross-store had covered. |
@@ -801,9 +801,9 @@ naming.
 **Green on all fifty is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 50 suites, 516 tests
+### Green — 50 suites, 517 tests
 
-Event sourcing — 43 suites, 447 tests:
+Event sourcing — 43 suites, 448 tests:
 
 | Suite | Tests |
 |---|---|
@@ -824,7 +824,7 @@ Event sourcing — 43 suites, 447 tests:
 | `ConjoinedEventTenancyCompliance` | 11 |
 | `EventDataMaskingCompliance` | 11 |
 | `RebuildAndCatchUpCompliance` | 11 |
-| `StreamCompactingCompliance` | 11 |
+| `StreamCompactingCompliance` | 12 |
 | `StreamReadCompliance` | 11 |
 | `SubscriptionCompliance` | 11 |
 | `FlatTableProjectionCompliance` | 10 |

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 50 suites and 516 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,952.
+> Fisher passes **all 50 suites and 517 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,953.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -9,7 +9,7 @@ namespace Fisher.Tests.Compliance;
  * these tests cannot drift between the products.
  *
  * Suites were added one at a time as Fisher grew into them, and fifty are enrolled from
- * JasperFx.Events.ComplianceTests 2.66.0, which itself ships fifty-two. One is not enrolled:
+ * JasperFx.Events.ComplianceTests 2.66.1, which itself ships fifty-two. One is not enrolled:
  * SingleTenantedEventSlicingCompliance, for the precondition reason set out below.
  *
  * Three of the ten suites this wave adds are enrolled and gated off rather than green, each for a


### PR DESCRIPTION
Moves all four JasperFx pins from 2.66.0 to 2.66.1 in `Directory.Packages.props`.

Prompted by the Wolverine 6.35 cut, which pins JasperFx 2.66.1 — a store compiled against 2.66.0
would roll forward at runtime, but the store's own floor is what a standalone Fisher consumer gets,
and there is a reason to want it here.

## Why 2.66.1 matters for Fisher specifically

jasperfx#796 appends `Compacted<TDoc>` to a single-stream projection's event types in
`JasperFxSingleStreamProjectionBase.determineEventTypes()` — the shared fix for **fisher#203**. Its
own commentary names the failure:

> a filtered async shard catching up over a compacted stream from a null snapshot folds only what was
> appended *after* compaction and persists an aggregate missing everything before it, with no
> exception and no log line, while an unfiltered shard over the identical rows disagrees.

The same release also dedupes that append, which had been reaching the generated SQL as a repeated
`IN` member.

No new interface members between 2.66.0 and 2.66.1, so this is a floor move rather than a port.

## Verification

`dotnet build fisher.slnx -c Release` clean, and the full suite on **both** target frameworks:

| Suite | net9.0 | net10.0 |
|---|---|---|
| `Fisher.Tests` | 1936 passed, 17 skipped | 1936 passed, 17 skipped |
| `Fisher.AspNetCore.Tests` | 36 passed | 36 passed |
| `Fisher.EntityFrameworkCore.Tests` | 19 passed | 19 passed |

0 failed anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)