### PR TITLE
Fisher 1.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,11 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.7</Version>
+        <!-- The published version comes from the release TAG: publish.yml passes
+             -p:Version=${TAG#v}, so this is only what a local `dotnet pack` stamps. It drifted three
+             releases behind before anybody noticed, which is why it says so here. Keep it in step
+             with the tag anyway: a locally packed 1.0.7 that is really 1.3.0 is its own trap. -->
+        <Version>1.3.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,10 +5,12 @@ architecture and the SQLite-specific decisions.
 
 Status: **two open issues, and neither is next-release work.**
 [#189](https://github.com/JasperFx/fisher/issues/189) is an unreproduced `Fisher.AspNetCore.Tests`
-failure — 12 of 36 on one loaded host, green on retry, with the failing test names never captured. Two
-concrete hazards have been removed since (the project's only wall-clock budget and its only
-sync-over-async call) and 35 runs under three- and four-way load have not reproduced it, so it stays
-open on evidence rather than on work outstanding.
+failure — 12 of 36 on one loaded host, green on retry, with the failing test names never captured.
+Three hazards have been removed since — the project's only wall-clock budget, its only
+sync-over-async call, and four `Fisher.Tests` classes that disposed an async daemon without stopping
+it — and **65 runs under three-, four- and twelve-way load have not reproduced it**, so it stays open
+on evidence rather than on work outstanding. The daemon one is the interesting find and it points
+*away* from this issue: the project that flaked was already stopping its daemons.
 [#109](https://github.com/JasperFx/fisher/issues/109) is the downstream half of
 [jasperfx#684](https://github.com/JasperFx/jasperfx/issues/684), and it got *more* blocked rather than
 less: analysis on that epic found the stage graph does not record enrichment edges, so the


### PR DESCRIPTION
Release prep for **1.3.0**.

## What is in the release

| PR | Issue | |
|---|---|---|
| #231 | #230 | JasperFx 2.67.0, and `EventQuery.TagValues` — the lossy name/value tag filter, AND'd with every other filter |
| #231 | #203 | closed by the same bump: jasperfx#796 puts `Compacted<TDoc>` beside `Archived` in the shared `determineEventTypes()` |
| #233 | #228 | numeric revision enforcement for `UseNumericRevisions()` types — `TryUpdateRevision` was dropping nothing, a silent lost update |
| #234 | #232 | test: wait on the outbox's own signal, not on non-staleness |
| #235, #236 | #189 | test: three load-sensitive hazards removed, plus a CI guard against leaked databases |

## Why a minor rather than a patch

`git diff v1.2.0..HEAD` shows **zero public or protected member changes** across all three packages —
only `EventOperations.RawQuery.cs` and `FisherSession.Documents.cs`, both internals. So the recorded
"patch by default, minor only for genuinely new public API" rule points at 1.2.1.

Called as a minor anyway, on Jeremy's decision and with precedent: v1.1.0 was cut largely for
"implement the broadened `EventQuery` (jasperfx#737)", which is the same kind of change as honoring
`EventQuery.TagValues` here. And #228 turns a previously-silent lost update into a
`ConcurrencyException` — a visible behaviour change even though no signature moved.

## The version property

`Directory.Build.props` said **1.0.7** while v1.1.0 and v1.2.0 had both shipped. That is not a bug in
those releases — `publish.yml` takes the version from the tag (`-p:Version=${TAG#v}`), so the property
only stamps a local `dotnet pack` — but it had silently stopped tracking, so it is now set to 1.3.0
with a comment saying which one is authoritative.

## Run

**2030 tests green on net9.0 and net10.0** — 1975 `Fisher.Tests`, 36 AspNetCore, 19 EF Core. 530
compliance across 50 suites. Scoreboard agrees on both legs; the new leaked-database check reports
zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)