### PR TITLE
Wait on the outbox's own signal, not on non-staleness (#232)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -906,6 +906,15 @@ messaging is not dialect-specific and projection code should port between the st
   separate connection: invisible at `BeforeCommit`, visible at `AfterCommit`. Verified by moving the
   call, in both paths.
 
+⚠️ **A daemon test of these hooks must wait on the hook's own signal, never on non-staleness**
+(fisher#232). The progression row is written *inside* the batch's transaction and `AfterCommitAsync`
+runs after it commits, so non-stale becomes true strictly first — a test that waits on it and then
+asserts the after-hook fired is a real intermittent, roughly one full-suite run in several. This is
+the same trap recorded under "Subscriptions" for the post-commit listener, one seam over, and it was
+not revisited there when that was learned. `RecordingOutbox.AfterCommitted` is the signal; making the
+hook take 500 ms turns the race deterministic, which is how the fix was verified rather than by
+re-running and hoping.
+
 `IProjectionBatch.PublishMessageAsync` hands over an `object`, but `IMessageSink.PublishAsync<T>` is
 generic, so `MessagePublishing` closes it over the runtime message type and caches the compiled
 delegate per type. Polecat does the same via polecat#46, with `FastExpressionCompiler` where Fisher

--- a/src/Fisher.Tests/Projections/projection_side_effects.cs
+++ b/src/Fisher.Tests/Projections/projection_side_effects.cs
@@ -240,7 +240,11 @@ public class projection_side_effects : IAsyncLifetime
 
         try
         {
-            await store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(30));
+            // fisher#232. Waiting on non-staleness here was a real intermittent: the progression row
+            // is written INSIDE the batch's transaction, so non-stale becomes true strictly before
+            // AfterCommitAsync runs, and the window between them is the flake. Wait on the hook's own
+            // signal — the same rule the subscription listener already follows.
+            await outbox.AfterCommitted.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
             outbox.Batch.ShouldNotBeNull();
             outbox.Batch!.Published.ShouldContain(x => x is QuestFinished);
@@ -262,6 +266,8 @@ public class projection_side_effects : IAsyncLifetime
 /// </summary>
 internal sealed class RecordingOutbox : IMessageOutbox
 {
+    private readonly TaskCompletionSource _afterCommit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
     public RecordingBatch? Batch { get; private set; }
 
     /// <summary>
@@ -270,9 +276,22 @@ internal sealed class RecordingOutbox : IMessageOutbox
     /// </summary>
     public Func<Task<long>>? Probe { get; set; }
 
+    /// <summary>
+    ///     Completes once a batch's <c>AfterCommitAsync</c> has run — what a daemon test has to wait on
+    ///     rather than on non-staleness (fisher#232).
+    /// </summary>
+    /// <remarks>
+    ///     The two are not the same event and the ordering is guaranteed the wrong way round:
+    ///     <c>FisherProjectionBatch.ExecuteAsync</c> writes the progression row inside the batch's
+    ///     transaction and calls <c>AfterCommitAsync</c> after it commits, so non-staleness is true
+    ///     strictly first. It lives on the outbox rather than on the batch because the batch is created
+    ///     lazily, so a test has nothing to await until the daemon has already run.
+    /// </remarks>
+    public Task AfterCommitted => _afterCommit.Task;
+
     public ValueTask<IMessageBatch> CreateBatch(IDocumentSession session)
     {
-        Batch ??= new RecordingBatch(Probe);
+        Batch ??= new RecordingBatch(Probe, () => _afterCommit.TrySetResult());
         return new ValueTask<IMessageBatch>(Batch);
     }
 }
@@ -282,8 +301,13 @@ internal sealed class RecordingBatch : IMessageBatch
     private readonly List<object> _published = [];
     private readonly List<string> _hooks = [];
     private readonly Func<Task<long>>? _probe;
+    private readonly Action? _afterCommit;
 
-    internal RecordingBatch(Func<Task<long>>? probe) => _probe = probe;
+    internal RecordingBatch(Func<Task<long>>? probe, Action? afterCommit = null)
+    {
+        _probe = probe;
+        _afterCommit = afterCommit;
+    }
 
     public long? VisibleAtBeforeCommit { get; private set; }
 
@@ -347,6 +371,9 @@ internal sealed class RecordingBatch : IMessageBatch
         {
             _hooks.Add("after");
         }
+
+        // Signalled last, so a test the signal releases sees every field this hook set.
+        _afterCommit?.Invoke();
     }
 }
 


### PR DESCRIPTION
Closes #232.

## The race

`projection_side_effects.an_async_projection_publishes_through_the_daemons_batch` waited with
`WaitForNonStaleProjectionDataAsync` and then asserted the outbox's `AfterCommitAsync` hook had fired.
Those are not the same event, and the ordering is guaranteed the wrong way round:
`FisherProjectionBatch.ExecuteAsync` writes the progression row **inside** the batch's transaction and
calls `AfterCommitAsync` **after** it commits. So non-staleness becomes true strictly first, and the
window between them is the flake.

CLAUDE.md already records this exact trap under "Subscriptions", for the post-commit listener:

> **`WaitForNonStale` does not imply the post-commit listener has run.** … A test that waits on
> non-staleness and then asserts the listener fired fails roughly one full-suite run in several. Wait
> on the listener's own signal.

This test is the same shape one seam over, and was not revisited when that was learned.

## The fix

`RecordingOutbox` exposes an `AfterCommitted` task, completed by the batch as the **last** thing in
its after-hook — so the signal releases a waiter only once every field that hook sets is visible. It
lives on the outbox rather than on the batch because the batch is created lazily: a test has nothing
to await until the daemon has already run.

## Verified deterministically, not by re-running

Re-running proves nothing about a race. Adding a 500 ms delay at the top of `AfterCommitAsync` turns
the window into a certainty:

| | old wait (non-staleness) | new wait (`AfterCommitted`) |
|---|---|---|
| with a 500 ms hook | **fails every time** | passes |

That is the ordering claim itself, rather than an observation about how often it bites. The delay was
removed again; it is not in the committed test.

## Sibling audit

`subscriptions.cs`'s four `WaitForNonStaleProjectionDataAsync` calls are all sound — each asserts on
state settled *inside* the batch's own transaction (the recorder's events, the progression row), which
is exactly what non-staleness does imply. The one subscription test that carried this hazard was
retired upstream in fisher#184 and its replacement in `SubscriptionCompliance` carries the warning.
This was the only remaining instance in the repository.

## Run

**2030 tests green on net9.0 and net10.0.** `scripts/check_scoreboard.py` agrees on both legs (no
count change — this replaces a wait, it does not add a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)