### PR TITLE
Remove the AspNetCore suite's two load-sensitive hazards, and narrow #189

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4774,6 +4774,22 @@ returning it goes from "parse JSON, build an object, serialize an object" to "co
 - Tested against a `DefaultHttpContext` with a `MemoryStream` body rather than through a test host: an
   `IResult`'s whole job is what it writes to a response, and a host would add a pipeline none of the
   assertions are about.
+- ⚠️ **No test in this project may hold a wall-clock budget, and none does** (fisher#189). The suite
+  once failed 12 of 36 on a loaded host and went green on retry, which sent a hunt for timing
+  assumptions; the audit found exactly one — a two-second sleep followed by a demand that
+  `last_updated` be under **one** second old, for a 200 ms poll cycle. It is now "poll until the value
+  moves", which a slow host makes slower rather than wrong. Everything else already waited 30 seconds
+  or moved a `TimeProvider`, and that is the standard to hold new tests to.
+  - **The one `GetAwaiter().GetResult()` went with it.** Blocking a thread-pool thread on async I/O is
+    how a saturated pool turns a passing test into a transient failure — the blocked thread waits for
+    a continuation that needs a pool thread of its own. It was the only such call in the repository.
+  - ⚠️ **Neither is a proven cause, and the shape of the evidence points elsewhere.** 35 runs under
+    three- and four-way load have not reproduced it (`scripts/repro_aspnetcore_flake.sh`). Every class
+    here builds its store and runs the schema migration in `InitializeAsync`, so one exception there
+    fails that whole class at once — and "12 of 36, transiently, green on retry" fits `11 + 1`, one
+    class plus a straggler, far better than a dozen independent flakes do. The harness now tallies
+    failures per class for exactly that reason: a class at its full size means the fixture died, and
+    that is a different investigation from a flaky assertion.
 
 ### `Fisher.EntityFrameworkCore` (fisher#50)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,12 @@
 Where Fisher is, what comes next, and why in this order. See [CLAUDE.md](CLAUDE.md) for
 architecture and the SQLite-specific decisions.
 
-Status: **one open issue, and it is not next-release work.**
+Status: **two open issues, and neither is next-release work.**
+[#189](https://github.com/JasperFx/fisher/issues/189) is an unreproduced `Fisher.AspNetCore.Tests`
+failure — 12 of 36 on one loaded host, green on retry, with the failing test names never captured. Two
+concrete hazards have been removed since (the project's only wall-clock budget and its only
+sync-over-async call) and 35 runs under three- and four-way load have not reproduced it, so it stays
+open on evidence rather than on work outstanding.
 [#109](https://github.com/JasperFx/fisher/issues/109) is the downstream half of
 [jasperfx#684](https://github.com/JasperFx/jasperfx/issues/684), and it got *more* blocked rather than
 less: analysis on that epic found the stage graph does not record enrichment edges, so the

--- a/scripts/repro_aspnetcore_flake.sh
+++ b/scripts/repro_aspnetcore_flake.sh
@@ -27,9 +27,9 @@ TARGET="src/Fisher.AspNetCore.Tests/bin/Release/$TFM/Fisher.AspNetCore.Tests"
 LOAD="src/Fisher.Tests/bin/Release/$TFM/Fisher.Tests"
 OUT="$ROOT/artifacts/flake-189"
 
-echo "==> Building Release/$TFM"
+# The load project has to exist before anything can generate load with it.
+echo "==> Building the load project (Release/$TFM)"
 dotnet build src/Fisher.Tests/Fisher.Tests.csproj -c Release -f "$TFM" --nologo -v q || exit 2
-dotnet build src/Fisher.AspNetCore.Tests/Fisher.AspNetCore.Tests.csproj -c Release -f "$TFM" --nologo -v q || exit 2
 
 [ -x "$TARGET" ] || { echo "no target executable at $TARGET" >&2; exit 2; }
 [ -x "$LOAD" ]   || { echo "no load executable at $LOAD" >&2; exit 2; }
@@ -54,6 +54,13 @@ done
 # Let the load runners get past startup and into real work before measuring anything -- the report
 # was of the FIRST invocation after a build, with the other suites already in flight.
 sleep 20
+
+# fisher#189: the TARGET is built here, under load, rather than before it. The reported failure was
+# the first invocation after a build while three other agents were mid-suite, and building first (as
+# this script used to) leaves that dimension untested -- a cold assembly load, a cold file cache and a
+# compiler competing for the same CPU are exactly what iteration 1 is supposed to reproduce.
+echo "==> Building the target under load (Release/$TFM)"
+dotnet build src/Fisher.AspNetCore.Tests/Fisher.AspNetCore.Tests.csproj -c Release -f "$TFM" --nologo -v q || exit 2
 
 echo "==> Looping Fisher.AspNetCore.Tests up to $ITERATIONS times under load"
 for i in $(seq 1 "$ITERATIONS"); do
@@ -80,8 +87,19 @@ for i in $(seq 1 "$ITERATIONS"); do
         # nothing installed beyond what a dotnet box already has.
         grep -o 'testName="[^"]*"[^>]*outcome="Failed"' "$trx_path" \
             | sed 's/testName="//; s/"[^>]*outcome="Failed"//' \
-            | sed 's/^/      /' \
-            | sort -u
+            > "$OUT/failed-$i.txt"
+
+        sed 's/^/      /' "$OUT/failed-$i.txt" | sort -u
+
+        # The tally is the discriminating evidence, not a convenience. Every class in this project
+        # builds its store and runs the schema migration in InitializeAsync, so one exception there
+        # fails that whole class at once -- which is what "12 of 36, transiently, green on retry" fits
+        # far better than a dozen independent timing flakes would. A tally that names one class at its
+        # full size says "the fixture died"; one spread thinly across classes says the opposite.
+        echo
+        echo "    Failures per class (a class at its full size means the fixture failed, not the tests):"
+        sed 's/\.[^.]*$//' "$OUT/failed-$i.txt" | sort | uniq -c | sed 's/^/      /'
+
         echo
         echo "    Attach $OUT/$trx to fisher#189."
     else

--- a/src/Fisher.AspNetCore.Tests/event_stream_results.cs
+++ b/src/Fisher.AspNetCore.Tests/event_stream_results.cs
@@ -242,7 +242,7 @@ public class event_stream_results : IAsyncLifetime
     public async Task the_health_check_is_healthy_when_the_daemon_keeps_up()
     {
         await using var database = TemporaryDatabase.Create("aspnet-health-ok");
-        await using var store = StoreWithAsyncProjection(database);
+        await using var store = await StoreWithAsyncProjectionAsync(database);
 
         await using (var session = store.LightweightSession())
         {
@@ -283,7 +283,7 @@ public class event_stream_results : IAsyncLifetime
     public async Task the_health_check_is_unhealthy_when_the_mark_is_stuck()
     {
         await using var database = TemporaryDatabase.Create("aspnet-health-stalled");
-        await using var store = StoreWithAsyncProjection(database, TimeSpan.Zero);
+        await using var store = await StoreWithAsyncProjectionAsync(database, TimeSpan.Zero);
 
         // The daemon runs once so a high-water row exists, then stops while events keep arriving.
         using (var daemon = await store.BuildProjectionDaemonAsync())
@@ -325,7 +325,17 @@ public class event_stream_results : IAsyncLifetime
         stalled.Description.ShouldContain("WAL");
     }
 
-    private DocumentStore StoreWithAsyncProjection(TemporaryDatabase database, TimeSpan? livenessInterval = null)
+    /// <summary>
+    ///     A store with one async projection, migrated and ready.
+    /// </summary>
+    /// <remarks>
+    ///     <b>Asynchronous, where this used to end in <c>GetAwaiter().GetResult()</c></b> (fisher#189).
+    ///     Blocking a thread-pool thread on async I/O is the classic way a host under load turns a
+    ///     passing test into a transient failure: the continuation the blocked thread is waiting for
+    ///     needs a pool thread of its own, and on a saturated pool it does not get one promptly. It was
+    ///     the only such call in this project, and three tests reached it.
+    /// </remarks>
+    private async Task<DocumentStore> StoreWithAsyncProjectionAsync(TemporaryDatabase database, TimeSpan? livenessInterval = null)
     {
         var store = DocumentStore.For(options =>
         {
@@ -340,7 +350,7 @@ public class event_stream_results : IAsyncLifetime
             }
         });
 
-        store.ApplyAllConfiguredChangesToDatabaseAsync(Token).GetAwaiter().GetResult();
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
 
         return store;
     }

--- a/src/Fisher.AspNetCore.Tests/high_water_health_check.cs
+++ b/src/Fisher.AspNetCore.Tests/high_water_health_check.cs
@@ -159,9 +159,21 @@ public class high_water_health_check : IAsyncLifetime
     ///         <c>last_updated</c> on an idle cycle.
     ///     </para>
     ///     <para>
-    ///         The idle wait is deliberately longer than the staleness threshold: without the liveness
-    ///         touch, <c>last_updated</c> would still hold the time of that one advance and the check
-    ///         would report a healthy daemon as stopped.
+    ///         <b>The discriminating assertion is that <c>last_updated</c> moved with nothing appended</b>
+    ///         — that <em>is</em> the liveness touch, observed directly. The health check's verdict
+    ///         beneath it is a corollary and its threshold is deliberately generous, because a tight one
+    ///         would not add discrimination: at this point in the test the mark itself advanced moments
+    ///         ago, so the check answers Healthy on that alone whether or not the touch ever happened.
+    ///         The unhealthy direction is covered by
+    ///         <see cref="a_stopped_daemon_is_unhealthy" />, which moves the clock instead of waiting.
+    ///     </para>
+    ///     <para>
+    ///         <b>Written as "wait until it moves", never as "sleep, then require it to be recent"</b>
+    ///         (fisher#189). It used to sleep two seconds and then require <c>last_updated</c> to be
+    ///         under one second old — a one-second budget for a 200ms poll cycle, which is the only
+    ///         tight wall-clock assumption anywhere in this project and exactly the shape that turns
+    ///         into an intermittent on a host running several suites at once. Polling for the change
+    ///         has no budget at all: a loaded host makes it slower, not wrong.
     ///     </para>
     /// </remarks>
     [Fact]
@@ -171,12 +183,63 @@ public class high_water_health_check : IAsyncLifetime
         await AppendAsync();
         await RunDaemonAsync();
 
-        // Nothing is appended here: the mark cannot move, only the poll loop can prove itself.
-        await Task.Delay(TimeSpan.FromSeconds(2), Token);
+        var advanced = await LastUpdatedAsync();
+        advanced.ShouldNotBeNull();
 
-        var result = await CheckAsync(TimeSpan.FromSeconds(1));
+        // Nothing is appended from here on: the mark cannot move, so only the idle poll loop can
+        // change this value.
+        var touched = await WaitForLivenessTouchAsync(advanced!);
+
+        touched.ShouldNotBe(advanced);
+
+        var result = await CheckAsync(TimeSpan.FromSeconds(30));
 
         result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    /// <summary>
+    ///     The high-water row's <c>last_updated</c>, read over a connection of the test's own.
+    /// </summary>
+    private async Task<string?> LastUpdatedAsync()
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(Token);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "select last_updated from fi_event_progression where name = 'HighWaterMark'";
+
+        var value = await command.ExecuteScalarAsync(Token);
+
+        return value is null or DBNull ? null : (string)value;
+    }
+
+    /// <summary>
+    ///     Poll until the idle agent re-stamps <c>last_updated</c>, or fail naming what was waited for.
+    /// </summary>
+    /// <remarks>
+    ///     The timeout is a backstop against a hang, not a budget the assertion depends on: a slow host
+    ///     takes longer to get here and still passes, where "sleep N then require an age under M" turns
+    ///     the same slowness into a failure.
+    /// </remarks>
+    private async Task<string> WaitForLivenessTouchAsync(string original)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var current = await LastUpdatedAsync();
+
+            if (current is not null && current != original)
+            {
+                return current;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50), Token);
+        }
+
+        throw new TimeoutException(
+            $"The high-water agent never re-stamped last_updated, which held '{original}' throughout. "
+            + "Nothing was appended, so the idle liveness touch is the only thing that could have moved it.");
     }
 
     /// <summary>


### PR DESCRIPTION
Hardening and evidence for #189. **That issue stays open** — nothing here is a proven cause, and the
reported failure has still never been reproduced. No closing keyword anywhere in this body, deliberately:
#226 auto-closed the issue from the words "Does not close" preceding the number.

## What the audit found

Two things in this project can turn a pass into a transient failure on a loaded host. Both are now gone.

**A one-second wall-clock budget — the only one in the project.**
`a_quiet_store_with_a_running_daemon_stays_healthy` slept two seconds and then required `last_updated`
to be under **one** second old, for a 200 ms poll cycle. That is exactly the shape #189 names as its
first suspect. It now polls until the value moves, which a slow host makes *slower* rather than *wrong*.

The rewrite also sharpens what the test proves. The discriminating assertion is that `last_updated`
moved **with nothing appended** — that *is* the idle liveness touch, observed directly. The health
check's verdict beneath it now carries a generous threshold, because a tight one added no
discrimination: at that point the mark itself advanced moments earlier, so the check answers Healthy on
that alone whether or not the touch ever happened. The unhealthy direction is already covered by
`a_stopped_daemon_is_unhealthy`, which moves a clock instead of waiting.

Verified load-bearing by disabling the liveness touch in `FisherHighWaterDetector`: the test fails, and
now says *"The high-water agent never re-stamped last_updated … the idle liveness touch is the only
thing that could have moved it"* rather than reporting a status mismatch.

**The only `GetAwaiter().GetResult()` in the repository.** `event_stream_results`' store helper, reached
by two tests. Blocking a thread-pool thread on async I/O is the classic way a saturated pool produces a
transient failure — the blocked thread is waiting for a continuation that needs a pool thread of its own.

Everything else in the suite already waited 30 seconds or moved a `TimeProvider`, which is itself part
of the finding: there was no population of tight timing assumptions to blame.

## The more useful finding: the shape is wrong for "12 timing flakes"

Every class here builds its store and runs the schema migration in `InitializeAsync`. **One exception
there fails that entire class at once.** Class sizes are 11, 11, 9, 5 — and "12 of 36, transiently,
green on retry" fits `11 + 1`, one whole class plus a straggler, far better than a dozen independent
flakes do.

That is a different investigation from a flaky assertion, so the harness now **tallies failures per
class** on a reproduction. A class at its full size means the fixture died; failures spread thinly
across classes means the opposite. The next occurrence answers the question outright instead of leaving
it to be re-derived.

The harness also now **builds the target under load** rather than before it. The reported run was the
first invocation after a build with three agents already mid-suite; building first — as it did — leaves
the cold assembly load, cold file cache and compiler contention untested, which is precisely what
iteration 1 is meant to reproduce.

## Runs

Fifteen more under **four-way** load on this host: all green, 36/36 each. With #226's twenty under
three-way load that is **35 runs without a reproduction**, which narrows the cause further away from
steady-state contention.

## Also

`ROADMAP.md`'s status line said "one open issue" while five were open. Updated, and it now records why
#189 stays open — on evidence rather than on work outstanding.

**2030 tests green on net9.0 and net10.0.** `scripts/check_scoreboard.py` agrees on both legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)