### PR TITLE
Honor EventQuery.TagValues, on JasperFx 2.67.0 (#230)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3777,6 +3777,41 @@ load-bearing, and both were verified by removing them:
   so an ungated filter is not an empty result but `SQLite Error 1: no such column`. Ignoring the filter
   is what `EventQuery` asks for and what Polecat does.
 
+**The two spellings of the tag filter are two renderings, not one folded into the other** (fisher#230
+/ jasperfx#801). `TagConditions` is the rich CLR-typed form and its conditions are **OR'd**;
+`TagValues` is the lossy name/value dictionary and its entries are **AND'd**, then AND'd with every
+other filter. Same `seq_id in (select seq_id from <tag table> where value = …)` sub-select on both —
+chosen over a join because a join multiplies rows when one event carries several matching tags, which
+is also what keeps `TotalCount` counting distinct events. Supplying both is refused by
+`EventQuery.AssertIsWellFormed`, which `AssertFiltersAreSupported` calls first thing, so the existing
+call site gets it for free.
+
+Three decisions in the lossy form:
+
+- **The name is resolved by the shared `TagTypeRegistrationExtensions.RequireByTagName`**, not by
+  anything of Fisher's: a caller holding only a store descriptor and a name cannot discover which
+  spelling an engine accepts, so the CLR simple name (`ManifestId`) and the registered table suffix
+  (`manifest`) both resolve, case-insensitively, on every store. An unregistered name is an
+  `ArgumentException` **listing what is registered** rather than an empty answer — "that tag type does
+  not exist here" and "no event carries that tag" must not read alike.
+- **Case-insensitive value matching is done by normalising the caller's value where the stored form is
+  canonical, and by `collate nocase` only where it is not.** `EventTagWriter.ToDatabaseValue` renders a
+  Guid as lowercase canonical text and a number as an INTEGER, so for those the caller's spelling is
+  converted and compared with a plain `=`, which the tag table's `(value, seq_id)` primary key serves
+  as a range scan; a value that does not parse binds as typed and therefore matches nothing, which is
+  the right answer rather than an error. Only a **string** tag needs `collate nocase`, its stored text
+  being the application's own casing with nothing to normalise to — and that one comparison cannot
+  reach the primary key index, since SQLite reaches an index only under the index's own collation. A
+  string-tag lookup in this spelling therefore scans the tag table, which is the honest price of the
+  contract and is confined to the tag table rather than to `fi_events`.
+- **SQLite's `NOCASE` folds ASCII only**, where .NET's `OrdinalIgnoreCase` folds the whole of Unicode,
+  so a non-ASCII string tag matches by exact casing here. Recorded rather than worked around: the
+  alternative is a scan with a custom collation, for a difference no shared fact exercises.
+
+Fisher does not implement the dictionary `IEventStore.QueryByTagsAsync` overload at all, so there is no
+second code path to keep in step — `TagValues` is the better home for that capability anyway, being
+composable and paged where the overload is neither.
+
 The count is a second statement rather than `count(*) over ()`, because a window function returns no
 row at all for a page past the end — and "page 9 of a 3-page result" is exactly when a tool most needs
 the real total. `a_page_past_the_end_still_reports_the_total` pins it.
@@ -4301,7 +4336,7 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**Fisher enrolls 50 of the 52 suites `JasperFx.Events.ComplianceTests` 2.65.0 ships — 516 tests.**
+**Fisher enrolls 50 of the 52 suites `JasperFx.Events.ComplianceTests` 2.67.0 ships — 530 tests.**
 `JasperFx.Events.ComplianceTests` is referenced unconditionally — the old `$(EnableComplianceTests)`
 gate is gone. See HANDOFF.md for the live scoreboard, which is machine-checked against a real run by
 `scripts/check_scoreboard.py`; what follows is the history and the mechanics.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.66.1" />
-        <PackageVersion Include="JasperFx.Events" Version="2.66.1" />
+        <PackageVersion Include="JasperFx" Version="2.67.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.67.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.66.1" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.66.1" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.67.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.67.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,9 +12,9 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2008 tests green on net9.0 and net10.0** — 1953 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 517 of
-them are shared cross-store compliance tests — 448 event sourcing and 69 document. On JasperFx **2.66.1** / Weasel **9.31.0**.
+**2026 tests green on net9.0 and net10.0** — 1971 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 530 of
+them are shared cross-store compliance tests — 461 event sourcing and 69 document. On JasperFx **2.67.0** / Weasel **9.31.0**.
 
 ## The high-water opt-out, audited (#199)
 
@@ -662,8 +662,8 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.66.1 ships 52 suites; Fisher enrolls **50 of them, 517 tests**.
-Fisher passes **517 of them, across all
+`JasperFx.Events.ComplianceTests` 2.67.0 ships 52 suites; Fisher enrolls **50 of them, 530 tests**.
+Fisher passes **530 of them, across all
 50 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
 pass on the 2.65.0 pin were the upstream ones described at the top of this file, and 2.66.0 closed
 all five.
@@ -699,7 +699,7 @@ shape: `DocumentLoadAndStoreCompliance` gained three tests for `LoadAsync<T>(obj
 fisher#89) and `DocumentComplianceConfig` gained `ValueTypes`. Diffing the suite *list* would have
 reported a clean bump — diff the contents.
 
-The library is now two halves. The **event sourcing** half is 43 enrolled suites and 448 tests, and the
+The library is now two halves. The **event sourcing** half is 43 enrolled suites and 461 tests, and the
 upstream backlog it emptied in 2.45.0 refilled in 2.64.0 — see "Wave 13" below. The
 **document** half arrived in 2.47.0 (jasperfx#647) and is now seven suites, 69 tests, over the
 store-agnostic document contract Fisher implements for fisher#68. Every suite added since 2.49.0 has
@@ -801,13 +801,13 @@ naming.
 **Green on all fifty is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 50 suites, 517 tests
+### Green — 50 suites, 530 tests
 
-Event sourcing — 43 suites, 448 tests:
+Event sourcing — 43 suites, 461 tests:
 
 | Suite | Tests |
 |---|---|
-| `EventQueryCompliance` | 41 |
+| `EventQueryCompliance` | 53 |
 | `DcbTagQueryAndConsistencyCompliance` | 28 |
 | `ProjectionScenarioCompliance` | 20 |
 | `StringStreamIdentityCompliance` | 19 |
@@ -824,7 +824,7 @@ Event sourcing — 43 suites, 448 tests:
 | `ConjoinedEventTenancyCompliance` | 11 |
 | `EventDataMaskingCompliance` | 11 |
 | `RebuildAndCatchUpCompliance` | 11 |
-| `StreamCompactingCompliance` | 12 |
+| `StreamCompactingCompliance` | 13 |
 | `StreamReadCompliance` | 11 |
 | `SubscriptionCompliance` | 11 |
 | `FlatTableProjectionCompliance` | 10 |

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 50 suites and 517 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,953.
+> Fisher passes **all 50 suites and 530 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,971.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -47,8 +47,8 @@ Two different policies, each right for its caller.
 var page = await session.Events.QueryEventsAsync(new EventQuery
 {
     StreamId = streamId.ToString(),
-    EventTypes = ["OrderPlaced"],
-    From = cutoff,
+    EventTypeNames = ["OrderPlaced"],
+    TimestampFrom = cutoff,
     CorrelationId = correlationId,
     PageNumber = 1,
     PageSize = 50
@@ -77,6 +77,43 @@ is what the query shape asks for and what Polecat does.
 The count is a **second statement**, not `count(*) over ()` — a window function returns no row at all
 for a page past the end, and "page 9 of a 3-page result" is exactly when a tool most needs the real
 total.
+
+### Filtering by tags
+
+Two spellings, and they are alternatives rather than a combination — supplying both is an
+`ArgumentException`.
+
+`TagValues` is the lossy name/value form. Entries are **AND'd**: an event matches when it carries
+every named tag at the given value, and that selection is then AND'd with every other filter, so a
+tag query keeps paging and a truthful `TotalCount`.
+
+```cs
+var page = await session.Events.QueryEventsAsync(new EventQuery
+{
+    // Either the registered table suffix or the tag type's CLR name, case-insensitively.
+    TagValues = { ["shipment"] = shipmentId.ToString(), ["CarrierCode"] = "Acme" },
+    EventTypeNames = ["CargoLoaded"],
+    PageSize = 50
+});
+```
+
+`TagConditions` is the rich CLR-typed form, and its conditions are **OR'd**. Reach for it when the
+caller holds the tag types; reach for `TagValues` when it holds only a name — an HTTP query string, a
+CritterWatch console, the `event-query --tags` flag.
+
+::: tip
+**An unregistered tag name is refused, not answered empty.** "That tag type does not exist here" and
+"no event carries that tag" must not read alike, or a caller with a typo concludes the events are
+gone. The message lists what *is* registered.
+:::
+
+::: warning
+**A string-valued tag is matched case-insensitively, and pays a scan of its tag table for it.** A Guid
+or numeric tag has a canonical stored form, so the value you pass is normalised to it and the tag
+table's primary key serves the lookup. A string tag's stored text is your own casing, so the
+comparison carries `collate nocase` — and SQLite reaches an index only under the index's own
+collation. Note also that SQLite's `NOCASE` folds ASCII only.
+:::
 
 ## Querying event bodies
 

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -9,7 +9,7 @@ namespace Fisher.Tests.Compliance;
  * these tests cannot drift between the products.
  *
  * Suites were added one at a time as Fisher grew into them, and fifty are enrolled from
- * JasperFx.Events.ComplianceTests 2.66.1, which itself ships fifty-two. One is not enrolled:
+ * JasperFx.Events.ComplianceTests 2.67.0, which itself ships fifty-two. One is not enrolled:
  * SingleTenantedEventSlicingCompliance, for the precondition reason set out below.
  *
  * Three of the ten suites this wave adds are enrolled and gated off rather than green, each for a

--- a/src/Fisher.Tests/Events/lossy_tag_queries.cs
+++ b/src/Fisher.Tests/Events/lossy_tag_queries.cs
@@ -1,0 +1,205 @@
+using JasperFx;
+using JasperFx.Events;
+using Microsoft.Data.Sqlite;
+
+namespace Fisher.Tests.Events;
+
+public record ShipmentId(Guid Value);
+
+public record CarrierCode(string Value);
+
+public record DockNumber(int Value);
+
+public record CargoLanded(string Species, int Weight);
+
+/// <summary>
+///     <c>EventQuery.TagValues</c> — the lossy name/value tag filter (fisher#230 / jasperfx#801).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>EventQueryCompliance</c> owns the behaviour: the name spellings, the case-insensitivity,
+///         the AND across entries and with every other filter, paging and <c>TotalCount</c>, and both
+///         refusals. Twelve facts, and none of them is repeated here.
+///     </para>
+///     <para>
+///         What is here is the two things that suite structurally cannot see. It registers a
+///         Guid-valued and a string-valued tag and no numeric one, so an INTEGER tag column — a
+///         different affinity path entirely, and one that fails by matching nothing — is uncovered.
+///         And it cannot see <em>which index SQLite reaches</em>, which is the whole reason
+///         <c>BindTagValue</c> exists: a blanket <c>collate nocase</c> answers every one of those
+///         twelve facts correctly and scans the tag table doing it.
+///     </para>
+/// </remarks>
+public class lossy_tag_queries : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("lossy-tag-queries");
+    private DocumentStore _store = null!;
+
+    private readonly ShipmentId _shipment = new(Guid.NewGuid());
+    private readonly CarrierCode _carrier = new("Acme");
+    private readonly DockNumber _dock = new(42);
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(o =>
+        {
+            o.ConnectionString = _database.ConnectionString;
+            o.AutoCreateSchemaObjects = AutoCreate.All;
+
+            // Suffixes deliberately unlike the CLR names, so a test naming one is naming that spelling.
+            o.Events.RegisterTagType<ShipmentId>("shipment");
+            o.Events.RegisterTagType<CarrierCode>("carrier");
+            o.Events.RegisterTagType<DockNumber>("dock");
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = _store.LightweightSession();
+
+        var loaded = session.Events.BuildEvent(new CargoLanded("Trout", 3));
+        loaded.WithTag(_shipment, _carrier, _dock);
+        session.Events.StartStream(Guid.NewGuid(), loaded);
+
+        var untagged = session.Events.BuildEvent(new CargoLanded("Pike", 11));
+        session.Events.StartStream(Guid.NewGuid(), untagged);
+
+        await session.SaveChangesAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    ///     An INTEGER-valued tag matches on the string form of its number. The compliance suite
+    ///     registers no numeric tag, and this is the one column type where the caller's value and the
+    ///     stored value have different SQLite types — so it either converts or silently matches
+    ///     nothing.
+    /// </summary>
+    [Fact]
+    public async Task an_integer_valued_tag_matches_on_its_string_form()
+    {
+        await using var session = _store.LightweightSession();
+
+        var result = await session.Events.QueryEventsAsync(
+            new EventQuery { TagValues = { ["dock"] = "42" }, PageSize = 100 }, Token);
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Data.ShouldBeOfType<CargoLanded>().Species.ShouldBe("Trout");
+
+        var miss = await session.Events.QueryEventsAsync(
+            new EventQuery { TagValues = { ["dock"] = "43" }, PageSize = 100 }, Token);
+
+        miss.TotalCount.ShouldBe(0);
+    }
+
+    /// <summary>
+    ///     A value that is not a number at all is an empty answer, not an error — the same rule the
+    ///     suite pins for an unmatched Guid, on the column type where a conversion could have thrown.
+    /// </summary>
+    [Fact]
+    public async Task an_unparseable_value_for_a_numeric_tag_is_an_empty_answer()
+    {
+        await using var session = _store.LightweightSession();
+
+        var result = await session.Events.QueryEventsAsync(
+            new EventQuery { TagValues = { ["dock"] = "not-a-number" }, PageSize = 100 }, Token);
+
+        result.TotalCount.ShouldBe(0);
+        result.Events.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     A Guid tag's comparison is exact, so the tag table's <c>(value, seq_id)</c> primary key
+    ///     serves the sub-select as a search rather than a scan.
+    /// </summary>
+    /// <remarks>
+    ///     The pin on <c>BindTagValue</c>'s Guid arm, and the only assertion that can see it: the
+    ///     caller's spelling is normalised to the lowercase canonical form
+    ///     <c>EventTagWriter.ToDatabaseValue</c> wrote, so the comparison needs no collation override
+    ///     and SQLite can reach the index. Replacing it with <c>collate nocase</c> answers the same
+    ///     rows and reports <c>SCAN</c> here.
+    /// </remarks>
+    [Fact]
+    public async Task a_guid_tag_lookup_is_served_by_the_tag_tables_primary_key()
+    {
+        var plan = await QueryPlanAsync(new EventQuery
+        {
+            TagValues = { ["shipment"] = _shipment.Value.ToString().ToUpperInvariant() }
+        });
+
+        plan.ShouldContain("fi_event_tag_shipment");
+        plan.ShouldContain("SEARCH");
+        plan.ShouldNotContain("SCAN fi_event_tag_shipment");
+    }
+
+    /// <summary>
+    ///     A numeric tag reaches the index the same way, its value having been normalised to an
+    ///     INTEGER rather than left as the caller's text.
+    /// </summary>
+    [Fact]
+    public async Task a_numeric_tag_lookup_is_served_by_the_tag_tables_primary_key()
+    {
+        var plan = await QueryPlanAsync(new EventQuery { TagValues = { ["dock"] = "42" } });
+
+        plan.ShouldContain("fi_event_tag_dock");
+        plan.ShouldNotContain("SCAN fi_event_tag_dock");
+    }
+
+    /// <summary>
+    ///     A string tag is the one that scans, and it is recorded rather than fixed: its stored text is
+    ///     the application's own casing, so there is nothing to normalise the caller's spelling to and
+    ///     <c>collate nocase</c> is what the contract's case-insensitivity costs. SQLite reaches an
+    ///     index only under the index's own collation.
+    /// </summary>
+    [Fact]
+    public async Task a_string_tag_lookup_pays_a_scan_for_its_case_insensitivity()
+    {
+        var plan = await QueryPlanAsync(new EventQuery { TagValues = { ["carrier"] = "ACME" } });
+
+        plan.ShouldContain("SCAN fi_event_tag_carrier");
+
+        // And it is genuinely case-insensitive, which is what the scan buys.
+        await using var session = _store.LightweightSession();
+        var result = await session.Events.QueryEventsAsync(
+            new EventQuery { TagValues = { ["carrier"] = "ACME" }, PageSize = 100 }, Token);
+
+        result.TotalCount.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     The production <c>where</c> clause, through <c>explain query plan</c>. Rendered by
+    ///     <c>EventOperations.AppendEventQueryFilters</c> itself rather than by a copy, because a plan
+    ///     over a re-derivation would report about SQL the store does not run — the same reason
+    ///     <c>ExplainAsync</c> takes the statement the query would run.
+    /// </summary>
+    private async Task<string> QueryPlanAsync(EventQuery query)
+    {
+        await using var session = _store.LightweightSession();
+
+        var builder = new Weasel.Sqlite.CommandBuilder();
+        builder.Append("explain query plan select seq_id from ");
+        builder.Append(_store.Options.EventGraph.EventsTableName);
+
+        session.Events.AppendEventQueryFilters(builder, query);
+
+        var command = builder.Compile();
+
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+        command.Connection = connection;
+
+        var lines = new List<string>();
+        await using var reader = await command.ExecuteReaderAsync(Token);
+        while (await reader.ReadAsync(Token))
+        {
+            lines.Add(reader.GetString(reader.GetOrdinal("detail")));
+        }
+
+        return string.Join(" | ", lines);
+    }
+}

--- a/src/Fisher/Events/EventOperations.RawQuery.cs
+++ b/src/Fisher/Events/EventOperations.RawQuery.cs
@@ -269,7 +269,14 @@ public partial class EventOperations
     ///     Append the query's <c>where</c> clause, shared by the page read and the count so the two
     ///     cannot disagree about what matches.
     /// </summary>
-    private void AppendEventQueryFilters(Weasel.Sqlite.CommandBuilder builder, EventQuery query)
+    /// <remarks>
+    ///     Internal rather than private so <c>lossy_tag_queries</c> can put the rendered clause through
+    ///     <c>explain query plan</c>. That test is asserting which index SQLite reaches, which is the
+    ///     one thing about <see cref="AppendTagValueFilter" /> no behavioural assertion can see — a
+    ///     blanket <c>collate nocase</c> answers every compliance fact correctly and scans the tag
+    ///     table doing it.
+    /// </remarks>
+    internal void AppendEventQueryFilters(Weasel.Sqlite.CommandBuilder builder, EventQuery query)
     {
         var first = true;
 
@@ -380,6 +387,18 @@ public partial class EventOperations
             AppendTagConditionsFilter(builder, query.TagConditions);
         }
 
+        // The lossy name/value spelling of the tag filter (jasperfx#801). One sub-select per entry,
+        // AND'd — the opposite combinator from TagConditions above, whose conditions are OR'd, which
+        // is why this is a second rendering rather than a fold into that one. Riding the same
+        // Prefix() run is what ANDs it with every other filter as well. Sub-selects rather than a
+        // join for the reason AppendTagConditionsFilter gives: a join multiplies rows when one event
+        // carries several of the named tags, and TotalCount has to count distinct events.
+        foreach (var pair in query.TagValues)
+        {
+            Prefix();
+            AppendTagValueFilter(builder, pair.Key, pair.Value);
+        }
+
         if (IsConjoined)
         {
             // The query's tenant selects the partition when supplied (jasperfx#555 — the read-only
@@ -459,6 +478,90 @@ public partial class EventOperations
         }
 
         builder.Append(')');
+    }
+
+    /// <summary>
+    ///     Render one entry of <see cref="EventQuery.TagValues" /> — the lossy name/value spelling of a
+    ///     tag filter (jasperfx#801) — as a <c>seq_id in (select …)</c> sub-select over that tag's
+    ///     table.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The name is resolved by the shared <see cref="TagTypeRegistrationExtensions.RequireByTagName" />
+    ///         matcher rather than by anything of Fisher's, because the name matching <em>is</em> the
+    ///         contract: a caller holding a store descriptor and a name/value pair cannot discover which
+    ///         spelling a given engine accepts, so the CLR simple name and the registered table suffix
+    ///         both have to work on every store. An unregistered name is an
+    ///         <see cref="ArgumentException" /> listing what <em>is</em> registered — never an empty
+    ///         answer, because "that tag type does not exist here" and "no event carries that tag" must
+    ///         not read alike.
+    ///     </para>
+    ///     <para>
+    ///         <b>The value is matched case-insensitively, and how that is done depends on the tag's
+    ///         primitive.</b> For a <see cref="Guid" /> or a number the stored form is canonical —
+    ///         <see cref="EventTagWriter.ToDatabaseValue" /> renders a Guid as lowercase canonical text
+    ///         and a number as an INTEGER — so the caller's spelling is normalised to that form and
+    ///         compared with a plain <c>=</c>, which the tag table's <c>(value, seq_id)</c> primary key
+    ///         serves as a range scan. A value that does not parse is bound as the caller typed it and
+    ///         therefore matches nothing, which is the right answer rather than an error.
+    ///     </para>
+    ///     <para>
+    ///         Only a <b>string</b> tag needs <c>collate nocase</c>: its stored text is the
+    ///         application's own casing and there is nothing to normalise it to. That one comparison
+    ///         cannot use the primary key index — SQLite reaches an index only under the index's own
+    ///         collation — so a string-tag lookup in this spelling scans the tag table. That is the
+    ///         honest price of the case-insensitivity the contract asks for, and it applies to the tag
+    ///         table alone rather than to <c>fi_events</c>. Note also that SQLite's <c>NOCASE</c> folds
+    ///         ASCII only, where .NET's <c>OrdinalIgnoreCase</c> folds the whole of Unicode, so a
+    ///         non-ASCII string tag matches by exact casing here.
+    ///     </para>
+    /// </remarks>
+    private void AppendTagValueFilter(Weasel.Sqlite.CommandBuilder builder, string tagName, string tagValue)
+    {
+        var registration = Graph.TagTypes
+            .RequireByTagName(tagName, $"{nameof(EventQuery)}.{nameof(EventQuery.TagValues)}");
+
+        var (bound, caseInsensitive) = BindTagValue(registration.SimpleType, tagValue);
+
+        builder.Append("seq_id in (select seq_id from ");
+        builder.Append(Graph.TagTableName(registration));
+        builder.Append(" where value = ");
+        builder.AppendParameter(bound);
+
+        if (caseInsensitive)
+        {
+            builder.Append(" collate nocase");
+        }
+
+        builder.Append(')');
+    }
+
+    /// <summary>
+    ///     The value to bind for a lossy tag comparison, and whether the comparison needs
+    ///     <c>collate nocase</c> to be case-insensitive.
+    /// </summary>
+    /// <remarks>
+    ///     The inverse of <see cref="EventTagWriter.ToDatabaseValue" />, which is why the two belong in
+    ///     each other's reading: a write renders the tag's primitive into the column, and this renders
+    ///     the caller's string back into the same form so the comparison is exact wherever it can be.
+    /// </remarks>
+    private static (object Value, bool CaseInsensitive) BindTagValue(Type simpleType, string tagValue)
+    {
+        if (simpleType == typeof(Guid))
+        {
+            return Guid.TryParse(tagValue, out var guid)
+                ? (guid.ToString(), false)
+                : (tagValue, false);
+        }
+
+        if (simpleType == typeof(int) || simpleType == typeof(long) || simpleType == typeof(short))
+        {
+            return long.TryParse(tagValue, out var number)
+                ? (number, false)
+                : (tagValue, false);
+        }
+
+        return (tagValue, true);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #230. Also closes #203, which the bump fixes with no Fisher change — see below.

Rebased onto `main` after #229 (the 2.66.1 bump) landed.

## The bump is not optional here

`EventQuery.TagValues` joined `EventQueryFilters.All` in 2.67.0, and Fisher's
`SupportedEventQueryFilters()` starts from `All`. So the version bump on its own makes Fisher
**silently claim support for a filter it does not implement** and return unfiltered results that read
as filtered — the exact failure the jasperfx#737 guard rail exists to prevent. Implemented in the same
change for that reason, as #230 asked.

## The filter

`TagValues` is the lossy name/value spelling: entries AND'd (the opposite combinator from
`TagConditions`, whose conditions are OR'd), then AND'd with every other filter, staying on the
`PagedEvents` path so a tag query keeps paging and a truthful `TotalCount`.

Two renderings rather than one folded into the other, precisely because the combinators differ. Both
use the same `seq_id in (select seq_id from <tag table> where value = …)` sub-select rather than a
join, which is what keeps `TotalCount` counting distinct events when one event carries several of the
named tags.

Three decisions:

- **Names go through the shared `TagTypeRegistrationExtensions.RequireByTagName`**, not anything of
  Fisher's — a caller holding only a store descriptor and a name cannot discover which spelling an
  engine accepts. An unregistered name is an `ArgumentException` listing what *is* registered, never
  an empty answer.
- **Case-insensitive values are done by normalising where the stored form is canonical, and by
  `collate nocase` only where it is not.** `EventTagWriter.ToDatabaseValue` renders a Guid as
  lowercase canonical text and a number as an INTEGER, so those are converted and compared with a
  plain `=` that the tag table's `(value, seq_id)` primary key serves as a search. Only a **string**
  tag needs `collate nocase`, its stored text being the application's own casing — and that
  comparison cannot reach the index, since SQLite reaches an index only under the index's own
  collation. Confined to the tag table, not `fi_events`.
- **SQLite's `NOCASE` folds ASCII only**, where .NET's `OrdinalIgnoreCase` folds all of Unicode.
  Recorded rather than worked around; the alternative is a scan with a custom collation for a
  difference no shared fact exercises.

## Tests

`EventQueryCompliance` goes 41 → 53; all twelve new facts pass. `StreamCompactingCompliance` goes
12 → 13.

`Events/lossy_tag_queries.cs` (5 tests) covers the two things the shared suite structurally cannot
see: an **INTEGER-valued tag** (it registers a Guid and a string one and no numeric one), and **which
index SQLite reaches**, by putting the production `where` clause through `explain query plan`. That
second one is the point — a blanket `collate nocase` answers every one of the twelve compliance facts
correctly and scans the tag table doing it.

**Verified load-bearing**, per the playbook: reverting `BindTagValue` to always return
`(value, caseInsensitive: true)` fails exactly the two plan tests and nothing else — including the
integer test, since SQLite's affinity rules convert a text parameter against an INTEGER column either
way. That is what says the plan assertions are the discriminating ones.

`AppendEventQueryFilters` moved from `private` to `internal` so the plan is taken over the statement
the store actually runs rather than a re-derivation — the same reason `ExplainAsync` does.

## fisher#203 closes with no Fisher change

jasperfx#796 shipped upstream (in 2.66.1, carried by 2.67.0) and puts `Compacted<TDoc>` beside
`Archived` in the shared `determineEventTypes()`. Fisher's `FisherEventLoader` composes its allow list
from `filtering.IncludedEventTypes`, so it inherits the fix. 2.67.0's new
`StreamCompactingCompliance.an_async_shard_folds_a_compacted_stream_from_the_marker` — a filtered
async shard over a stream compacted before the daemon ever ran — is green here, which is the
discriminating fact #203 asked for. Nothing in `src/Fisher` changed for it.

## Drive-by

`docs/events/querying.md`'s `EventQuery` example named `EventTypes` and `From`, neither of which is a
field on `EventQuery`. Corrected to `EventTypeNames` / `TimestampFrom` in the block the new tag
section sits beside — it is an inline fence rather than a compiled snippet, which is how it rotted.

## Run

**2026 tests green on net9.0 and net10.0** — 1971 `Fisher.Tests`, 36 AspNetCore, 19 EF Core. 530
compliance across 50 suites (461 event / 69 document). `scripts/check_scoreboard.py` agrees on both
legs.

One unrelated pre-existing flake was seen once during this work and is filed separately:
`projection_side_effects.an_async_projection_publishes_through_the_daemons_batch` waits on
`WaitForNonStaleProjectionDataAsync` and then asserts `AfterCommitAsync` fired — but the progression
row is written *inside* the batch's transaction, so non-stale is true strictly before that hook runs.
CLAUDE.md already names this exact trap for the subscription listener. Green on re-run and on every
other leg here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)