### PR TITLE
Stop async daemons before disposing them in tests (#189)

### DIFF
--- a/.github/workflows/fisher.yml
+++ b/.github/workflows/fisher.yml
@@ -107,6 +107,19 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 scripts/check_source_is_text.py
 
+      # fisher#189. Every test database is a real file in the temp directory, and one surviving the
+      # run means something outlived the test that owned it -- the way it happened was an async
+      # daemon disposed without being stopped, whose next poll re-created the file the fixture had
+      # just deleted. A daemon still polling after its test finished is doing unpredictable work
+      # while other tests run, so the leaked file is the cheap visible symptom of a hazard that is
+      # otherwise invisible until a loaded host turns it into a failure.
+      #
+      # No `if:`, so it inherits "only when the steps before it succeeded", like the scoreboard check
+      # and unlike the NUL-byte one: a failing test may legitimately skip its own cleanup, so a leak
+      # reported over a red suite points at the wrong thing.
+      - name: The suites left no databases behind
+        run: python3 scripts/check_no_leaked_databases.py
+
       - name: Report results
         uses: dorny/test-reporter@v3
         if: ${{ !cancelled() }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4903,6 +4903,16 @@ factory)`, over `Projections.StorageProviders` in the core.
   really "how you do X against SQLite" rather than "how Fisher stores X" should be written to be moved
   into Weasel.Sqlite later. See "Raw data access goes through Weasel.Sqlite first".
 - Database execution should go through `StoreOptions.ResiliencePipeline`.
+- ⚠️ **A test that builds an async daemon must `await daemon.StopAllAsync()` before disposing it**
+  (fisher#189). `IProjectionDaemon` is `IDisposable` only, so `Dispose()` does not await in-flight
+  shard work — and a shard's next poll **re-creates the database file the fixture has already
+  deleted**. That is how it was found: a full `Fisher.Tests` run left 12 files in the shared temp
+  directory, eleven of them from four classes that disposed a daemon without stopping it (the
+  twelfth was `db-patch`'s `.drop.sql` companion, which the test that wrote it never deleted). The
+  leaked file is the cheap visible symptom; the thing that matters is that a daemon still polling
+  after its test finished is doing unpredictable work while other tests run. `scripts/check_no_leaked_databases.py`
+  runs in CI after a green suite and holds it at zero — a runner starts with an empty temp
+  directory, so the check is exact rather than heuristic.
 - **Never call `SqliteConnection.ClearAllPools()`.** It disposes every pooled connection in the
   process, and xUnit runs test collections in parallel — one test's cleanup will take out another
   with `ObjectDisposedException: SQLitePCL.sqlite3`, intermittently enough to look like a flake.

--- a/scripts/check_no_leaked_databases.py
+++ b/scripts/check_no_leaked_databases.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Fail if a test run left SQLite files behind in the system temp directory.
+
+fisher#189. Every test database is a real file under `Path.GetTempPath()` -- `TemporaryDatabase`
+names it `fisher-<name>-<guid>.db` and deletes it, plus its `-wal` / `-shm` / `-journal` sidecars, on
+dispose. Files surviving the run mean something outlived the test that owned them.
+
+That is not a tidiness concern. The way it happened was an async daemon disposed WITHOUT being
+stopped first: `IProjectionDaemon` is `IDisposable` only, so `Dispose()` does not await in-flight
+shard work, and a shard's next poll RE-CREATES the database file the fixture just deleted. A daemon
+still polling after its test finished is doing unpredictable work while other tests run, which is
+exactly the class of hazard #189 is about -- the leaked file is simply the visible symptom of it.
+
+So this guards the symptom because the symptom is cheap to see and the cause is not. Eleven of the
+twelve files a full `Fisher.Tests` run used to leave behind came from four classes that disposed a
+daemon without stopping it; the twelfth was `db-patch`'s `.drop.sql` companion, which the test that
+wrote it never deleted.
+
+Run after the suites, and only on a green run: a failing test may legitimately skip its own cleanup,
+so a leak reported over a red suite would be noise pointing at the wrong thing.
+"""
+
+import os
+import sys
+import tempfile
+
+PREFIX = "fisher-"
+
+
+def main() -> int:
+    temp = tempfile.gettempdir()
+
+    try:
+        leaked = sorted(name for name in os.listdir(temp) if name.startswith(PREFIX))
+    except OSError as error:
+        print(f"Could not read the temp directory {temp}: {error}", file=sys.stderr)
+        return 0
+
+    if not leaked:
+        print(f"No test databases left behind in {temp}.")
+        return 0
+
+    print(f"{len(leaked)} file(s) left behind in {temp} by the test run:\n")
+    for name in leaked[:40]:
+        print(f"  - {name}")
+    if len(leaked) > 40:
+        print(f"  ... and {len(leaked) - 40} more")
+
+    print(
+        "\nSomething outlived the test that owned it. The usual cause is an async daemon disposed\n"
+        "without `await daemon.StopAllAsync()` first: Dispose() does not await in-flight shard work,\n"
+        "so the next poll re-creates the file the fixture had already deleted. Check any test that\n"
+        "builds a daemon, and any test that writes a file of its own beside the one it cleans up."
+    )
+
+    # Capped: a developer running this against a machine with an accumulated backlog would otherwise
+    # emit thousands of annotations. A CI runner starts with an empty temp directory, so on the run
+    # this exists to guard, the cap is never reached.
+    for name in leaked[:40]:
+        print(f"::error::leaked temp file: {name}")
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Fisher.TestUtils/TemporaryDatabase.cs
+++ b/src/Fisher.TestUtils/TemporaryDatabase.cs
@@ -61,7 +61,9 @@ public sealed class TemporaryDatabase : IAsyncDisposable, IDisposable
             SqliteConnection.ClearPool(pooled);
         }
 
-        foreach (var suffix in new[] { "", "-wal", "-shm" })
+        // -journal as well as the WAL pair: a store whose PragmaSettings turn WAL off uses a rollback
+        // journal instead, and a process killed mid-transaction leaves one behind.
+        foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
         {
             var file = Path + suffix;
 

--- a/src/Fisher.Tests/Configuration/command_line_integration.cs
+++ b/src/Fisher.Tests/Configuration/command_line_integration.cs
@@ -225,7 +225,13 @@ public class command_line_integration : IAsyncLifetime
         }
         finally
         {
-            if (File.Exists(file)) File.Delete(file);
+            // db-patch writes the rollback beside the patch, so cleaning up only the name we passed
+            // leaves a `.drop.sql` behind on every run -- the whole of what Fisher.Tests still leaked
+            // into the shared temp directory once the daemons were stopped properly.
+            foreach (var written in new[] { file, Path.ChangeExtension(file, null) + ".drop.sql" })
+            {
+                if (File.Exists(written)) File.Delete(written);
+            }
         }
     }
 

--- a/src/Fisher.Tests/Configuration/otel_counters.cs
+++ b/src/Fisher.Tests/Configuration/otel_counters.cs
@@ -261,6 +261,7 @@ public class otel_counters : IAsyncLifetime
         using var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
         await daemon.WaitForNonStaleData(30.Seconds());
+        await daemon.StopAllAsync();
 
         For("fisher.write_lock.wait")
             .ShouldContain(x => x.Tags["fisher.write_lock.holder"] as string == "daemon");

--- a/src/Fisher.Tests/Events/composite_member_teardown.cs
+++ b/src/Fisher.Tests/Events/composite_member_teardown.cs
@@ -101,6 +101,7 @@ public class composite_member_teardown : IAsyncLifetime
         {
             await daemon.StartAllAsync();
             await daemon.WaitForNonStaleData(TimeSpan.FromSeconds(20));
+            await daemon.StopAllAsync();
         }
 
         await using (var session = _store.LightweightSession())
@@ -119,6 +120,7 @@ public class composite_member_teardown : IAsyncLifetime
     {
         using var daemon = await _store.BuildProjectionDaemonAsync();
         await daemon.RebuildProjectionAsync("ledger", TimeSpan.FromSeconds(30), Token);
+        await daemon.StopAllAsync();
     }
 
     /// <summary>

--- a/src/Fisher.Tests/Events/composite_projections.cs
+++ b/src/Fisher.Tests/Events/composite_projections.cs
@@ -83,6 +83,7 @@ public class composite_projections : IAsyncLifetime
         using var daemon = await _store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
         await daemon.WaitForNonStaleData(TimeSpan.FromSeconds(20));
+        await daemon.StopAllAsync();
 
         await using var session = _store.LightweightSession();
 
@@ -98,6 +99,7 @@ public class composite_projections : IAsyncLifetime
 
         using var daemon = await _store.BuildProjectionDaemonAsync();
         await daemon.RebuildProjectionAsync("catches", TimeSpan.FromSeconds(30), Token);
+        await daemon.StopAllAsync();
 
         await using var session = _store.LightweightSession();
         (await session.LoadAsync<Trip>(trip, Token))!.Catches.ShouldBe(3);

--- a/src/Fisher.Tests/Events/shared_published_table_rebuild.cs
+++ b/src/Fisher.Tests/Events/shared_published_table_rebuild.cs
@@ -80,6 +80,7 @@ public class shared_published_table_rebuild : IAsyncLifetime
         using var daemon = await _store.BuildProjectionDaemonAsync(logger: _logger);
         await daemon.StartAllAsync();
         await daemon.WaitForNonStaleData(TimeSpan.FromSeconds(20));
+        await daemon.StopAllAsync();
 
         return (landed, released);
     }
@@ -88,6 +89,7 @@ public class shared_published_table_rebuild : IAsyncLifetime
     {
         using var daemon = await _store.BuildProjectionDaemonAsync(logger: _logger);
         await daemon.RebuildProjectionAsync(projectionName, TimeSpan.FromSeconds(30), Token);
+        await daemon.StopAllAsync();
     }
 
     /// <summary>
@@ -185,6 +187,7 @@ public class shared_published_table_rebuild : IAsyncLifetime
             await daemon.StartAllAsync();
             await daemon.RewindSubscriptionAsync(nameof(ReleasedTally), Token, sequenceFloor: 0);
             await daemon.WaitForNonStaleData(TimeSpan.FromSeconds(20));
+            await daemon.StopAllAsync();
         }
 
         await using var after = _store.LightweightSession();


### PR DESCRIPTION
Work on #189. **Not a fix for the reported failure** — it removes a suspect rather than confirming
one, and closes a real hazard of the same family found while looking. No closing keyword anywhere in
this body, deliberately.

## What was found

A full `Fisher.Tests` run left **12 SQLite files behind in the shared temp directory, every run**,
unbounded. This machine had accumulated **3,166 of them (~750 MB)** over five days.

The mechanism is the part worth knowing. `IProjectionDaemon` is `IDisposable` only, so `Dispose()`
does not await in-flight shard work — and **a shard's next poll re-creates the database file the
fixture has already deleted**. Eleven of the twelve came from four classes that disposed a daemon
without stopping it first. The twelfth was `db-patch`'s `.drop.sql` companion, which the test that
wrote it never deleted.

**The correlation is what identified it**, rather than a guess:

| Project / site | Stops the daemon? | Leaks? |
|---|---|---|
| `Fisher.AspNetCore.Tests` — both sites | yes, `await StopAllAsync()` | no |
| `high_water_health_check` | yes | no |
| `database_per_tenant` — three sites | yes, `try`/`finally` | no |
| the four `using var daemon` sites | **no** | **yes, one file each** |

Adding the stop takes a full run from **12 leaked files to 1**; fixing the `.drop.sql` takes it to
**0 across all three suites**.

## Also

`TemporaryDatabase` now deletes a `-journal` sidecar, which it never has. A store whose
`PragmaSettings` turn WAL off uses a rollback journal instead of the WAL pair, and a process killed
mid-transaction leaves one behind.

## The guard

`scripts/check_no_leaked_databases.py` runs in CI and holds it at zero. A runner starts with an empty
temp directory, so the check is **exact rather than heuristic** — any `fisher-*` entry left afterwards
is a leak.

It runs only after a green suite, for the same reason the scoreboard check does: a failing test may
legitimately skip its own cleanup, so a leak reported over a red suite points at the wrong thing. That
is the opposite choice from the NUL-byte check beside it, which reads only the source tree and so runs
either way.

## What this means for #189

**It rules a suspect out.** The project that flaked is `Fisher.AspNetCore.Tests` — the one that was
already stopping its daemons and leaks nothing. So "leaked background daemons from earlier tests" is
now excluded by evidence rather than by assertion.

What it closes is a genuine hazard of the same family: a daemon still polling after its test finished
is doing unpredictable work while other tests run, which is exactly the kind of thing that only bites
on a loaded host.

**Still no reproduction.** 30 further runs under 12-way load — 10 concurrent full `Fisher.Tests`
runners plus 2 `dotnet build` loops, on 18 cores — all green, 36/36 each. With the earlier attempts
that is **65 runs**. Two other suspects were closed cheaply along the way: file-descriptor exhaustion
(the limit here is 1,048,576) and any process-wide mutable state in the suite (there is none).

## Run

**2030 tests green on net9.0 and net10.0.** `scripts/check_scoreboard.py` agrees on both legs; the new
leak check reports zero across all three suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)