### PR TITLE
gh-241: vector search over a declared embedding member

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,10 @@ Working, with tests:
   generated column, so a predicate against that member is served by an index
 - **User-declared indexes** — `Schema.For<T>().Index(x => x.Name)` / `.UniqueIndex(...)`, as SQLite
   expression indexes that add no column at all
+- **Vector search** — `Schema.For<T>().VectorIndex(x => x.Embedding, dimensions)` or
+  `[VectorIndex(dimensions)]`, `session.VectorSearchAsync<T>(...)` and the scored
+  `VectorSearchWithScoresAsync<T>(...)`, brute force over the stored JSON through a registered
+  `fi_vector_distance` function — no side table, no trigger, no native extension
 - **Document metadata member mapping** — `guid_version`, `last_modified`, `is_deleted` and
   `deleted_at` projected back onto members of the document, by interface, attribute or DSL
 - **Strong-typed identities** — a wrapper around any of the four id types, as an aggregate's identity
@@ -1325,6 +1329,50 @@ stitch.
   `Select`/`GroupBy`/`Distinct`/`DistinctBy` after the join. `ToListAsync`, the `First`/`Single`/`Last`
   families, the scalar aggregates, `CountAsync`, `AnyAsync`, `ToPagedListAsync` and `ToSql` all work,
   over a chain as well as over one join.
+
+### Vector search — fisher#241
+
+`VectorSearchAsync` / `VectorSearchWithScoresAsync` on `IQuerySession`, over a member declared with
+`Schema.For<T>().VectorIndex(x => x.Embedding, dimensions, distance)` or `[VectorIndex(dimensions)]`.
+The API shape is Marten.PgVector's and the types are the store-neutral ones from
+`JasperFx.Events.Vectors` (`IEmbeddingProvider`, `DistanceFunction`, `VectorMatch<T>`), so
+application code reads the same against either store.
+
+- **The search reads the embedding straight out of `data`, and that is the whole design.** One
+  statement through `IAdvancedSql`: the document's columns plus
+  `fi_vector_distance(metric, json_extract(data, '$.embedding'), @query)`, ordered by that distance,
+  limited; the query vector bound as a float32 BLOB. `StoreOptions.Functions` is the new
+  `SqliteFunctionRegistry` the data source registers on every connection (weasel#588), and the
+  distance function is registered in the `StoreOptions` constructor so it is on every tenant's
+  connections for free.
+- ⚠️ **No side table and no trigger, deliberately, and not for lack of trying.** SQLite has no
+  built-in that turns a JSON array into a float32 BLOB, so a trigger keeping a BLOB column in step —
+  the full-text index's shape — would have to call an application-defined function, and then every
+  foreign writer on the file (an EF Core context, the `sqlite3` shell, a restore) fails with *no such
+  function*. A side table maintained on Fisher's own write path would go silently stale under those
+  same writers, which is exactly the failure the full-text design refused. Reading from `data` cannot
+  drift; `a_write_that_bypassed_fisher_still_ranks_by_the_new_vector` pins it.
+- **Brute force, and honest about it.** The JSON is parsed on every row (`Utf8JsonReader`, pooled
+  buffer); a 768-float embedding parses in tens of microseconds, so a search is milliseconds at
+  thousands of rows and under a second at tens of thousands — Fisher's scale. `sqlite-vec` is
+  deliberately not taken on: pre-1.0, no NuGet package, a native binary per platform behind a feature
+  that works without one. `VectorSearchAsync` is the seam it would slot behind.
+- **Every metric is a distance — smaller is closer — including inner product, which is negated**, so
+  one `ORDER BY` serves all three and the promise `DistanceFunction` makes on every store holds here.
+- **`VectorIndex` is metadata, not a schema object**, and what it buys is the refusals: a search on a
+  type with no declared index, on a member that is not the declared one, or with a query vector of
+  another length is refused by name before any SQL runs — the full-text rule, because the alternative
+  is valid SQL that scans nothing. A *stored* vector of the wrong length fails its row loudly inside
+  the function, the one check that cannot happen earlier because the JSON is the record.
+- **The locator comes from `MemberFactory`**, so the serializer's naming policy and
+  `[JsonPropertyName]` decide the path — the Marten.PgVector bug (`member.Name` regardless of casing,
+  zero rows with no error) is not repeated.
+- **The soft-delete filter applies**, as it does to every query; tenancy needs nothing, a tenant being
+  its own database. The identity map is not consulted, the rows coming back through the same selector
+  `Query<T>()` uses — Marten's behaviour too.
+
+The event-sourced `VectorProjection` (content-hash skipping, async) and hybrid search with the
+full-text index are their own pieces.
 
 ### The four Marten operators — fisher#202
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4416,7 +4416,7 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**Fisher enrolls 50 of the 52 suites `JasperFx.Events.ComplianceTests` 2.67.0 ships — 530 tests.**
+**Fisher enrolls 50 of the 52 suites `JasperFx.Events.ComplianceTests` 2.68.0 ships — 535 tests.**
 `JasperFx.Events.ComplianceTests` is referenced unconditionally — the old `$(EnableComplianceTests)`
 gate is gone. See HANDOFF.md for the live scoreboard, which is machine-checked against a real run by
 `scripts/check_scoreboard.py`; what follows is the history and the mechanics.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.67.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.67.0" />
+        <PackageVersion Include="JasperFx" Version="2.68.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.68.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.67.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.67.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.68.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.68.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage
@@ -26,8 +26,8 @@
              (weasel#561). It also carries weasel#574, which brings the shared flat-table
              DecrementMemberMap into line with fisher#183; Fisher does not use that DSL yet, but the
              agreement is what makes adopting it later cost nothing. -->
-        <PackageVersion Include="Weasel.Sqlite" Version="9.31.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.31.0" />
+        <PackageVersion Include="Weasel.Sqlite" Version="9.31.2" />
+        <PackageVersion Include="Weasel.Storage" Version="9.31.2" />
 
         <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
         <!-- Override the transitive SQLitePCLRaw 2.1.11 (vulnerable native lib,

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,9 +12,9 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2030 tests green on net9.0 and net10.0** — 1975 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 530 of
-them are shared cross-store compliance tests — 461 event sourcing and 69 document. On JasperFx **2.67.0** / Weasel **9.31.0**.
+**2045 tests green on net9.0 and net10.0** — 1990 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 535 of
+them are shared cross-store compliance tests — 466 event sourcing and 69 document. On JasperFx **2.68.0** / Weasel **9.31.2**.
 
 ## The high-water opt-out, audited (#199)
 
@@ -662,11 +662,22 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.67.0 ships 52 suites; Fisher enrolls **50 of them, 530 tests**.
-Fisher passes **530 of them, across all
+`JasperFx.Events.ComplianceTests` 2.68.0 ships 52 suites; Fisher enrolls **50 of them, 535 tests**.
+Fisher passes **535 of them, across all
 50 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
 pass on the 2.65.0 pin were the upstream ones described at the top of this file, and 2.66.0 closed
 all five.
+
+**2.68.0 added five tests to two existing suites and cost nothing** (fisher#241 took the bump for
+`JasperFx.Events.Vectors`). `EventStoreExplorerCompliance` went from 14 to 18 with the four
+database-scoped explorer reads — recent streams, stream metadata and stream events scoped to one
+`IEventDatabase` agreeing with the store-global read, and a null database refused — and
+`AsyncDaemonCompliance` from 2 to 3 with the registered shard names reachable from the non-generic
+`IEventStore` (jasperfx#815). All five were green on the bump alone, and none of them is Fisher's
+code: the scoped reads are interface defaults that forward to the store-global read when the store
+reports `DatabaseCardinality.Single` — the suite skips itself otherwise — and the shard names are a
+default over the closed generic's `AllShards()`. Worth knowing before assuming the four scoped facts
+say anything about database-per-tenant: they do not run against it.
 
 **What that does and does not claim, because the difference is load-bearing** (fisher#124). The suite
 pins **API portability, not behavioural equivalence**: code written against one store compiles and
@@ -699,7 +710,7 @@ shape: `DocumentLoadAndStoreCompliance` gained three tests for `LoadAsync<T>(obj
 fisher#89) and `DocumentComplianceConfig` gained `ValueTypes`. Diffing the suite *list* would have
 reported a clean bump — diff the contents.
 
-The library is now two halves. The **event sourcing** half is 43 enrolled suites and 461 tests, and the
+The library is now two halves. The **event sourcing** half is 43 enrolled suites and 466 tests, and the
 upstream backlog it emptied in 2.45.0 refilled in 2.64.0 — see "Wave 13" below. The
 **document** half arrived in 2.47.0 (jasperfx#647) and is now seven suites, 69 tests, over the
 store-agnostic document contract Fisher implements for fisher#68. Every suite added since 2.49.0 has
@@ -801,9 +812,9 @@ naming.
 **Green on all fifty is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 50 suites, 530 tests
+### Green — 50 suites, 535 tests
 
-Event sourcing — 43 suites, 461 tests:
+Event sourcing — 43 suites, 466 tests:
 
 | Suite | Tests |
 |---|---|
@@ -811,11 +822,11 @@ Event sourcing — 43 suites, 461 tests:
 | `DcbTagQueryAndConsistencyCompliance` | 28 |
 | `ProjectionScenarioCompliance` | 20 |
 | `StringStreamIdentityCompliance` | 19 |
+| `EventStoreExplorerCompliance` | 18 |
 | `NaturalKeyCompliance` | 17 |
 | `StreamArchivingCompliance` | 16 |
 | `StreamStateQueryCompliance` | 15 |
 | `AggregateWriteCacheCompliance` | 14 |
-| `EventStoreExplorerCompliance` | 14 |
 | `StrongTypedIdentityCompliance` | 14 |
 | `FetchForWritingCompliance` | 13 |
 | `StreamQueryPlanCompliance` | 13 |
@@ -845,10 +856,10 @@ Event sourcing — 43 suites, 461 tests:
 | `AggregateToManyCompliance` | 5 |
 | `RebuildConcurrencyCapCompliance` | 5 |
 | `ActivityCorrelationCompliance` | 4 |
+| `AsyncDaemonCompliance` | 3 |
 | `CompositeProjectionCompliance` | 3 |
 | `EventProjectionEnrichmentCompliance` | 3 |
 | `EventProjectionRegistrationCompliance` | 3 |
-| `AsyncDaemonCompliance` | 2 |
 | `AutoDiscoveredAggregateCompliance` | 2 |
 
 Documents — 7 suites, 69 tests, through `FisherDocumentComplianceFixture`:

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 50 suites and 530 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,975.
+> Fisher passes **all 50 suites and 535 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,990.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -99,6 +99,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                 { text: 'Grouping and Aggregates', link: '/documents/querying/linq/grouping' },
                 { text: 'Joins', link: '/documents/querying/linq/joins' },
                 { text: 'Full-Text Search', link: '/documents/querying/linq/full-text' },
+                { text: 'Vector Search', link: '/documents/querying/vector-search' },
                 { text: 'Including Related Documents', link: '/documents/querying/linq/includes' },
                 { text: 'Querying for Raw JSON', link: '/documents/querying/query-json' },
                 { text: 'Batched Queries', link: '/documents/querying/batched-queries' },

--- a/docs/documents/querying/vector-search.md
+++ b/docs/documents/querying/vector-search.md
@@ -1,0 +1,131 @@
+# Vector Search
+
+Fisher searches documents by embedding similarity over a member you declare. Store the vector
+the way you store anything else — a `float[]` on the document — and declare it:
+
+<!-- snippet: sample_vector_declare_index -->
+<a id='snippet-sample_vector_declare_index'></a>
+```cs
+opts.Schema.For<Memory>().VectorIndex(x => x.Embedding, dimensions: 768);
+```
+<sup><a href='https://github.com/JasperFx/fisher/blob/main/src/Fisher.Tests/Documentation/vector_samples.cs#L34-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_vector_declare_index' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+then search it with a query vector from the same model:
+
+<!-- snippet: sample_vector_search -->
+<a id='snippet-sample_vector_search'></a>
+```cs
+// The query vector comes from whatever model produced the stored ones — the
+// store-neutral IEmbeddingProvider from JasperFx.Events, here.
+var query = await embeddings.GenerateEmbeddingAsync("how does the daemon pick a mode?");
+
+var nearest = await session.VectorSearchAsync<Memory>(x => x.Embedding, query, limit: 5);
+```
+<sup><a href='https://github.com/JasperFx/fisher/blob/main/src/Fisher.Tests/Documentation/vector_samples.cs#L48-L54' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_vector_search' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The API shape is Marten.PgVector's, and the types are the store-neutral ones from
+`JasperFx.Events.Vectors`: `IEmbeddingProvider` for the model, `DistanceFunction` for the metric,
+`VectorMatch<T>` for a scored result. Application code written against one store reads the same
+against the other.
+
+Fisher never calls a model. Computing the embedding — at write time in your own code, or from an
+event stream in a projection — is yours, and `JasperFx.Events.MicrosoftExtensionsAI` adapts any
+Microsoft.Extensions.AI generator (OpenAI, Azure OpenAI, Ollama, ONNX) to `IEmbeddingProvider` so
+you do not write one by hand.
+
+## Scores
+
+<!-- snippet: sample_vector_search_with_scores -->
+<a id='snippet-sample_vector_search_with_scores'></a>
+```cs
+var matches = await session.VectorSearchWithScoresAsync<Memory>(x => x.Embedding, query, limit: 5);
+
+// Distance is smaller-is-closer under every metric; for cosine it is 1 - similarity.
+var confident = matches.Where(m => m.Distance < 0.3).Select(m => m.Document);
+```
+<sup><a href='https://github.com/JasperFx/fisher/blob/main/src/Fisher.Tests/Documentation/vector_samples.cs#L61-L66' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_vector_search_with_scores' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Every metric is a **distance**: smaller is closer, on every store. That is what lets one
+`ORDER BY` serve all three and a similarity floor be one comparison.
+
+| `DistanceFunction` | Computes | Use for |
+| :--- | :--- | :--- |
+| `Cosine` (default) | `1 − cos θ`, in `[0, 2]` | text embeddings, which are trained for it and usually unit length |
+| `L2` | Euclidean distance | when magnitude carries meaning |
+| `InnerProduct` | the **negative** inner product | unit vectors, where it equals cosine and is cheaper |
+
+The index pins the default metric; a call can name another:
+
+<!-- snippet: sample_vector_search_metric -->
+<a id='snippet-sample_vector_search_metric'></a>
+```cs
+var byMagnitude = await session.VectorSearchAsync<Memory>(
+    x => x.Embedding, query, limit: 5, distance: DistanceFunction.L2);
+```
+<sup><a href='https://github.com/JasperFx/fisher/blob/main/src/Fisher.Tests/Documentation/vector_samples.cs#L73-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_vector_search_metric' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## The attribute
+
+<!-- snippet: sample_vector_attribute -->
+<a id='snippet-sample_vector_attribute'></a>
+```cs
+[VectorIndex(768, Distance = DistanceFunction.Cosine)]
+public float[]? Embedding { get; set; }
+```
+<sup><a href='https://github.com/JasperFx/fisher/blob/main/src/Fisher.Tests/Documentation/vector_samples.cs#L24-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_vector_attribute' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`[VectorIndex(dimensions)]` on a member declares it exactly as `Schema.For<T>().VectorIndex(...)`
+does. `Distance` is optional and defaults to cosine.
+
+## How it works, and why there is no side table
+
+The search is one statement on the session's own connection: the document's columns plus
+`fi_vector_distance(metric, json_extract(data, '$.embedding'), @query)`, ordered by that distance,
+limited. `fi_vector_distance` is an application-defined function Fisher registers on every
+connection the store opens — the query vector is bound as a float32 BLOB, the stored one is read
+from the JSON, and the metric decides the arithmetic.
+
+**Reading from `data` is the point.** The alternatives were considered and refused:
+
+- A BLOB column kept in step by a trigger, the way the full-text index is, would need the trigger
+  to call an application-defined function — and then every writer that is not Fisher (an EF Core
+  context sharing the file, the `sqlite3` shell, a restore edited in place) would fail with
+  *no such function*.
+- A BLOB side table maintained on Fisher's own write path would go silently stale under those
+  same writers, which is precisely the failure the full-text design was built to refuse.
+
+A stored embedding that a foreign writer changed ranks by its new value, because nothing is
+cached. A document whose embedding is `null` is skipped, not scored. Soft-deleted documents are
+excluded as they are from every query. A tenant is its own database, so tenancy costs nothing.
+
+**It is brute force.** The JSON is parsed on every row and the distance computed in full; a
+768-float embedding parses in tens of microseconds, so a search is milliseconds at thousands of
+rows and under a second at tens of thousands. That is Fisher's scale, and it is the seam a native
+index would slot behind if a workload ever outgrows it — `sqlite-vec` is deliberately not taken
+on today: it is pre-1.0, has no NuGet package, and would put a native binary per platform behind
+a feature that works without one.
+
+## What is refused
+
+| | Why |
+| :--- | :--- |
+| `VectorSearchAsync` on a type with no declared index | There is nothing to search; the query would otherwise be valid SQL that scans nothing |
+| A member that is not the declared one | The search would silently run against the wrong locator |
+| A query vector whose length is not the declared `dimensions` | Every stored row would fail, one at a time, inside SQLite |
+| Declaring a member that cannot hold a vector (a `string`, an `int`) | Caught when the store is configured, not when the first search returns nothing |
+| Declaring the same member twice, or with a dimension count under one | Same |
+
+A **stored** vector whose length differs from the query's fails that row loudly at query time
+rather than scoring it wrong — the one check that cannot happen earlier, because the JSON is the
+record.
+
+## Not yet
+
+- **No hybrid search** with the full-text index, and no event-sourced vector projection with
+  content-hash skipping. Both are on the way as their own pieces.
+- **No approximate index.** See above.

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -9,7 +9,7 @@ namespace Fisher.Tests.Compliance;
  * these tests cannot drift between the products.
  *
  * Suites were added one at a time as Fisher grew into them, and fifty are enrolled from
- * JasperFx.Events.ComplianceTests 2.67.0, which itself ships fifty-two. One is not enrolled:
+ * JasperFx.Events.ComplianceTests 2.68.0, which itself ships fifty-two. One is not enrolled:
  * SingleTenantedEventSlicingCompliance, for the precondition reason set out below.
  *
  * Three of the ten suites this wave adds are enrolled and gated off rather than green, each for a

--- a/src/Fisher.Tests/Documentation/vector_samples.cs
+++ b/src/Fisher.Tests/Documentation/vector_samples.cs
@@ -1,0 +1,80 @@
+using Fisher.Storage.Vectors;
+using JasperFx.Events.Vectors;
+
+namespace Fisher.Tests.Documentation;
+
+/*
+ * The compiled source behind docs/documents/querying/vector-search.md.
+ *
+ * See "Documentation samples come from compiled code" in CLAUDE.md.
+ */
+
+public class Memory
+{
+    public string Id { get; set; } = "";
+    public string Title { get; set; } = "";
+    public string Body { get; set; } = "";
+    public float[]? Embedding { get; set; }
+}
+
+public class Snippet
+{
+    public Guid Id { get; set; }
+
+    #region sample_vector_attribute
+    [VectorIndex(768, Distance = DistanceFunction.Cosine)]
+    public float[]? Embedding { get; set; }
+    #endregion
+}
+
+public static class vector_samples
+{
+    public static void declare_index(StoreOptions opts)
+    {
+        #region sample_vector_declare_index
+        opts.Schema.For<Memory>().VectorIndex(x => x.Embedding, dimensions: 768);
+        #endregion
+    }
+
+    public static void declare_index_with_metric(StoreOptions opts)
+    {
+        #region sample_vector_declare_index_l2
+        opts.Schema.For<Memory>().VectorIndex(x => x.Embedding, dimensions: 768, DistanceFunction.L2);
+        #endregion
+    }
+
+    public static async Task search(IQuerySession session, IEmbeddingProvider embeddings)
+    {
+        #region sample_vector_search
+        // The query vector comes from whatever model produced the stored ones — the
+        // store-neutral IEmbeddingProvider from JasperFx.Events, here.
+        var query = await embeddings.GenerateEmbeddingAsync("how does the daemon pick a mode?");
+
+        var nearest = await session.VectorSearchAsync<Memory>(x => x.Embedding, query, limit: 5);
+        #endregion
+
+        _ = nearest;
+    }
+
+    public static async Task search_with_scores(IQuerySession session, ReadOnlyMemory<float> query)
+    {
+        #region sample_vector_search_with_scores
+        var matches = await session.VectorSearchWithScoresAsync<Memory>(x => x.Embedding, query, limit: 5);
+
+        // Distance is smaller-is-closer under every metric; for cosine it is 1 - similarity.
+        var confident = matches.Where(m => m.Distance < 0.3).Select(m => m.Document);
+        #endregion
+
+        _ = confident;
+    }
+
+    public static async Task search_with_another_metric(IQuerySession session, ReadOnlyMemory<float> query)
+    {
+        #region sample_vector_search_metric
+        var byMagnitude = await session.VectorSearchAsync<Memory>(
+            x => x.Embedding, query, limit: 5, distance: DistanceFunction.L2);
+        #endregion
+
+        _ = byMagnitude;
+    }
+}

--- a/src/Fisher.Tests/Linq/vector_search.cs
+++ b/src/Fisher.Tests/Linq/vector_search.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+using Fisher.Storage.Vectors;
+using JasperFx;
+using JasperFx.Events.Vectors;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+
+namespace Fisher.Tests.Linq;
+
+/// <summary>
+///     Vector search over a declared embedding member — fisher#241.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The search reads the embedding straight out of <c>data</c>, so the tests that matter are
+///         the ones proving it cannot drift: a document updated past Fisher with raw SQL ranks by its
+///         NEW vector, and a soft-deleted one is not returned. Every refusal is pinned by name, because
+///         each replaces a search that would otherwise have returned nothing.
+///     </para>
+/// </remarks>
+public class vector_search : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("vectors");
+    private DocumentStore _store = null!;
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<Passage>().SoftDeleted()
+                .VectorIndex(x => x.Embedding, dimensions: 3);
+            options.Schema.For<Tagged>();
+            options.Schema.For<Unindexed>();
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = _store.LightweightSession();
+        session.Store(
+            new Passage { Id = "east", Text = "points east", Embedding = [1, 0, 0] },
+            new Passage { Id = "north", Text = "points north", Embedding = [0, 1, 0] },
+            new Passage { Id = "north-east", Text = "between", Embedding = [0.7f, 0.7f, 0] },
+            new Passage { Id = "far-east", Text = "same direction, further", Embedding = [5, 0, 0] },
+            new Passage { Id = "blank", Text = "no embedding", Embedding = null });
+        await session.SaveChangesAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _store.Dispose();
+        await _database.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task nearest_first_by_cosine_and_the_limit_holds()
+    {
+        await using var session = _store.QuerySession();
+
+        var nearest = await session.VectorSearchAsync<Passage>(x => x.Embedding, new float[] { 1, 0, 0 }, limit: 3, token: Token);
+
+        // Cosine ignores magnitude: east and far-east tie at 0, then north-east, then north.
+        nearest.Select(x => x.Id).Take(2).ShouldBe(["east", "far-east"], ignoreOrder: true);
+        nearest[2].Id.ShouldBe("north-east");
+        nearest.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task scores_are_distances_smaller_is_closer_under_every_metric()
+    {
+        await using var session = _store.QuerySession();
+        var query = new float[] { 1, 0, 0 };
+
+        var cosine = await session.VectorSearchWithScoresAsync<Passage>(x => x.Embedding, query, limit: 4, token: Token);
+        cosine.Select(m => m.Distance).ShouldBeInOrder();
+        cosine[0].Distance.ShouldBe(0, 1e-6);
+        cosine.Single(m => m.Document.Id == "north").Distance.ShouldBe(1, 1e-6);
+
+        // L2 does not ignore magnitude: far-east is now far.
+        var l2 = await session.VectorSearchWithScoresAsync<Passage>(x => x.Embedding, query, limit: 4, DistanceFunction.L2, Token);
+        l2[0].Document.Id.ShouldBe("east");
+        l2.Single(m => m.Document.Id == "far-east").Distance.ShouldBe(4, 1e-6);
+
+        // Inner product is negated so it is still a distance: far-east is the best match.
+        var inner = await session.VectorSearchWithScoresAsync<Passage>(x => x.Embedding, query, limit: 4, DistanceFunction.InnerProduct, Token);
+        inner[0].Document.Id.ShouldBe("far-east");
+        inner[0].Distance.ShouldBe(-5, 1e-6);
+    }
+
+    [Fact]
+    public async Task a_document_with_no_embedding_is_skipped_not_scored()
+    {
+        await using var session = _store.QuerySession();
+
+        var all = await session.VectorSearchAsync<Passage>(x => x.Embedding, new float[] { 0, 0, 1 }, limit: 10, token: Token);
+
+        all.Select(x => x.Id).ShouldNotContain("blank");
+        all.Count.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task a_soft_deleted_document_is_not_returned()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Delete<Passage>("east");
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = _store.QuerySession();
+        var nearest = await query.VectorSearchAsync<Passage>(x => x.Embedding, new float[] { 1, 0, 0 }, limit: 1, token: Token);
+        nearest.Single().Id.ShouldBe("far-east");
+    }
+
+    [Fact]
+    public async Task a_write_that_bypassed_fisher_still_ranks_by_the_new_vector()
+    {
+        // The reason there is no side table: reading from data cannot drift.
+        await using (var conn = new SqliteConnection(_database.ConnectionString))
+        {
+            await conn.OpenAsync(Token);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "update fi_doc_passage set data = json_set(data, '$.embedding', json('[0,0,1]')) where id = 'north'";
+            (await cmd.ExecuteNonQueryAsync(Token)).ShouldBe(1);
+        }
+
+        await using var session = _store.QuerySession();
+        var nearest = await session.VectorSearchAsync<Passage>(x => x.Embedding, new float[] { 0, 0, 1 }, limit: 1, token: Token);
+        nearest.Single().Id.ShouldBe("north");
+    }
+
+    [Fact]
+    public async Task the_index_default_metric_is_used_unless_the_call_names_one()
+    {
+        var database = TemporaryDatabase.Create("vectors-l2");
+        await using var _ = database;
+        using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<Passage>().VectorIndex(x => x.Embedding, 3, DistanceFunction.L2);
+        });
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = store.LightweightSession();
+        session.Store(new Passage { Id = "near", Embedding = [1, 0, 0] }, new Passage { Id = "far", Embedding = [5, 0, 0] });
+        await session.SaveChangesAsync(Token);
+
+        (await session.VectorSearchAsync<Passage>(x => x.Embedding, new float[] { 1, 0, 0 }, 1, token: Token)).Single().Id.ShouldBe("near");
+        (await session.VectorSearchAsync<Passage>(x => x.Embedding, new float[] { 1, 0, 0 }, 1, DistanceFunction.InnerProduct, Token)).Single().Id.ShouldBe("far");
+    }
+
+    [Fact]
+    public async Task the_attribute_form_declares_the_index_and_camel_case_paths_are_honoured()
+    {
+        await using var session = _store.LightweightSession();
+        session.Store(new Tagged { Id = 1, MyVector = [0, 1] }, new Tagged { Id = 2, MyVector = [1, 0] });
+        await session.SaveChangesAsync(Token);
+
+        // "myVector" in the JSON under the default naming policy; the locator must say so too.
+        var nearest = await session.VectorSearchAsync<Tagged>(x => x.MyVector, new float[] { 1, 0 }, 1, token: Token);
+        nearest.Single().Id.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task refusals_name_the_problem()
+    {
+        await using var session = _store.QuerySession();
+
+        var noIndex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            session.VectorSearchAsync<Unindexed>(x => x.Embedding, new float[] { 1, 0, 0 }, token: Token));
+        noIndex.Message.ShouldContain("'Unindexed' declares no vector index");
+        noIndex.Message.ShouldContain("VectorIndex(x => x.Embedding, dimensions)");
+
+        var wrongMember = await Should.ThrowAsync<InvalidOperationException>(() =>
+            session.VectorSearchAsync<Passage>(x => x.Text, new float[] { 1, 0, 0 }, token: Token));
+        wrongMember.Message.ShouldContain("'Passage.Text' is not a declared vector member");
+        wrongMember.Message.ShouldContain("Declared: Embedding");
+
+        var wrongLength = await Should.ThrowAsync<ArgumentException>(() =>
+            session.VectorSearchAsync<Passage>(x => x.Embedding, new float[] { 1, 0 }, token: Token));
+        wrongLength.Message.ShouldContain("has 2 dimensions but 'Passage.Embedding' was declared with 3");
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() =>
+            session.VectorSearchAsync<Passage>(x => x.Embedding, new float[] { 1, 0, 0 }, limit: 0, token: Token));
+    }
+
+    [Fact]
+    public void declaring_is_refused_by_name_for_the_wrong_member_type_dimensions_or_twice()
+    {
+        Should.Throw<InvalidOperationException>(() => DocumentStore.For(o =>
+            {
+                o.ConnectionString = _database.ConnectionString;
+                o.Schema.For<Passage>().VectorIndex(x => x.Text, 3);
+            }))
+            .Message.ShouldContain("'Passage.Text' is a String, which cannot hold an embedding");
+
+        Should.Throw<ArgumentOutOfRangeException>(() => DocumentStore.For(o =>
+            {
+                o.ConnectionString = _database.ConnectionString;
+                o.Schema.For<Passage>().VectorIndex(x => x.Embedding, 0);
+            }))
+            .Message.ShouldContain("needs a positive dimension count");
+
+        Should.Throw<InvalidOperationException>(() => DocumentStore.For(o =>
+            {
+                o.ConnectionString = _database.ConnectionString;
+                o.Schema.For<Passage>().VectorIndex(x => x.Embedding, 3).VectorIndex(x => x.Embedding, 4);
+            }))
+            .Message.ShouldContain("already carries a vector index (3 dimensions, Cosine)");
+    }
+
+    [Fact]
+    public void the_distance_function_itself_is_pinned()
+    {
+        var q = VectorFunctions.ToBlob(new float[] { 1, 0, 0 });
+
+        VectorFunctions.Distance("cosine", "[1,0,0]", q)!.Value.ShouldBe(0, 1e-9);
+        VectorFunctions.Distance("cosine", "[0,1,0]", q)!.Value.ShouldBe(1, 1e-9);
+        VectorFunctions.Distance("l2", "[0,1,0]", q)!.Value.ShouldBe(Math.Sqrt(2), 1e-9);
+        VectorFunctions.Distance("inner", "[2,0,0]", q)!.Value.ShouldBe(-2, 1e-9);
+        VectorFunctions.Distance("cosine", null, q).ShouldBeNull();
+        VectorFunctions.Distance("cosine", "[0,0,0]", q)!.Value.ShouldBe(1, 1e-9); // a zero vector is maximally far, not NaN
+
+        Should.Throw<ArgumentException>(() => VectorFunctions.Distance("cosine", "[1,0]", q))
+            .Message.ShouldContain("the stored vector has 2 dimensions but the query has 3");
+        Should.Throw<ArgumentException>(() => VectorFunctions.Distance("manhattan", "[1,0,0]", q))
+            .Message.ShouldContain("metric 'manhattan'");
+        Should.Throw<ArgumentException>(() => VectorFunctions.Distance("cosine", "{\"not\":\"an array\"}", q))
+            .Message.ShouldContain("not a JSON array");
+    }
+
+    public class Passage
+    {
+        public string Id { get; set; } = "";
+        public string Text { get; set; } = "";
+        public float[]? Embedding { get; set; }
+    }
+
+    public class Tagged
+    {
+        public int Id { get; set; }
+
+        [VectorIndex(2)]
+        public float[] MyVector { get; set; } = [];
+    }
+
+    public class Unindexed
+    {
+        public Guid Id { get; set; }
+        public float[]? Embedding { get; set; }
+    }
+}

--- a/src/Fisher/Storage/DocumentMapping.cs
+++ b/src/Fisher/Storage/DocumentMapping.cs
@@ -177,6 +177,22 @@ public class DocumentMapping
         }
 
         ApplyFullTextAttributes(documentType, members);
+        ApplyVectorAttributes(members);
+    }
+
+    /// <summary>
+    ///     <c>[VectorIndex(dimensions)]</c> on a member declares it, exactly as
+    ///     <c>Schema.For&lt;T&gt;().VectorIndex(...)</c> would.
+    /// </summary>
+    private void ApplyVectorAttributes(MemberInfo[] members)
+    {
+        foreach (var member in members)
+        {
+            var attribute = member.GetCustomAttribute<Vectors.VectorIndexAttribute>();
+            if (attribute is null) continue;
+
+            AddVectorIndex([member], attribute.Dimensions, attribute.Distance);
+        }
     }
 
     /// <summary>
@@ -412,6 +428,59 @@ public class DocumentMapping
     ///     second would have nothing to disambiguate it and is refused instead.
     /// </remarks>
     internal FullText.FullTextIndex? FullTextIndex { get; private set; }
+
+    /// <summary>The declared vector members (fisher#241), one entry per member.</summary>
+    internal List<Vectors.VectorIndex> VectorIndexes { get; } = new();
+
+    internal Vectors.VectorIndex? FindVectorIndex(MemberInfo[] chain)
+        => VectorIndexes.FirstOrDefault(v => v.Covers(chain));
+
+    /// <summary>
+    ///     Declare a member as a vector embedding. Refuses a member that cannot hold one, a
+    ///     dimension count under one, and a second declaration of the same member — each by name,
+    ///     at configuration time, rather than as a search that returns nothing.
+    /// </summary>
+    internal Vectors.VectorIndex AddVectorIndex(MemberInfo[] memberChain, int dimensions,
+        JasperFx.Events.Vectors.DistanceFunction distance)
+    {
+        ArgumentNullException.ThrowIfNull(memberChain);
+        if (memberChain.Length == 0)
+        {
+            throw new ArgumentException("A vector index names a member; it cannot cover the whole document.", nameof(memberChain));
+        }
+
+        var name = string.Join(".", memberChain.Select(x => x.Name));
+        var memberType = memberChain[^1] switch
+        {
+            PropertyInfo p => p.PropertyType,
+            FieldInfo f => f.FieldType,
+            var other => throw new ArgumentException($"'{other.Name}' is not a property or field", nameof(memberChain))
+        };
+
+        if (!Vectors.VectorIndex.IsVectorType(memberType))
+        {
+            throw new InvalidOperationException(
+                $"'{DocumentType.Name}.{name}' is a {memberType.Name}, which cannot hold an embedding. Declare the "
+                + "vector index on a float[], ReadOnlyMemory<float>, double[] or List<float> member.");
+        }
+
+        if (dimensions < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), dimensions,
+                $"'{DocumentType.Name}.{name}' needs a positive dimension count — the length of every vector it holds.");
+        }
+
+        if (FindVectorIndex(memberChain) is { } existing)
+        {
+            throw new InvalidOperationException(
+                $"'{DocumentType.Name}.{name}' already carries a vector index ({existing.Dimensions} dimensions, "
+                + $"{existing.Distance}). Declare it once.");
+        }
+
+        var index = new Vectors.VectorIndex(memberChain, dimensions, distance);
+        VectorIndexes.Add(index);
+        return index;
+    }
 
     /// <summary>
     ///     Register the full-text index over the named member chains, or over the whole stored

--- a/src/Fisher/Storage/DocumentMappingExpression.cs
+++ b/src/Fisher/Storage/DocumentMappingExpression.cs
@@ -212,6 +212,26 @@ public class DocumentMappingExpression<T> where T : notnull
     ///         nothing to tell it apart — put every searchable member in the one declaration.
     ///     </para>
     /// </remarks>
+    /// <summary>
+    ///     Declare a member as a vector embedding for <c>VectorSearchAsync</c> (fisher#241).
+    /// </summary>
+    /// <param name="member">The member holding the vector, e.g. <c>x =&gt; x.Embedding</c>.</param>
+    /// <param name="dimensions">The length of every vector it holds; a query of another length is refused.</param>
+    /// <param name="distance">The distance a search uses when the caller names none. Cosine by default.</param>
+    /// <remarks>
+    ///     Metadata rather than a schema object: the search reads the embedding straight out of the
+    ///     stored JSON through a registered distance function, so nothing has to be kept in step and
+    ///     nothing can drift. See the vector search documentation for why there is no side table.
+    /// </remarks>
+    public DocumentMappingExpression<T> VectorIndex(Expression<Func<T, object?>> member, int dimensions,
+        JasperFx.Events.Vectors.DistanceFunction distance = JasperFx.Events.Vectors.DistanceFunction.Cosine)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+
+        Mapping.AddVectorIndex(ChainOf(member), dimensions, distance);
+        return this;
+    }
+
     public DocumentMappingExpression<T> FullTextIndex(params Expression<Func<T, object?>>[] members)
         => FullTextIndex(FullText.FullTextTokenizer.Porter, members);
 

--- a/src/Fisher/Storage/FisherDatabase.cs
+++ b/src/Fisher/Storage/FisherDatabase.cs
@@ -45,7 +45,7 @@ public partial class FisherDatabase : SqliteDatabase, Weasel.Storage.IStorageDat
     {
         _options = options;
         _events = options.EventGraph;
-        _dataSource = new SqliteDataSource(connectionString, options.PragmaSettings);
+        _dataSource = new SqliteDataSource(connectionString, options.PragmaSettings, options.Functions, null);
         TenantId = tenantId;
     }
 

--- a/src/Fisher/Storage/Vectors/VectorFunctions.cs
+++ b/src/Fisher/Storage/Vectors/VectorFunctions.cs
@@ -1,0 +1,161 @@
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using JasperFx.Events.Vectors;
+using Weasel.Sqlite.Functions;
+
+namespace Fisher.Storage.Vectors;
+
+/// <summary>
+///     The application-defined SQLite functions vector search runs on, registered on every
+///     connection the store opens through <see cref="StoreOptions.Functions" /> (fisher#241).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>fi_vector_distance(metric, json, query)</c>: <c>metric</c> is <c>'cosine'</c>,
+///         <c>'l2'</c> or <c>'inner'</c>; <c>json</c> is the stored embedding as the JSON array
+///         <c>json_extract</c> hands back; <c>query</c> is the caller's vector as a little-endian
+///         float32 BLOB. Every metric is a DISTANCE — smaller is closer — including inner product,
+///         which is negated, so one <c>ORDER BY</c> serves all three; that is the promise
+///         <see cref="DistanceFunction" /> makes on every store.
+///     </para>
+///     <para>
+///         The JSON is parsed on every row, and that is the cost of reading from <c>data</c> rather
+///         than a BLOB column that could drift (see <see cref="VectorIndex" />). A 768-float array
+///         parses in tens of microseconds, so the scan is milliseconds at thousands of rows and well
+///         under a second at tens of thousands — Fisher's scale. A stored vector whose length differs
+///         from the query's fails the row loudly rather than scoring it wrong.
+///     </para>
+/// </remarks>
+internal static class VectorFunctions
+{
+    internal const string DistanceFunctionName = "fi_vector_distance";
+
+    internal static void Register(SqliteFunctionRegistry functions)
+    {
+        functions.AddScalar<double?>(DistanceFunctionName,
+            (object? metric, object? json, object? query) => Distance(metric as string, json as string, query as byte[]),
+            isDeterministic: true);
+    }
+
+    internal static string MetricName(DistanceFunction distance) => distance switch
+    {
+        DistanceFunction.Cosine => "cosine",
+        DistanceFunction.L2 => "l2",
+        DistanceFunction.InnerProduct => "inner",
+        _ => throw new ArgumentOutOfRangeException(nameof(distance), distance, null)
+    };
+
+    /// <summary>The query vector in the shape the function reads: little-endian float32.</summary>
+    internal static byte[] ToBlob(ReadOnlySpan<float> vector)
+    {
+        var bytes = new byte[vector.Length * sizeof(float)];
+        MemoryMarshal.AsBytes(vector).CopyTo(bytes);
+        if (!BitConverter.IsLittleEndian)
+        {
+            for (var i = 0; i < bytes.Length; i += sizeof(float)) Array.Reverse(bytes, i, sizeof(float));
+        }
+
+        return bytes;
+    }
+
+    internal static double? Distance(string? metric, string? json, byte[]? query)
+    {
+        if (json is null || query is null) return null;
+        if (query.Length % sizeof(float) != 0)
+        {
+            throw new ArgumentException($"{DistanceFunctionName}: the query BLOB is not a whole number of float32 values");
+        }
+
+        var dimensions = query.Length / sizeof(float);
+        var stored = ArrayPool<float>.Shared.Rent(dimensions);
+        try
+        {
+            var count = ParseJsonArray(json, stored, dimensions);
+            if (count != dimensions)
+            {
+                throw new ArgumentException(
+                    $"{DistanceFunctionName}: the stored vector has {count} dimensions but the query has {dimensions}");
+            }
+
+            var q = MemoryMarshal.Cast<byte, float>(query);
+            var s = stored.AsSpan(0, dimensions);
+
+            return metric switch
+            {
+                "cosine" => Cosine(s, q),
+                "l2" => L2(s, q),
+                "inner" => NegativeInner(s, q),
+                _ => throw new ArgumentException($"{DistanceFunctionName}: metric '{metric}' must be cosine, l2 or inner")
+            };
+        }
+        finally
+        {
+            ArrayPool<float>.Shared.Return(stored);
+        }
+    }
+
+    /// <summary>
+    ///     Reads a JSON array of numbers into <paramref name="into" />, returning how many there were.
+    ///     Stops counting past <paramref name="capacity" /> but keeps counting, so a length mismatch is
+    ///     reported as the real length rather than as the capacity.
+    /// </summary>
+    private static int ParseJsonArray(string json, float[] into, int capacity)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var reader = new Utf8JsonReader(bytes);
+
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new ArgumentException($"{DistanceFunctionName}: the stored value is not a JSON array");
+        }
+
+        var count = 0;
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+        {
+            if (reader.TokenType != JsonTokenType.Number)
+            {
+                throw new ArgumentException($"{DistanceFunctionName}: the stored array holds a non-numeric element");
+            }
+
+            if (count < capacity) into[count] = reader.GetSingle();
+            count++;
+        }
+
+        return count;
+    }
+
+    private static double Cosine(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+    {
+        double dot = 0, na = 0, nb = 0;
+        for (var i = 0; i < a.Length; i++)
+        {
+            dot += (double)a[i] * b[i];
+            na += (double)a[i] * a[i];
+            nb += (double)b[i] * b[i];
+        }
+
+        if (na == 0 || nb == 0) return 1.0;
+        return 1.0 - dot / (Math.Sqrt(na) * Math.Sqrt(nb));
+    }
+
+    private static double L2(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+    {
+        double sum = 0;
+        for (var i = 0; i < a.Length; i++)
+        {
+            var d = (double)a[i] - b[i];
+            sum += d * d;
+        }
+
+        return Math.Sqrt(sum);
+    }
+
+    private static double NegativeInner(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+    {
+        double dot = 0;
+        for (var i = 0; i < a.Length; i++) dot += (double)a[i] * b[i];
+        return -dot;
+    }
+}

--- a/src/Fisher/Storage/Vectors/VectorIndex.cs
+++ b/src/Fisher/Storage/Vectors/VectorIndex.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+using Fisher.Linq.Members;
+using JasperFx.Events.Vectors;
+
+namespace Fisher.Storage.Vectors;
+
+/// <summary>
+///     A declared vector member on a document type (fisher#241): which member holds the embedding,
+///     how long it is, and which distance a search over it uses when the caller names none.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Metadata, not a schema object.</b> There is no side table and no trigger, deliberately.
+///         SQLite has no built-in that turns a JSON array into a float32 BLOB, so a trigger keeping a
+///         BLOB column in step would have to call an application-defined function — and then every
+///         foreign writer on the file (an EF Core context, the <c>sqlite3</c> shell, a restore) would
+///         fail with "no such function". A side table maintained on Fisher's own write path would go
+///         silently stale under those same writers, which is exactly the failure the full-text design
+///         refused. So a search reads the embedding straight out of <c>data</c> through
+///         <c>json_extract</c> and the registered <c>fi_vector_distance</c> function, which cannot drift.
+///         Brute force, <c>ORDER BY … LIMIT k</c> — the right answer at Fisher's scale, and the seam a
+///         native index would slot behind if a workload ever outgrew it.
+///     </para>
+///     <para>
+///         What the declaration buys: a search on a type with no declared index is refused by name
+///         (the full-text rule — the alternative is a valid query that scans nothing), the query
+///         vector's length is checked against <see cref="Dimensions" /> before any SQL runs, and the
+///         default <see cref="Distance" /> is pinned once rather than repeated at every call.
+///     </para>
+/// </remarks>
+internal sealed class VectorIndex
+{
+    internal VectorIndex(MemberInfo[] memberChain, int dimensions, DistanceFunction distance)
+    {
+        MemberChain = memberChain;
+        Dimensions = dimensions;
+        Distance = distance;
+    }
+
+    internal MemberInfo[] MemberChain { get; }
+
+    internal int Dimensions { get; }
+
+    internal DistanceFunction Distance { get; }
+
+    internal string MemberName => string.Join(".", MemberChain.Select(x => x.Name));
+
+    /// <summary>The <c>json_extract</c> locator for the member, casing and all.</summary>
+    internal string Locator(MemberFactory members) => members.ResolveMember(MemberChain).RawLocator;
+
+    internal bool Covers(MemberInfo[] chain)
+        => chain.Length == MemberChain.Length
+           && chain.Zip(MemberChain).All(pair => pair.First.MetadataToken == pair.Second.MetadataToken
+                                                  && pair.First.Module == pair.Second.Module);
+
+    /// <summary>
+    ///     The member types an embedding may be declared as. Anything that serializes to a JSON array
+    ///     of numbers works at query time; this is the list the declaration checks so a typo is caught
+    ///     when the store is configured rather than when the first search returns nothing.
+    /// </summary>
+    internal static bool IsVectorType(Type type)
+        => type == typeof(float[])
+           || type == typeof(ReadOnlyMemory<float>)
+           || type == typeof(ReadOnlyMemory<float>?)
+           || type == typeof(Memory<float>)
+           || type == typeof(double[])
+           || type == typeof(List<float>)
+           || type == typeof(IReadOnlyList<float>)
+           || type == typeof(IList<float>)
+           || type == typeof(IEnumerable<float>);
+}
+
+/// <summary>
+///     Declare a member as a vector embedding — the attribute form of
+///     <c>Schema.For&lt;T&gt;().VectorIndex(x =&gt; x.Embedding, dimensions)</c>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class VectorIndexAttribute : Attribute
+{
+    public VectorIndexAttribute(int dimensions)
+    {
+        Dimensions = dimensions;
+    }
+
+    /// <summary>The length of every vector stored in the member.</summary>
+    public int Dimensions { get; }
+
+    /// <summary>The distance a search uses when the caller names none. Cosine by default.</summary>
+    public DistanceFunction Distance { get; set; } = DistanceFunction.Cosine;
+}

--- a/src/Fisher/StoreOptions.cs
+++ b/src/Fisher/StoreOptions.cs
@@ -29,6 +29,7 @@ public class StoreOptions
 
     public StoreOptions()
     {
+        Storage.Vectors.VectorFunctions.Register(Functions);
         EventGraph = new EventGraph(this);
         Events.EventGraph = EventGraph;
         Projections = new Fisher.Projections.FisherProjectionOptions(EventGraph);
@@ -231,6 +232,16 @@ public class StoreOptions
     /// </remarks>
     public Weasel.Sqlite.SqlitePragmaSettings PragmaSettings { get; set; }
         = Weasel.Sqlite.SqlitePragmaSettings.Default;
+
+    /// <summary>
+    ///     Application-defined SQLite functions registered on every connection the store opens
+    ///     (weasel#588). Fisher registers <c>fi_vector_distance</c> here for vector search; add your
+    ///     own and they are on every connection too, tenants included. Functions live on the
+    ///     connection, never in the file, which is why this is a store setting and not a schema
+    ///     object — and why a function registered anywhere else is on some connections and not
+    ///     others.
+    /// </summary>
+    public Weasel.Sqlite.Functions.SqliteFunctionRegistry Functions { get; } = new();
 
     /// <summary>
     ///     Set by <c>ApplyAllDatabaseChangesOnStartup()</c>; consumed by the hosted service.

--- a/src/Fisher/VectorSearchExtensions.cs
+++ b/src/Fisher/VectorSearchExtensions.cs
@@ -1,0 +1,136 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Fisher.Internal;
+using Fisher.Linq.Members;
+using Fisher.Storage;
+using Fisher.Storage.Vectors;
+using JasperFx.Events.Vectors;
+
+namespace Fisher;
+
+/// <summary>
+///     Vector similarity search over a declared embedding member (fisher#241), on Marten.PgVector's
+///     API shape so application code written against one store reads the same against the other.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Both overloads run one SQL statement on the session's own connection through
+///         <see cref="IAdvancedSql" />: the document's columns, plus <c>fi_vector_distance</c> over the
+///         member's <c>json_extract</c> locator and the query vector bound as a float32 BLOB, ordered
+///         by that distance, limited. The soft-delete filter applies as it does to every query;
+///         tenancy needs nothing, because a tenant is its own database.
+///     </para>
+///     <para>
+///         The document's identity map is not consulted (the rows come back through the same selector
+///         <c>Query&lt;T&gt;()</c> uses), and a query vector whose length is not the index's declared
+///         <c>dimensions</c> is refused before any SQL runs. A stored vector of the wrong length fails
+///         the row at query time rather than scoring it — see <c>VectorFunctions</c>.
+///     </para>
+/// </remarks>
+public static class VectorSearchExtensions
+{
+    /// <summary>
+    ///     The <paramref name="limit" /> documents nearest to <paramref name="query" /> under the
+    ///     index's distance (or <paramref name="distance" /> when given), nearest first.
+    /// </summary>
+    public static async Task<IReadOnlyList<T>> VectorSearchAsync<T>(
+        this IQuerySession session,
+        Expression<Func<T, object?>> member,
+        ReadOnlyMemory<float> query,
+        int limit = 10,
+        DistanceFunction? distance = null,
+        CancellationToken token = default) where T : notnull
+    {
+        var (sql, parameters) = Build(session, member, query, limit, distance, withScore: false);
+        return await session.AdvancedSql.QueryAsync<T>(sql, token, parameters).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     The same search, each document paired with its distance — smaller is closer under every
+    ///     metric — for a similarity floor, or for fusing with a full-text ranking.
+    /// </summary>
+    public static async Task<IReadOnlyList<VectorMatch<T>>> VectorSearchWithScoresAsync<T>(
+        this IQuerySession session,
+        Expression<Func<T, object?>> member,
+        ReadOnlyMemory<float> query,
+        int limit = 10,
+        DistanceFunction? distance = null,
+        CancellationToken token = default) where T : notnull
+    {
+        var (sql, parameters) = Build(session, member, query, limit, distance, withScore: true);
+        var rows = await session.AdvancedSql.QueryAsync<T, double>(sql, token, parameters).ConfigureAwait(false);
+        return rows.Select(row => new VectorMatch<T>(row.Item1, row.Item2)).ToList();
+    }
+
+    private static (string Sql, object?[] Parameters) Build<T>(
+        IQuerySession session,
+        Expression<Func<T, object?>> member,
+        ReadOnlyMemory<float> query,
+        int limit,
+        DistanceFunction? distance,
+        bool withScore)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+        if (limit < 1) throw new ArgumentOutOfRangeException(nameof(limit), limit, "limit must be at least 1");
+
+        var options = ((FisherSession)session).Options;
+        var mapping = options.Schema.MappingFor(typeof(T));
+        var chain = ChainOf(member);
+        var index = mapping.FindVectorIndex(chain)
+                    ?? throw new InvalidOperationException(
+                        mapping.VectorIndexes.Count == 0
+                            ? $"'{typeof(T).Name}' declares no vector index, so there is nothing to search. Declare one with "
+                              + $"Schema.For<{typeof(T).Name}>().VectorIndex(x => x.{string.Join(".", chain.Select(m => m.Name))}, dimensions) "
+                              + "or [VectorIndex(dimensions)] on the member."
+                            : $"'{typeof(T).Name}.{string.Join(".", chain.Select(m => m.Name))}' is not a declared vector member. Declared: "
+                              + string.Join(", ", mapping.VectorIndexes.Select(v => v.MemberName)) + ".");
+
+        if (query.Length != index.Dimensions)
+        {
+            throw new ArgumentException(
+                $"The query vector has {query.Length} dimensions but '{typeof(T).Name}.{index.MemberName}' was declared with {index.Dimensions}.",
+                nameof(query));
+        }
+
+        var members = new MemberFactory(options, mapping);
+        var locator = index.Locator(members);
+        var metric = VectorFunctions.MetricName(distance ?? index.Distance);
+        var fields = string.Join(", ", session.AdvancedSql.SelectFieldsFor<T>());
+        var scoreColumn = $"{VectorFunctions.DistanceFunctionName}(?, {locator}, ?)";
+
+        var sql = $"select {fields}, {scoreColumn} as distance from {mapping.QuotedTableName} where {locator} is not null";
+        if (mapping.IsSoftDeleted) sql += $" and {SoftDelete.NotDeletedSql}";
+        sql += " order by distance limit ?";
+
+        // The score column is selected either way: SQLite's ORDER BY can name a select-list alias,
+        // and a document-only read simply ignores a trailing column it was not asked for.
+        _ = withScore;
+        return (sql, [metric, VectorFunctions.ToBlob(query.Span), limit]);
+    }
+
+    /// <summary>The member chain of <c>x =&gt; x.A.B</c>, unwrapping the boxing convert.</summary>
+    private static MemberInfo[] ChainOf<T>(Expression<Func<T, object?>> member)
+    {
+        var body = member.Body;
+        while (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
+        {
+            body = unary.Operand;
+        }
+
+        var chain = new List<MemberInfo>();
+        while (body is MemberExpression access)
+        {
+            chain.Insert(0, access.Member);
+            body = access.Expression!;
+        }
+
+        if (chain.Count == 0 || body is not ParameterExpression)
+        {
+            throw new ArgumentException(
+                "The vector member must be a plain member access on the document, like x => x.Embedding or x => x.Content.Vector.",
+                nameof(member));
+        }
+
+        return chain.ToArray();
+    }
+}


### PR DESCRIPTION
Closes #241

`VectorSearchAsync<T>` / `VectorSearchWithScoresAsync<T>` on `IQuerySession`, over a member declared with `Schema.For<T>().VectorIndex(x => x.Embedding, dimensions, distance)` or `[VectorIndex(dimensions)]`. The API shape is Marten.PgVector's and the types are the store-neutral ones from `JasperFx.Events.Vectors` (`IEmbeddingProvider`, `DistanceFunction`, `VectorMatch<T>`), so application code reads the same against either store.

## Design

- **Reads the embedding straight out of `data`.** One statement through `IAdvancedSql`: the document's columns plus `fi_vector_distance(metric, json_extract(data, '$.embedding'), @query)`, ordered by that distance, limited. The query vector binds as a float32 BLOB.
- **No side table and no trigger, deliberately.** A trigger keeping a BLOB column in step would need an application-defined function, and every foreign writer on the file (EF Core, the `sqlite3` shell, a restore) would then fail with *no such function*. A side table on Fisher's own write path would go silently stale under those same writers. Reading from `data` cannot drift; `a_write_that_bypassed_fisher_still_ranks_by_the_new_vector` pins it.
- **Brute force**, honestly. The JSON is parsed per row with `Utf8JsonReader` into a pooled buffer; a 768-float embedding parses in tens of microseconds. `sqlite-vec` is deliberately not taken on (pre-1.0, no NuGet package, native binary per platform); `VectorSearchAsync` is the seam it would slot behind.
- **Every metric is a distance, smaller is closer**, including inner product, which is negated, so one `ORDER BY` serves all three.
- **`VectorIndex` is metadata**, and what it buys is the refusals by name: no declared index, wrong member, query vector of another length, a member that cannot hold a vector, a duplicate declaration. A *stored* vector of the wrong length fails its row loudly inside the function.
- **The locator comes from `MemberFactory`**, so the serializer's naming policy decides the JSON path. The soft-delete filter applies.

## Wiring

- `StoreOptions.Functions` is a new `SqliteFunctionRegistry` (Weasel.Sqlite 9.31.2, weasel#588) that `FisherDatabase` hands to `SqliteDataSource`, so the distance function is on every connection of every tenant.
- Packages: JasperFx / JasperFx.Events / ComplianceTests / SourceGenerator → 2.68.0; Weasel.Sqlite / Weasel.Storage → 9.31.2.

## Verification

- 10 new tests in `Linq/vector_search.cs`; full `Fisher.Tests` 1973 passed / 17 skipped; AspNetCore 36 and EFCore 19 green.
- `npm run docs-build` exit 0 with the new `documents/querying/vector-search.md` page and five compiled samples.
- `scripts/check_no_leaked_databases.py` clean.

Not in this PR: the event-sourced `VectorProjection` and hybrid FTS+vector search, which are their own plan nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)