### PR TITLE
Enforce numeric revisions for UseNumericRevisions() types too (#228)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2164,6 +2164,29 @@ reserved and Fisher was passing null — so this is dialect SQL plus wiring, not
 - **The column is INTEGER, and that is load-bearing.** A TEXT affinity would sort revision 10 below
   revision 9 and turn the "must be greater" guard into nonsense.
 
+- ⚠️ **The expected revision is a parameter, never read back off the document** (fisher#228). It used
+  to be the latter — `Store<T>(T, int)` set `IRevisioned.Version` and the operation then read that
+  member back — which made **both** halves conditional on the document implementing `IRevisioned`. So
+  for a type that opted in through `Schema.For<T>().UseNumericRevisions()` the supplied revision was
+  dropped on the floor and the operation guarded on `0`, which means auto: `UpdateRevision(doc, 7)`
+  stored the next auto-increment value, a backwards write was accepted, and `TryUpdateRevision`
+  dropped nothing — **a silent lost update, in the method whose whole purpose is to prevent one.**
+  The two routes into numeric revisions are documented as equivalent, and only the interface one
+  worked.
+  - **The mode is read off the *operation*, not off the mapping.** Only the numeric operations
+    implement `Weasel.Storage.IRevisionedOperation`, so that is the one source which cannot disagree
+    with the statement actually being built; `DocumentMapping.UseNumericRevisions` would be a second
+    answer to the same question, free to drift from it.
+  - **`Insert` and `Update` keep the fallback and need nothing else**, having no explicit-revision
+    overload — which is why `CaptureExpectedRevision` still exists, with the revision optional.
+  - **No shared suite reaches this.** `NumericRevisionCompliance` is written against `IRevisioned`
+    throughout, because the store-agnostic document contract has no configuration surface for saying
+    "this type uses numeric revisions" any other way. Fisher's own coverage did not reach it either:
+    `a_type_configured_through_the_dsl_gets_the_same_column` asserted the column existed and
+    auto-incremented, and stopped there. The four `a_dsl_configured_type_*` tests are the
+    interface-route guard tests one for one, against a type that opted in the other way, so the
+    property under test is that the two routes agree.
+
 `0` means auto — increment whatever is stored — which is the sentinel the shared operations bind when
 no revision was named, and why every guard starts with `? = 0 or`.
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2026 tests green on net9.0 and net10.0** — 1971 in
+**2030 tests green on net9.0 and net10.0** — 1975 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 530 of
 them are shared cross-store compliance tests — 461 event sourcing and 69 document. On JasperFx **2.67.0** / Weasel **9.31.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 50 suites and 530 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,971.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,975.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/documents/concurrency.md
+++ b/docs/documents/concurrency.md
@@ -81,6 +81,14 @@ session.TryUpdateRevision(doc, 4);     // no exception if it loses
 
 `0` means **auto** — increment whatever is stored.
 
+::: tip
+**The two routes behave identically, but a DSL-configured type has no `Version` member to carry an
+expectation on.** So for one of those a plain `Store(doc)` always means auto, and guarding a write
+means naming the revision: `UpdateRevision(doc, 4)`. For an `IRevisioned` type the member is both the
+expectation and where the new revision is written back, which is what makes `Store(doc)` guard on its
+own — the sharp edge below.
+:::
+
 ### The sharp edge
 
 ::: warning

--- a/src/Fisher.Tests/Documents/numeric_revisions.cs
+++ b/src/Fisher.Tests/Documents/numeric_revisions.cs
@@ -364,6 +364,125 @@ public class numeric_revisions : IAsyncLifetime
         (await StoredRevisionAsync(licence.Id, "fi_doc_licence")).ShouldBe(1);
     }
 
+    /*
+     * fisher#228. The column was the only half of the DSL route that worked. Both the supplied
+     * revision and the operation's expected revision were read off the document through
+     * `document is IRevisioned`, which a DSL-configured type is not — so UpdateRevision(doc, 7)
+     * stored the next auto-increment value instead of 7, a backwards write was accepted, and
+     * TryUpdateRevision dropped nothing, which is a silent lost update.
+     *
+     * The tests below are the interface-route guard tests one for one, against a type that opted in
+     * the other way. That the two routes agree is the property; `a_type_configured_through_the_dsl_
+     * gets_the_same_column` above asserted only that the column exists, which is why this survived.
+     *
+     * No shared suite reaches it either: NumericRevisionCompliance is written against IRevisioned
+     * throughout, because the store-agnostic document contract has no configuration surface to say
+     * "this type uses numeric revisions" any other way.
+     */
+
+    [Fact]
+    public async Task a_dsl_configured_type_stores_the_revision_it_was_given()
+    {
+        await using var store = await DslStoreAsync();
+
+        var licence = new Licence { Id = Guid.NewGuid(), Holder = "Isaak" };
+
+        await using (var session = store.LightweightSession())
+        {
+            session.UpdateRevision(licence, 7);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // 7, not the next auto-increment value.
+        (await StoredRevisionAsync(licence.Id, "fi_doc_licence")).ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task a_dsl_configured_type_refuses_a_backwards_revision()
+    {
+        await using var store = await DslStoreAsync();
+
+        var licence = new Licence { Id = Guid.NewGuid(), Holder = "Isaak" };
+
+        await using (var session = store.LightweightSession())
+        {
+            session.UpdateRevision(licence, 7);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            session.UpdateRevision(new Licence { Id = licence.Id, Holder = "Stale" }, 3);
+
+            await Should.ThrowAsync<ConcurrencyException>(async () =>
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken));
+        }
+
+        await using var check = store.LightweightSession();
+        (await check.LoadAsync<Licence>(licence.Id, TestContext.Current.CancellationToken))!
+            .Holder.ShouldBe("Isaak");
+    }
+
+    /// <summary>
+    ///     The one that was a silent lost update: <c>TryUpdateRevision</c> dropped nothing for a
+    ///     DSL-configured type, so it was indistinguishable from <c>UpdateRevision</c> and the stale
+    ///     write landed with no exception anywhere.
+    /// </summary>
+    [Fact]
+    public async Task a_dsl_configured_type_drops_a_stale_try_update()
+    {
+        await using var store = await DslStoreAsync();
+
+        var licence = new Licence { Id = Guid.NewGuid(), Holder = "Isaak" };
+
+        await using (var session = store.LightweightSession())
+        {
+            session.UpdateRevision(licence, 7);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            session.TryUpdateRevision(new Licence { Id = licence.Id, Holder = "Stale" }, 3);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var check = store.LightweightSession();
+        (await check.LoadAsync<Licence>(licence.Id, TestContext.Current.CancellationToken))!
+            .Holder.ShouldBe("Isaak");
+        (await StoredRevisionAsync(licence.Id, "fi_doc_licence")).ShouldBe(7);
+    }
+
+    /// <summary>
+    ///     A plain <c>Store</c> still means auto. The fix threads an explicit revision through as a
+    ///     parameter, and zero is what "no expectation" has to keep binding — for a type with no
+    ///     member to have read one off in the first place.
+    /// </summary>
+    [Fact]
+    public async Task a_dsl_configured_type_still_auto_increments_on_a_plain_store()
+    {
+        await using var store = await DslStoreAsync();
+
+        var licence = new Licence { Id = Guid.NewGuid(), Holder = "Isaak" };
+
+        for (var i = 0; i < 3; i++)
+        {
+            await using var session = store.LightweightSession();
+            session.Store(licence);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await StoredRevisionAsync(licence.Id, "fi_doc_licence")).ShouldBe(3);
+    }
+
+    private async Task<DocumentStore> DslStoreAsync()
+    {
+        var store = StoreFor(options => options.Schema.For<Licence>().UseNumericRevisions());
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(TestContext.Current.CancellationToken);
+
+        return store;
+    }
+
     // ---- helpers ----
 
     private async Task<Permit> StorePermitAsync(string description)

--- a/src/Fisher/Internal/FisherSession.Documents.cs
+++ b/src/Fisher/Internal/FisherSession.Documents.cs
@@ -31,41 +31,7 @@ internal partial class FisherSession
     ///     </para>
     /// </remarks>
     public void Store<T>(T document) where T : notnull
-    {
-        ArgumentNullException.ThrowIfNull(document);
-
-        var storage = StorageFor<T>();
-        storage.Store(this, document);
-
-        QueueOperation(CaptureExpectedRevision(storage.Upsert(document, this, TenantId), document));
-    }
-
-    /// <summary>
-    ///     Copy the revision the document carries onto the operation that is about to write it.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Under <c>ConcurrencyMode.Numeric</c> the revision is an <em>expectation</em>, and it
-    ///         travels on the document rather than as a parameter — which is why
-    ///         <see cref="Store{T}(T,int)" /> is just "set the member, then store". Zero means auto, so
-    ///         a document that carries no revision (a new one, or a type that does not implement
-    ///         <see cref="JasperFx.IRevisioned" />) is written unguarded.
-    ///     </para>
-    ///     <para>
-    ///         A no-op for every other concurrency mode: only the numeric operations implement
-    ///         <see cref="Weasel.Storage.IRevisionedOperation" />.
-    ///     </para>
-    /// </remarks>
-    private static Weasel.Storage.IStorageOperation CaptureExpectedRevision(
-        Weasel.Storage.IStorageOperation operation, object document)
-    {
-        if (operation is Weasel.Storage.IRevisionedOperation revisioned)
-        {
-            revisioned.Revision = document is JasperFx.IRevisioned carried ? carried.Version : 0;
-        }
-
-        return operation;
-    }
+        => StoreWithRevision(document, revision: null, ignoreConcurrencyViolation: false);
 
     /// <summary>
     ///     Store a document and require the stored row's revision to be below
@@ -76,26 +42,18 @@ internal partial class FisherSession
     ///     that revision or beyond. The document type has to be configured for numeric revisions, by
     ///     implementing <see cref="JasperFx.IRevisioned" /> or through
     ///     <c>Schema.For&lt;T&gt;().UseNumericRevisions()</c>; on any other type the revision is
-    ///     recorded on the document and then ignored, because there is no column to guard against.
+    ///     recorded on the document where there is a member to record it on, and then ignored, because
+    ///     there is no column to guard against.
     /// </remarks>
     public void Store<T>(T document, int revision) where T : notnull
-    {
-        ArgumentNullException.ThrowIfNull(document);
-
-        if (document is JasperFx.IRevisioned revisioned)
-        {
-            revisioned.Version = revision;
-        }
-
-        Store(document);
-    }
+        => StoreWithRevision(document, revision, ignoreConcurrencyViolation: false);
 
     /// <summary>
     ///     Store a document at an explicit revision. Marten spells the same operation this way.
     /// </summary>
     /// <inheritdoc cref="Store{T}(T,int)" path="/remarks" />
     public void UpdateRevision<T>(T document, int revision) where T : notnull
-        => Store(document, revision);
+        => StoreWithRevision(document, revision, ignoreConcurrencyViolation: false);
 
     /// <summary>
     ///     Store a document at an explicit revision, ignoring a revision miss rather than failing the
@@ -106,25 +64,102 @@ internal partial class FisherSession
     ///     unit of work still commits. Marten's <c>TryUpdateRevision</c>.
     /// </remarks>
     public void TryUpdateRevision<T>(T document, int revision) where T : notnull
+        => StoreWithRevision(document, revision, ignoreConcurrencyViolation: true);
+
+    /// <summary>
+    ///     Queue a document write, carrying the expected revision onto the operation that will guard on
+    ///     it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>The expected revision is a parameter, not something read back off the document</b>
+    ///         (fisher#228). It used to be the latter, which meant both halves of the mechanism were
+    ///         gated on the document implementing <see cref="JasperFx.IRevisioned" /> — so a type that
+    ///         opted in through <c>Schema.For&lt;T&gt;().UseNumericRevisions()</c> had its supplied
+    ///         revision dropped on the floor and its operation guarded on <c>0</c>, which means auto.
+    ///         The two routes into numeric revisions are documented as equivalent and only the
+    ///         interface one worked; <c>TryUpdateRevision</c> for such a type dropped nothing, so a
+    ///         stale write landed silently — the exact lost update the guard exists to prevent.
+    ///     </para>
+    ///     <para>
+    ///         The mode is read off the <em>operation</em> rather than off the mapping, since only the
+    ///         numeric operations implement <see cref="Weasel.Storage.IRevisionedOperation" />. That is
+    ///         the one source that cannot disagree with the statement actually being built — a mapping
+    ///         lookup would be a second answer to the same question.
+    ///     </para>
+    ///     <para>
+    ///         <see cref="Weasel.Storage.IRevisionedOperation.Revision" /> drives both the SET and the
+    ///         guard in the shared numeric operations, so passing it is what makes
+    ///         <c>UpdateRevision(doc, 7)</c> store 7 <em>and</em> refuse a backwards write. Zero means
+    ///         auto — increment whatever is stored — which is what a plain <c>Store</c> passes, and
+    ///         what an <see cref="JasperFx.IRevisioned" /> document that has never been written
+    ///         carries.
+    ///     </para>
+    ///     <para>
+    ///         An explicit revision is still copied onto <see cref="JasperFx.IRevisioned.Version" />
+    ///         where the document has one, so the member and the guard cannot disagree about what this
+    ///         write expects.
+    ///     </para>
+    /// </remarks>
+    private void StoreWithRevision<T>(T document, int? revision, bool ignoreConcurrencyViolation)
+        where T : notnull
     {
         ArgumentNullException.ThrowIfNull(document);
 
-        if (document is JasperFx.IRevisioned revisioned)
+        if (revision.HasValue && document is JasperFx.IRevisioned carried)
         {
-            revisioned.Version = revision;
+            carried.Version = revision.Value;
         }
 
         var storage = StorageFor<T>();
         storage.Store(this, document);
 
-        var operation = CaptureExpectedRevision(storage.Upsert(document, this, TenantId), document);
+        var operation = storage.Upsert(document, this, TenantId);
 
-        if (operation is Weasel.Storage.IRevisionedOperation revisionedOperation)
+        if (operation is Weasel.Storage.IRevisionedOperation revisioned)
         {
-            revisionedOperation.IgnoreConcurrencyViolation = true;
+            revisioned.IgnoreConcurrencyViolation = ignoreConcurrencyViolation;
         }
 
-        QueueOperation(operation);
+        QueueOperation(CaptureExpectedRevision(operation, document, revision));
+    }
+
+    /// <summary>
+    ///     Carry the expected revision onto the operation that is about to write the document.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <paramref name="revision" /> is the caller's explicit expectation where there was one,
+    ///         and null where the caller simply stored. Null falls back to whatever
+    ///         <see cref="JasperFx.IRevisioned.Version" /> the document carries, and to zero — auto,
+    ///         increment whatever is stored — for a document with no such member. That fallback is the
+    ///         whole of what <see cref="Insert{T}" /> and <see cref="Update{T}" /> need, neither having
+    ///         an explicit-revision overload.
+    ///     </para>
+    ///     <para>
+    ///         <b>Reading the caller's value off the document instead was fisher#228</b>: it made both
+    ///         halves of the mechanism conditional on the document implementing
+    ///         <see cref="JasperFx.IRevisioned" />, so a type that opted in through
+    ///         <c>Schema.For&lt;T&gt;().UseNumericRevisions()</c> guarded on zero and a stale write
+    ///         landed silently.
+    ///     </para>
+    ///     <para>
+    ///         A no-op for every other concurrency mode: only the numeric operations implement
+    ///         <see cref="Weasel.Storage.IRevisionedOperation" />, which is also why the mode is read
+    ///         off the operation rather than off the mapping — that is the one source which cannot
+    ///         disagree with the statement being built.
+    ///     </para>
+    /// </remarks>
+    private static Weasel.Storage.IStorageOperation CaptureExpectedRevision(
+        Weasel.Storage.IStorageOperation operation, object document, int? revision = null)
+    {
+        if (operation is Weasel.Storage.IRevisionedOperation revisioned)
+        {
+            revisioned.Revision =
+                revision ?? (document is JasperFx.IRevisioned carried ? carried.Version : 0);
+        }
+
+        return operation;
     }
 
     private Linq.FisherQueryProvider? _queryProvider;


### PR DESCRIPTION
Closes #228.

## What was wrong

Both halves of the revision mechanism were gated on the document implementing `JasperFx.IRevisioned`:
`Store<T>(T, int)` set that member, and `CaptureExpectedRevision` then read it back off the document
to put on the operation. A type that opted in through `Schema.For<T>().UseNumericRevisions()` has no
such member, so the supplied revision was dropped and the operation guarded on `0` — which means
*auto*.

All three of the surface's promises broke, and the third one silently:

| | `IRevisioned` | `UseNumericRevisions()` (before) |
|---|---|---|
| stored revision after `UpdateRevision(doc, 7)` | 7 | the next auto-increment value |
| backwards `UpdateRevision(doc, 3)` | `ConcurrencyException` | accepted |
| `TryUpdateRevision(doc, 3)` | dropped | **landed** |

That last row is a lost update, in the method whose entire purpose is to prevent one. The XML doc on
`Store<T>(T, int)` names both routes as equivalent; only the interface one worked.

## The fix

The expected revision is now a **parameter**, threaded to `IRevisionedOperation.Revision` — which
drives both the SET and the guard in the shared numeric operations, so passing it makes
`UpdateRevision(doc, 7)` store 7 *and* refuse a backwards write. Null means "no expectation" and falls
back to the document's member where there is one, then to `0`; that fallback is what a plain `Store`
passes and all `Insert` and `Update` ever need, which is why `CaptureExpectedRevision` survives with
the revision optional.

Two decisions:

- **The mode is read off the operation, not off the mapping.** Only the numeric operations implement
  `Weasel.Storage.IRevisionedOperation`, so that is the one source which cannot disagree with the
  statement actually being built. `DocumentMapping.UseNumericRevisions` would be a second answer to
  the same question, free to drift.
- **An explicit revision is still copied onto `IRevisioned.Version` where the document has one**, so
  the member and the guard cannot disagree about what a write expects.

## Why nothing caught it

`NumericRevisionCompliance` is written against `IRevisioned` throughout — the store-agnostic document
contract has no configuration surface for saying "this type uses numeric revisions" any other way, so
no shared suite can reach this for any store.

Fisher's own coverage stopped at the column: `a_type_configured_through_the_dsl_gets_the_same_column`
asserted `revision` exists and auto-increments, and went no further. The guard was never exercised on
that route.

## Tests

Four new tests in `numeric_revisions.cs`, three of them the interface-route guard tests one for one
against a type that opted in the other way — so the property under test is that **the two routes
agree**, not that the DSL route works in isolation. The fourth pins that a plain `Store` still means
auto for a type with no member to have read an expectation off.

**Verified load-bearing**: reverting `CaptureExpectedRevision` to ignore the parameter fails exactly
`a_dsl_configured_type_stores_the_revision_it_was_given`,
`a_dsl_configured_type_refuses_a_backwards_revision` and `a_dsl_configured_type_drops_a_stale_try_update`,
and leaves `a_dsl_configured_type_still_auto_increments_on_a_plain_store` and every interface-route
test green.

## Docs

`docs/documents/concurrency.md` gains the one thing the two routes genuinely do *not* share: a
DSL-configured type has no `Version` member to carry an expectation, so a plain `Store(doc)` always
means auto for it and guarding a write means naming the revision. For an `IRevisioned` type the member
is both the expectation and where the new revision is written back, which is what makes `Store(doc)`
guard on its own — the "sharp edge" already documented below it.

## Run

**2030 tests green on net9.0 and net10.0** — 1975 `Fisher.Tests`, 36 AspNetCore, 19 EF Core.
`scripts/check_scoreboard.py` agrees on both legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)