### PR TITLE
gh-240: give the explorer reads a database dimension, and fix the cardinality claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3917,6 +3917,71 @@ Three SQLite-specific points:
 `ReadStreamMetadata` returns an **empty tag dictionary, not null**: the record declares `Tags`
 non-nullable, and returning null there is what polecat#412 was.
 
+#### The explorer reads have a database dimension — fisher#240
+
+jasperfx#810 gave every explorer read a third scope: `GetRecentStreamsAsync`, `ReadStreamAsync`,
+`GetStreamMetadataAsync`, `QueryByTagsAsync` and `GetProjectionStatusesAsync` each take an
+`IEventDatabase` overload beside the tenant-scoped one. The interface's default delegates on a
+single-database store and refuses otherwise — a default interface member, so **nothing breaks at
+compile time and nothing tells you the store is wrong.**
+
+**The question the issue opened with had a stale answer written into this codebase in two places.**
+`DocumentStore.EventStore.cs` claimed in prose that "Fisher has no database-per-tenant tenancy, so the
+cardinality is always `Single`" while the expression beside it deferred to `Tenancy.Cardinality` —
+which has answered `StaticMultiple` since fisher#47 and `DynamicMultiple` since fisher#58. The comment
+predates both and was never revisited; `database_per_tenant.tooling_sees_every_tenants_database` had
+been asserting the opposite for as long.
+
+So Fisher **is** multi-database, and the pre-existing bug jasperfx#810 predicts was real here: every
+one of these reads went to `Database`, the store's *default* file. A database-per-tenant store answered
+from one tenant and the result was indistinguishable from the whole store's — right for whoever owned
+the default file, wrong for everybody else, silent either way.
+
+- **The listing fans out and merges; a single-stream lookup refuses.** That split is the shape of the
+  signatures rather than a preference. "The ten most recently updated streams" has an answer across a
+  hundred files and the ordering key computes it — `fi_streams.timestamp` is `SqliteTimestamp`'s
+  fixed-width UTC text, so it compares across databases exactly as within one, and reading `count` from
+  each file and keeping the newest `count` is exact rather than approximate. `ReadStreamAsync` and
+  `GetStreamMetadataAsync` return **one** answer over an id that is unique *within* a database and not
+  across them, so there is no merge to perform and "whichever file we opened" is the bug itself. They
+  throw, naming both the tenant-scoped and database-scoped overloads.
+- **A fanned-out summary is stamped with its database's tenant, and that is what makes the refusal
+  actionable rather than a dead end.** A console lists, then drills in — so the listing has to hand it
+  the scope the lookup demands. It cannot come off the row: `StreamsTable` gives `tenant_id` a
+  `DEFAULT '*DEFAULT*'` for a store that is not conjoined, so every row in `north.db` reads
+  `*DEFAULT*`. The file is the tenant, so `FisherDatabase.TenantId` is what knows.
+- ⚠️ **A tenant predicate in SQL is correct only under conjoined tenancy, and the old tenant-scoped
+  `ReadStreamAsync` had that backwards.** It composed `and tenant_id = @tenant_id` unconditionally
+  against the default file, so under database-per-tenant it matched nothing at all. `ResolveTenantScope`
+  is the one place that decides: conjoined means a column predicate, everything else means the tenant
+  selects the *database* and adds no `where`. An unknown tenant throws out of `Tenancy.DatabaseFor`
+  rather than falling back to the default file, which is the rule every tenant-scoped member follows.
+- **The tenant-scoped siblings were asymmetric and are not now.** `ReadStreamAsync` had a tenant
+  overload; `GetRecentStreamsAsync` and `GetStreamMetadataAsync` fell through to JasperFx's default,
+  which *throws* for a non-null tenant. One of three implemented is the shape the issue's "audit the
+  siblings" item exists to catch.
+- **`QueryByTagsAsync` and `GetProjectionStatusesAsync` are overridden only to keep the message
+  honest.** Fisher answers neither at any scope — the dictionary `QueryByTagsAsync` deliberately (see
+  "DCB tags"; `EventQuery.TagValues` is the composable, paged home for it), `GetProjectionStatusesAsync`
+  not yet (fisher#243, where the gap is shard *state*, which `fi_event_progression` does not know and
+  which reporting as `"Stopped"` — Polecat's answer, polecat#200 — would fake). Left to the interface
+  default, a multi-database store would meet jasperfx#810's refusal, which blames the database dimension
+  for a read that does not exist at any dimension. Forwarding reaches the accurate "not implemented".
+- **Both usage descriptors hardcoded `Cardinality = Single`**, event and document alike. That is the
+  fisher#120 shape one field over: a console does not read it as "unknown", it renders a hundred tenants'
+  files as a one-file store. `DescribeDatabases()` is the one place both now read, and it fills
+  `DatabaseUsage.Databases` too, because an empty list claims there are no tenants.
+- **`HasMultipleTenants` said `false` unconditionally**, which was wrong in both directions a Fisher
+  store can be multi-tenanted. It now matches Marten's three clauses exactly — non-`Single` cardinality,
+  conjoined event tenancy, or any `MultiTenanted()` document type.
+
+**The shared suite cannot reach any of this**, and says so in its own comments: its fixture is
+single-database, so its four database-scoped facts pin that the database overload *agrees with* the
+store-global read — vacuously true of a store that ignores the argument. `explorer_reads_across_databases`
+is the multi-database arm and `explorer_reads_under_conjoined_tenancy` the column-predicate one;
+16 of their 19 tests fail against the previous behaviour, and the three that pass are the regression
+guards for what a single-database store already did.
+
 #### What `TryCreateUsage` puts on the wire — fisher#120
 
 `projections list` rendered "No projections in this store." for a store with twenty registered, and

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,8 +26,8 @@
              (weasel#561). It also carries weasel#574, which brings the shared flat-table
              DecrementMemberMap into line with fisher#183; Fisher does not use that DSL yet, but the
              agreement is what makes adopting it later cost nothing. -->
-        <PackageVersion Include="Weasel.Sqlite" Version="9.31.2" />
-        <PackageVersion Include="Weasel.Storage" Version="9.31.2" />
+        <PackageVersion Include="Weasel.Sqlite" Version="9.32.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.32.0" />
 
         <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
         <!-- Override the transitive SQLitePCLRaw 2.1.11 (vulnerable native lib,

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,9 +12,9 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2045 tests green on net9.0 and net10.0** — 1990 in
+**2064 tests green on net9.0 and net10.0** — 2009 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 535 of
-them are shared cross-store compliance tests — 466 event sourcing and 69 document. On JasperFx **2.68.0** / Weasel **9.31.2**.
+them are shared cross-store compliance tests — 466 event sourcing and 69 document. On JasperFx **2.68.0** / Weasel **9.32.0**.
 
 ## The high-water opt-out, audited (#199)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 50 suites and 535 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 1,990.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,009.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -160,6 +160,56 @@ var metadata = await eventStore.GetStreamMetadataAsync(streamId);
 Re-exposing one through it would undo the point of implementing them explicitly.
 :::
 
+### The explorer reads have three scopes
+
+`GetRecentStreamsAsync`, `ReadStreamAsync` and `GetStreamMetadataAsync` each come in three overloads,
+and on a [database-per-tenant](/configuration/multitenancy) store the difference is not a
+convenience — it decides whether the answer is the whole store's.
+
+```cs
+// store-global
+await eventStore.GetRecentStreamsAsync(10, ct);
+
+// one tenant, wherever that tenant lives
+await eventStore.GetRecentStreamsAsync(10, "north", ct);
+
+// one database, from AllDatabases()
+foreach (var database in await eventStore.AllDatabases())
+{
+    await eventStore.GetRecentStreamsAsync(database, 10, null, ct);
+}
+```
+
+`DatabaseCardinality` is what tells the three apart, and on Fisher **it is not always `Single`**: one
+SQLite *file* is one database, but a database-per-tenant store is a file per tenant —
+`StaticMultiple` under `MultiTenantedDatabases`, `DynamicMultiple` under
+`MultiTenantedDatabasesInDirectory` and `MultiTenantedDatabasesInRegistry`.
+
+What a store-global read does once there is more than one file depends on whether one answer can
+stand for all of them:
+
+- **The listing fans out and merges.** "The ten most recently updated streams in this store" has an
+  answer across a hundred files, and `fi_streams.timestamp` is fixed-width UTC text, so it compares
+  across databases exactly as it does within one. Each merged summary is stamped with the tenant whose
+  file it came from — which it has to be, because the tenant cannot be read off the row: under
+  database-per-tenant the `tenant_id` column holds `*DEFAULT*` in every file.
+- **A single-stream lookup refuses.** `ReadStreamAsync` and `GetStreamMetadataAsync` return *one*
+  answer, and a stream id is unique within a database rather than across them — so there is no merge
+  to perform, and answering from whichever file the store's default session resolved would be a
+  confident wrong answer rather than a partial one. The refusal names both ways forward, and the
+  listing above is where the tenant id comes from.
+
+::: tip
+A **tenant predicate in SQL is correct only under conjoined tenancy.** Under database-per-tenant the
+tenant *is* the file, so naming a tenant resolves the database and adds no `where` clause. That is why
+an unknown tenant throws rather than falling back to the default file.
+:::
+
+Two reads on that interface Fisher does not answer at any scope, and the database overload changes
+nothing for either: the dictionary-shaped `QueryByTagsAsync` — [`EventQuery.TagValues`](/events/dcb)
+is the composable, paged home for that capability here — and `GetProjectionStatusesAsync`
+([fisher#243](https://github.com/JasperFx/fisher/issues/243)). Both refuse by name.
+
 ::: tip
 A [secondary store's](/configuration/multiple-stores) marker proxy is *not* an `IEventStore` —
 `DispatchProxy` implements only the interfaces it was asked for. The `IEventStore` registration

--- a/src/Fisher.Tests/Events/explorer_reads_across_databases.cs
+++ b/src/Fisher.Tests/Events/explorer_reads_across_databases.cs
@@ -1,0 +1,414 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using Fisher.Storage;
+using JasperFx.MultiTenancy;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>
+///     fisher#240 — the explorer reads on a store that spans more than one SQLite file.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Every fact here is one the shared suite structurally cannot reach.</b>
+///         <c>EventStoreExplorerCompliance</c>'s fixture is single-database and its four
+///         database-scoped tests say so in their own comments: what they pin is that the database
+///         overload agrees with the store-global read, which is vacuously true of a store that ignores
+///         the argument. The multi-database arm is where the bug was, and it is store-side.
+///     </para>
+///     <para>
+///         The bug's shape is worth restating, because it is why these assert in both directions. Every
+///         one of these reads went to <c>Database</c> — the store's <em>default</em> file — so a
+///         database-per-tenant store answered from one tenant and the result was indistinguishable from
+///         the whole store's. Right for whoever owned the default file, wrong for everybody else, and
+///         silent either way. A test that only checked "the answer is non-empty" passes against that.
+///     </para>
+/// </remarks>
+public class explorer_reads_across_databases : IAsyncLifetime
+{
+    private readonly string _directory =
+        Path.Combine(Path.GetTempPath(), "fisher-explorer-tenants-" + Guid.NewGuid().ToString("n")[..8]);
+
+    private DocumentStore _store = null!;
+    private readonly Guid _north = Guid.NewGuid();
+    private readonly Guid _south = Guid.NewGuid();
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.MultiTenantedDatabases(databases => databases.InDirectory(_directory).AddTenants("north", "south"));
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        // North first, so "most recently updated" has a defined answer across the two files.
+        await using (var session = _store.LightweightSession("north"))
+        {
+            session.Events.StartStream<Quest>(_north, new QuestStarted("Chart the Minch"));
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using (var session = _store.LightweightSession("south"))
+        {
+            session.Events.StartStream<Quest>(_south, new QuestStarted("Chart the Solent"),
+                new MemberJoined("Darwin"));
+            await session.SaveChangesAsync(Token);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+
+        if (Directory.Exists(_directory))
+        {
+            try
+            {
+                Directory.Delete(_directory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A tenant file still held by a pooled connection; the directory is under the temp path.
+            }
+        }
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private IEventStore TheExplorer => _store;
+
+    private async Task<IEventDatabase> DatabaseFor(string tenantId)
+        => (await TheExplorer.AllDatabases()).Single(x => x.Identifier == tenantId);
+
+    // ---- the claim the issue asked to be settled ----
+
+    /// <remarks>
+    ///     The doc comment on <c>DatabaseCardinality</c> claimed <c>Single</c> unconditionally while the
+    ///     expression deferred to the tenancy. Both halves are asserted so the two cannot drift apart
+    ///     again without something failing.
+    /// </remarks>
+    [Fact]
+    public void the_store_reports_the_cardinality_it_actually_has()
+    {
+        TheExplorer.DatabaseCardinality.ShouldBe(DatabaseCardinality.StaticMultiple);
+        TheExplorer.HasMultipleTenants.ShouldBeTrue();
+    }
+
+    // ---- the listing fans out ----
+
+    /// <summary>
+    ///     A store-global listing reaches every tenant's file, not just the default one.
+    /// </summary>
+    /// <remarks>
+    ///     This is the fact that fails against the old behaviour: the default file is north's, so the
+    ///     old read returned north's stream and looked entirely correct until you asked about south.
+    /// </remarks>
+    [Fact]
+    public async Task the_store_global_listing_reaches_every_database()
+    {
+        var streams = await TheExplorer.GetRecentStreamsAsync(10, Token);
+
+        streams.Select(x => x.StreamId)
+            .ShouldBe([_south.ToString(), _north.ToString()], ignoreOrder: true);
+    }
+
+    /// <summary>
+    ///     And each merged summary carries the tenant whose file it came from.
+    /// </summary>
+    /// <remarks>
+    ///     <b>This is what makes the store-global refusal below actionable rather than a dead end.</b>
+    ///     A console lists streams, then drills into one — and the single-stream reads refuse without a
+    ///     scope, so the listing has to hand it one. It cannot come off the row: <c>StreamsTable</c>
+    ///     gives <c>tenant_id</c> a <c>DEFAULT '*DEFAULT*'</c> on a store that is not conjoined, so
+    ///     every row in <c>north.db</c> reads <c>*DEFAULT*</c>. The file is the tenant, so the database
+    ///     is what knows.
+    /// </remarks>
+    [Fact]
+    public async Task a_fanned_out_summary_is_stamped_with_the_tenant_whose_file_it_came_from()
+    {
+        var streams = await TheExplorer.GetRecentStreamsAsync(10, Token);
+
+        streams.Single(x => x.StreamId == _north.ToString()).TenantId.ShouldBe("north");
+        streams.Single(x => x.StreamId == _south.ToString()).TenantId.ShouldBe("south");
+    }
+
+    /// <remarks>
+    ///     The merge is a real merge rather than a concatenation that happens to be short enough:
+    ///     <c>count</c> bounds the result across the two files, and the newest wins. South was written
+    ///     second.
+    /// </remarks>
+    [Fact]
+    public async Task the_count_bounds_the_merged_listing_and_the_newest_wins()
+    {
+        var streams = await TheExplorer.GetRecentStreamsAsync(1, Token);
+
+        streams.Count.ShouldBe(1);
+        streams[0].StreamId.ShouldBe(_south.ToString());
+    }
+
+    [Fact]
+    public async Task a_tenant_scoped_listing_reads_that_tenants_file_only()
+    {
+        var north = await TheExplorer.GetRecentStreamsAsync(10, "north", Token);
+        var south = await TheExplorer.GetRecentStreamsAsync(10, "south", Token);
+
+        north.Select(x => x.StreamId).ShouldBe([_north.ToString()]);
+        south.Select(x => x.StreamId).ShouldBe([_south.ToString()]);
+    }
+
+    [Fact]
+    public async Task a_database_scoped_listing_reads_that_database_only()
+    {
+        var north = await TheExplorer.GetRecentStreamsAsync(await DatabaseFor("north"), 10, null, Token);
+        var south = await TheExplorer.GetRecentStreamsAsync(await DatabaseFor("south"), 10, null, Token);
+
+        north.Select(x => x.StreamId).ShouldBe([_north.ToString()]);
+        south.Select(x => x.StreamId).ShouldBe([_south.ToString()]);
+    }
+
+    // ---- a single-stream lookup refuses rather than picking a file ----
+
+    /// <summary>
+    ///     A store-global lookup of one stream is refused, naming both ways forward.
+    /// </summary>
+    /// <remarks>
+    ///     <b>Refused rather than fanned out, and the signature is the reason.</b> These return one
+    ///     answer, and a stream id is unique within a database rather than across them — so there is no
+    ///     merge to perform, and "whichever file we happened to open" is the bug. The message is
+    ///     asserted, not just the exception type: a refusal that did not say which overloads exist would
+    ///     leave a console with nowhere to go.
+    /// </remarks>
+    [Fact]
+    public async Task a_store_global_stream_lookup_is_refused_with_both_ways_forward()
+    {
+        var ex = await Should.ThrowAsync<NotSupportedException>(
+            () => TheExplorer.GetStreamMetadataAsync(_north.ToString(), Token));
+
+        ex.Message.ShouldContain("StaticMultiple");
+        ex.Message.ShouldContain("tenantId");
+        ex.Message.ShouldContain("database");
+    }
+
+    /// <remarks>
+    ///     Its sibling, and the one where answering from the wrong file is worst: it would hand back
+    ///     another tenant's events under the id the caller asked about. The refusal is raised eagerly
+    ///     rather than from inside the iterator — an <c>async</c> iterator defers its body to the first
+    ///     <c>MoveNextAsync</c>, so a refusal written inline there would surface at the
+    ///     <c>await foreach</c> instead of at the call, which is the discipline
+    ///     <c>ToAsyncEnumerable</c> already follows.
+    /// </remarks>
+    [Fact]
+    public async Task a_store_global_stream_read_is_refused_too()
+    {
+        await Should.ThrowAsync<NotSupportedException>(async () =>
+        {
+            await foreach (var _ in TheExplorer.ReadStreamAsync(_north.ToString(), Token))
+            {
+            }
+        });
+    }
+
+    [Fact]
+    public async Task a_tenant_scoped_lookup_finds_its_own_stream_and_not_the_others()
+    {
+        (await TheExplorer.GetStreamMetadataAsync(_north.ToString(), "north", Token)).ShouldNotBeNull();
+
+        // Null means "no such stream in THIS tenant", which is the distinction the store-global read
+        // could not make — and the one that would have been answered wrongly by reading one file.
+        (await TheExplorer.GetStreamMetadataAsync(_north.ToString(), "south", Token)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_database_scoped_lookup_finds_its_own_stream_and_not_the_others()
+    {
+        var north = await DatabaseFor("north");
+        var south = await DatabaseFor("south");
+
+        var found = await TheExplorer.GetStreamMetadataAsync(north, _north.ToString(), null, Token);
+        found.ShouldNotBeNull();
+        found.Version.ShouldBe(1);
+        found.TenantId.ShouldBe("north");
+
+        (await TheExplorer.GetStreamMetadataAsync(south, _north.ToString(), null, Token)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_database_scoped_stream_read_returns_that_databases_events()
+    {
+        var versions = new List<long>();
+
+        await foreach (var record in TheExplorer.ReadStreamAsync(await DatabaseFor("south"), _south.ToString(),
+                           null, Token))
+        {
+            versions.Add(record.StreamVersion);
+        }
+
+        versions.ShouldBe([1L, 2L]);
+
+        // And the same read against the other file finds nothing, rather than another tenant's stream.
+        await foreach (var _ in TheExplorer.ReadStreamAsync(await DatabaseFor("north"), _south.ToString(),
+                           null, Token))
+        {
+            throw new Exception("north.db answered for south's stream");
+        }
+    }
+
+    [Fact]
+    public async Task an_unknown_tenant_is_refused_rather_than_read_from_the_default_file()
+    {
+        await Should.ThrowAsync<UnknownTenantException>(
+            () => TheExplorer.GetRecentStreamsAsync(10, "east", Token));
+    }
+
+    // ---- what a monitoring tool is told about the shape of the store ----
+
+    /// <remarks>
+    ///     Both usage descriptors hardcoded <c>Single</c>, which a console does not render as "unknown"
+    ///     — it renders it as a one-file store. The <c>Databases</c> list is where the tenants are, and
+    ///     an empty one claims there are none. Same failure the missing <c>Subscriptions</c> list was in
+    ///     fisher#120, one field over.
+    /// </remarks>
+    [Fact]
+    public async Task the_usage_descriptors_report_every_database()
+    {
+        var events = await TheExplorer.TryCreateUsage(Token);
+        events.ShouldNotBeNull();
+        events.Database.ShouldNotBeNull();
+        events.Database.Cardinality.ShouldBe(DatabaseCardinality.StaticMultiple);
+        events.Database.Databases.Count.ShouldBe(2);
+
+        var documents = await ((IDocumentStoreUsageSource)_store).TryCreateUsage(Token);
+        documents.ShouldNotBeNull();
+        documents.Database.ShouldNotBeNull();
+        documents.Database.Cardinality.ShouldBe(DatabaseCardinality.StaticMultiple);
+        documents.Database.Databases.Count.ShouldBe(2);
+    }
+}
+
+/// <summary>
+///     The other arm of tenant scoping: one file, and the tenant is a column value.
+/// </summary>
+/// <remarks>
+///     <b>A tenant predicate in SQL is correct here and wrong under database-per-tenant</b>, which is
+///     the asymmetry <c>ResolveTenantScope</c> exists for and the half the old tenant-scoped
+///     <c>ReadStreamAsync</c> had backwards: it composed <c>and tenant_id = @tenant_id</c>
+///     unconditionally, against the store's default file. Under conjoined tenancy that is right; under
+///     database-per-tenant the column holds <c>*DEFAULT*</c> in every file, so it matched nothing.
+/// </remarks>
+public class explorer_reads_under_conjoined_tenancy : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("explorer-conjoined");
+    private DocumentStore _store = null!;
+    private readonly Guid _north = Guid.NewGuid();
+    private readonly Guid _south = Guid.NewGuid();
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = _store.LightweightSession("north");
+        session.Events.StartStream<Quest>(_north, new QuestStarted("Chart the Minch"));
+        session.ForTenant("south").Events.StartStream<Quest>(_south, new QuestStarted("Chart the Solent"));
+        await session.SaveChangesAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private IEventStore TheExplorer => _store;
+
+    /// <remarks>
+    ///     One file, so the cardinality is <c>Single</c> — and the store is still multi-tenanted, which
+    ///     is the pair <c>HasMultipleTenants</c> got wrong by answering <see langword="false" />
+    ///     unconditionally. A console reading that renders no tenant dimension at all.
+    /// </remarks>
+    [Fact]
+    public void one_file_can_still_be_multi_tenanted()
+    {
+        TheExplorer.DatabaseCardinality.ShouldBe(DatabaseCardinality.Single);
+        TheExplorer.HasMultipleTenants.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task a_tenant_scoped_listing_filters_on_the_column()
+    {
+        var north = await TheExplorer.GetRecentStreamsAsync(10, "north", Token);
+
+        north.Select(x => x.StreamId).ShouldBe([_north.ToString()]);
+        north[0].TenantId.ShouldBe("north");
+    }
+
+    /// <remarks>
+    ///     The store-global read is <em>not</em> refused here, because one file has one answer — it
+    ///     returns both tenants' streams, as it always did. The refusal is about database cardinality,
+    ///     not about tenancy.
+    /// </remarks>
+    [Fact]
+    public async Task the_store_global_listing_still_spans_both_tenants()
+    {
+        var streams = await TheExplorer.GetRecentStreamsAsync(10, Token);
+
+        streams.Select(x => x.StreamId)
+            .ShouldBe([_north.ToString(), _south.ToString()], ignoreOrder: true);
+    }
+
+    /// <remarks>
+    ///     The case jasperfx#503 added the tenant overloads for: the same lookup, two tenants, and the
+    ///     tenant-less read resolves whichever the default session carries.
+    /// </remarks>
+    [Fact]
+    public async Task a_tenant_scoped_lookup_will_not_see_another_tenants_stream()
+    {
+        (await TheExplorer.GetStreamMetadataAsync(_south.ToString(), "south", Token)).ShouldNotBeNull();
+        (await TheExplorer.GetStreamMetadataAsync(_south.ToString(), "north", Token)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_tenant_scoped_stream_read_will_not_see_another_tenants_events()
+    {
+        var mine = new List<long>();
+        await foreach (var record in TheExplorer.ReadStreamAsync(_south.ToString(), "south", Token))
+        {
+            mine.Add(record.StreamVersion);
+        }
+
+        mine.ShouldBe([1L]);
+
+        await foreach (var _ in TheExplorer.ReadStreamAsync(_south.ToString(), "north", Token))
+        {
+            throw new Exception("the north tenant answered for south's stream");
+        }
+    }
+
+    /// <remarks>
+    ///     A single-database store's one database is necessarily the argument, so the database overload
+    ///     is the store-global read — which is what the shared suite pins, and what has to keep holding
+    ///     once the multi-database arm exists beside it.
+    /// </remarks>
+    [Fact]
+    public async Task the_database_overload_agrees_with_the_store_global_read()
+    {
+        var database = (await TheExplorer.AllDatabases()).Single();
+
+        var scoped = await TheExplorer.GetRecentStreamsAsync(database, 10, null, Token);
+        var global = await TheExplorer.GetRecentStreamsAsync(10, Token);
+
+        scoped.Select(x => x.StreamId).ShouldBe(global.Select(x => x.StreamId));
+    }
+}

--- a/src/Fisher/DocumentStore.DocumentUsage.cs
+++ b/src/Fisher/DocumentStore.DocumentUsage.cs
@@ -36,11 +36,8 @@ public partial class DocumentStore : IDocumentStoreUsageSource
             Subject = "Fisher.DocumentStore",
             SubjectUri = Database.Describe().DatabaseUri(),
             Version = GetType().Assembly.GetName().Version?.ToString(),
-            Database = new DatabaseUsage
-            {
-                Cardinality = DatabaseCardinality.Single,
-                MainDatabase = Database.Describe()
-            },
+            // fisher#240 — the tenancy's answer, not a hardcoded Single. See DescribeDatabases.
+            Database = DescribeDatabases(),
             StoreName = Options.StoreName,
             DatabaseSchemaName = Options.DatabaseSchemaName,
             AutoCreateSchemaObjects = Options.AutoCreateSchemaObjects.ToString(),

--- a/src/Fisher/DocumentStore.EventStore.cs
+++ b/src/Fisher/DocumentStore.EventStore.cs
@@ -25,10 +25,16 @@ namespace Fisher;
 ///     </para>
 ///     <para>
 ///         Most of <see cref="IEventStore" /> is default-implemented by the interface itself and left
-///         alone here. What Fisher overrides is the pair of explorer reads it can answer from
-///         <c>fi_streams</c> — <see cref="IEventStore.GetRecentStreamsAsync(int, CancellationToken)" />
-///         and <see cref="IEventStore.GetStreamMetadataAsync(string, CancellationToken)" /> — plus the
-///         required members.
+///         alone here. What Fisher overrides is the explorer reads it can answer from <c>fi_streams</c>
+///         and <c>fi_events</c> — recent streams, one stream's events, one stream's metadata — at all
+///         three of their scopes, plus the required members.
+///     </para>
+///     <para>
+///         <b>Those reads have a database dimension as well as a tenant one</b> (fisher#240,
+///         jasperfx#810), and on Fisher that is not theoretical: a database-per-tenant store is a file
+///         per tenant. See the block above the reads themselves for what a store-global answer means
+///         once there is more than one file, and why a listing merges where a single-stream lookup
+///         refuses.
 ///     </para>
 ///     <para>
 ///         <b>Nothing here throws any more</b> (fisher#15). The standing discipline, for the next
@@ -52,12 +58,43 @@ public partial class DocumentStore : IEventStore
     Uri IEventStore.Subject => Database.Describe().DatabaseUri();
 
     /// <summary>
-    ///     One SQLite file is one database, and Fisher has no database-per-tenant tenancy, so the
-    ///     cardinality is always <see cref="DatabaseCardinality.Single" />.
+    ///     How many databases this store spans — the tenancy's answer, which is not always
+    ///     <see cref="DatabaseCardinality.Single" /> (fisher#240).
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>This used to claim <c>Single</c> unconditionally in prose while deferring to the
+    ///         tenancy in code, and the prose was the stale half.</b> One SQLite <em>file</em> is one
+    ///         database, but a database-per-tenant store is a file per tenant — <c>StaticMultiple</c>
+    ///         under <see cref="StoreOptions.MultiTenantedDatabases" />, <c>DynamicMultiple</c> under
+    ///         <c>MultiTenantedDatabasesInDirectory</c> / <c>MultiTenantedDatabasesInRegistry</c> — and
+    ///         <c>FisherServiceCollectionExtensions</c> has branched on <c>DynamicMultiple</c> since the
+    ///         daemon learned to run per tenant. The expression was right all along; the comment was
+    ///         written before fisher#47 and never revisited.
+    ///     </para>
+    ///     <para>
+    ///         It is not decorative. Every database-scoped explorer read below reads this to decide
+    ///         whether a store-global answer is honest, so a store that claimed <c>Single</c> while
+    ///         spanning a hundred files would answer from one of them and read as complete.
+    ///     </para>
+    /// </remarks>
     DatabaseCardinality IEventStore.DatabaseCardinality => Tenancy.Cardinality;
 
-    bool IEventStore.HasMultipleTenants => false;
+    /// <summary>
+    ///     Whether this store partitions data by tenant at all, either way it can.
+    /// </summary>
+    /// <remarks>
+    ///     <b>This said <see langword="false" /> unconditionally, which was wrong in both directions a
+    ///     Fisher store can be multi-tenanted</b> (fisher#240): conjoined tenancy puts a
+    ///     <c>tenant_id</c> column on the event tables and on every <c>MultiTenanted()</c> document
+    ///     table, and database-per-tenant puts each tenant in its own file. A console reading
+    ///     <see langword="false" /> renders no tenant dimension at all, so the tenant-scoped overloads
+    ///     beside it are reachable by an API caller and invisible to the tool they exist for.
+    /// </remarks>
+    bool IEventStore.HasMultipleTenants
+        => Tenancy.Cardinality != DatabaseCardinality.Single
+           || Options.Events.TenancyStyle == JasperFx.MultiTenancy.TenancyStyle.Conjoined
+           || Options.Schema.AllMappings().Any(x => x.IsConjoined);
 
     EventStoreIdentity IEventStore.Identity => new(Options.DatabaseSchemaName, "fisher");
 
@@ -86,11 +123,150 @@ public partial class DocumentStore : IEventStore
     }
 
     // ---- explorer reads ----
+    //
+    // jasperfx#810 / fisher#240 — these reads have three scopes, and which one a caller reaches for is
+    // not a preference.
+    //
+    //   * database-scoped  — the widest honest answer on a store with more than one file. A tool walks
+    //                        AllDatabases() and attributes each answer to the database it came from.
+    //   * tenant-scoped    — one tenant, wherever that tenant lives.
+    //   * store-global     — every database, and only meaningful where one answer can stand for all of
+    //                        them. A listing merges; a lookup that names ONE stream cannot, and refuses.
+    //
+    // The refusal is the point of the issue. Before this, every one of these read Database — the store's
+    // default file — so a database-per-tenant store answered from one tenant's file and the result was
+    // indistinguishable from the whole store's. Silent, and asymmetric in the usual way: right for
+    // whichever tenant happened to own the default file, wrong for every other one.
+
+    /// <summary>
+    ///     Which database a tenant's rows are in, and whether the tenant is also a column value.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>A tenant predicate in SQL is correct only under conjoined tenancy, and that is the
+    ///         half the old tenant-scoped <c>ReadStreamAsync</c> had backwards.</b> Under
+    ///         database-per-tenant the tenant <em>is</em> the file: <c>StreamsTable</c> gives
+    ///         <c>tenant_id</c> a <c>DEFAULT '*DEFAULT*'</c> for a store that is not conjoined, so every
+    ///         row in <c>north.db</c> reads <c>*DEFAULT*</c> and <c>and tenant_id = 'north'</c> matches
+    ///         nothing at all. Resolving the database is the whole of the scoping there.
+    ///     </para>
+    ///     <para>
+    ///         An unknown tenant throws out of <see cref="ITenancy.DatabaseFor" /> rather than falling
+    ///         back to the default file, which is the rule every tenant-scoped member follows.
+    ///     </para>
+    /// </remarks>
+    private (FisherDatabase Database, string? ColumnPredicate) ResolveTenantScope(string tenantId)
+        => (Tenancy.DatabaseFor(tenantId), TenantColumnPredicate(tenantId));
+
+    /// <summary>
+    ///     The <c>tenant_id</c> predicate a tenant deserves in SQL, which is none unless the store is
+    ///     conjoined.
+    /// </summary>
+    /// <remarks>
+    ///     Split from <see cref="ResolveTenantScope" /> for the database-scoped overloads, where the
+    ///     caller has already named the database: asking the tenancy to resolve the tenant as well
+    ///     would be work whose result is discarded, and would refuse an unregistered tenant id on a
+    ///     read that was never going to consult the tenancy.
+    /// </remarks>
+    private string? TenantColumnPredicate(string? tenantId)
+        => tenantId is not null && EventGraph.TenancyStyle == JasperFx.MultiTenancy.TenancyStyle.Conjoined
+            ? tenantId
+            : null;
+
+    /// <summary>
+    ///     The refusal a store-global single-stream read gives once the store spans more than one file.
+    /// </summary>
+    /// <remarks>
+    ///     A stream id is unique within a database and not across them, so there is no merge that
+    ///     produces the one answer these signatures return — which is exactly why answering from the
+    ///     default file was wrong rather than merely partial. The message names both ways forward, and
+    ///     they are both reachable: <c>GetRecentStreamsAsync</c> fans out and stamps each summary with
+    ///     its database's tenant, so a console that found a stream has the tenant id this refusal asks
+    ///     for.
+    /// </remarks>
+    private NotSupportedException streamLookupNeedsAScope(string member)
+        => new(
+            $"Store-global {member} cannot answer on this Fisher store, whose DatabaseCardinality is "
+            + $"{Tenancy.Cardinality} — it spans {Tenancy.AllDatabases().Count} database files, and a stream id is "
+            + "unique within one of them rather than across them, so there is no single answer to return. "
+            + $"Name the scope: {member}(tenantId, ...) for one tenant's file, or {member}(database, ...) "
+            + "for a database from AllDatabases(). GetRecentStreamsAsync fans out and stamps each stream "
+            + "with its tenant, which is where that tenant id comes from. See fisher#240, jasperfx#810.");
+
+    // ---- recent streams ----
 
     Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(int count, CancellationToken ct)
-        => GetRecentStreamsAsync(count, ct);
+        => RecentStreamsAcrossDatabasesAsync(count, null, ct);
 
-    private async Task<IReadOnlyList<StreamSummary>> GetRecentStreamsAsync(int count, CancellationToken ct)
+    Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(int count, string? tenantId,
+        CancellationToken ct)
+        => RecentStreamsAcrossDatabasesAsync(count, tenantId, ct);
+
+    Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(IEventDatabase database, int count,
+        string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+
+        return GetRecentStreamsAsync(DatabaseFrom(database), count, TenantColumnPredicate(tenantId), ct);
+    }
+
+    /// <summary>
+    ///     The store-global listing, which <b>fans out and merges</b> rather than refusing.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>A listing is the one shape of this family where merging is what the caller meant.</b>
+    ///         "The ten most recently updated streams in this store" has an answer across a hundred
+    ///         files, and the ordering key makes it computable: <c>fi_streams.timestamp</c> is
+    ///         <see cref="SqliteTimestamp" />'s fixed-width UTC text, so it compares across databases
+    ///         exactly as it does within one. Reading <paramref name="count" /> from each file and
+    ///         keeping the newest <paramref name="count" /> is the whole merge, and it is exact — a
+    ///         stream outside a file's own top <paramref name="count" /> cannot be in the store's.
+    ///     </para>
+    ///     <para>
+    ///         The cost is one file open per database, which is what makes this defensible on Fisher and
+    ///         would not be on a sibling: these are local files, not server round trips. A store with
+    ///         several hundred tenants should page per database through the database-scoped overload.
+    ///     </para>
+    /// </remarks>
+    private async Task<IReadOnlyList<StreamSummary>> RecentStreamsAcrossDatabasesAsync(int count, string? tenantId,
+        CancellationToken ct)
+    {
+        if (count <= 0)
+        {
+            return [];
+        }
+
+        if (tenantId is not null)
+        {
+            var (database, predicate) = ResolveTenantScope(tenantId);
+            return await GetRecentStreamsAsync(database, count, predicate, ct).ConfigureAwait(false);
+        }
+
+        await RefreshTenantsAsync(ct).ConfigureAwait(false);
+
+        var databases = Tenancy.AllDatabases();
+
+        if (databases.Count == 1)
+        {
+            return await GetRecentStreamsAsync(databases[0], count, null, ct).ConfigureAwait(false);
+        }
+
+        var merged = new List<StreamSummary>();
+
+        foreach (var database in databases)
+        {
+            merged.AddRange(await GetRecentStreamsAsync(database, count, null, ct).ConfigureAwait(false));
+        }
+
+        return merged
+            .OrderByDescending(x => x.LastUpdatedAt)
+            .Take(count)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<StreamSummary>> GetRecentStreamsAsync(FisherDatabase database, int count,
+        string? tenantPredicate, CancellationToken ct)
     {
         if (count <= 0)
         {
@@ -100,19 +276,30 @@ public partial class DocumentStore : IEventStore
         // Ordering by the ISO-8601 TEXT timestamp is a string sort, and correct only because
         // SqliteTimestamp.Format is fixed-width, UTC-normalised and millisecond-precision. A format
         // with a variable-width offset or no sub-second component would silently mis-order streams
-        // written within the same second.
+        // written within the same second — and it is the same property the cross-database merge above
+        // leans on, one level up.
         var sql = $"""
                    select {FisherStreamsRowReader.SelectColumns}
                    from {EventGraph.StreamsTableName}
-                   order by timestamp desc
+                   {WhereTenant(tenantPredicate)}order by timestamp desc
                    limit @count;
                    """;
 
-        return await ReadStreamsAsync(sql,
-            command => command.Parameters.AddWithValue("@count", count),
+        var rows = await ReadStreamsAsync(database, sql,
+            command =>
+            {
+                command.Parameters.AddWithValue("@count", count);
+                if (tenantPredicate is not null) command.Parameters.AddWithValue("@tenant_id", tenantPredicate);
+            },
             FisherStreamsRowReader.ReadStreamSummary,
             ct).ConfigureAwait(false);
+
+        return database.TenantId is null
+            ? rows
+            : rows.Select(x => x with { TenantId = database.TenantId }).ToList();
     }
+
+    // ---- one stream's events ----
 
     IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(string streamId, CancellationToken ct)
         => ReadStreamAsync(streamId, null, ct);
@@ -121,13 +308,37 @@ public partial class DocumentStore : IEventStore
         CancellationToken ct)
         => ReadStreamAsync(streamId, tenantId, ct);
 
+    IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(IEventDatabase database, string streamId,
+        string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+
+        return ReadStreamAsync(DatabaseFrom(database), streamId, TenantColumnPredicate(tenantId), ct);
+    }
+
+    private IAsyncEnumerable<EventRecord> ReadStreamAsync(string streamId, string? tenantId, CancellationToken ct)
+    {
+        if (tenantId is not null)
+        {
+            var (database, predicate) = ResolveTenantScope(tenantId);
+            return ReadStreamAsync(database, streamId, predicate, ct);
+        }
+
+        if (Tenancy.Cardinality != DatabaseCardinality.Single)
+        {
+            throw streamLookupNeedsAScope(nameof(IEventStore.ReadStreamAsync));
+        }
+
+        return ReadStreamAsync(Database, streamId, null, ct);
+    }
+
     /// <summary>
     ///     Every event of one stream, in version order, as wire <see cref="EventRecord" />s.
     /// </summary>
     /// <remarks>
     ///     <para>
     ///         Materialised inside <see cref="StoreOptions.ResiliencePipeline" /> and then yielded,
-    ///         rather than streamed out of it — the same reason <c>ReadStreamsAsync</c> gives above. A
+    ///         rather than streamed out of it — the same reason <c>ReadStreamsAsync</c> gives below. A
     ///         retried <c>SQLITE_BUSY</c> re-executes the whole delegate, so handing a live reader to the
     ///         caller would let a retry resume against a connection the previous attempt had already
     ///         disposed. A single stream is a bounded read, so holding it in memory costs little.
@@ -139,8 +350,8 @@ public partial class DocumentStore : IEventStore
     ///         event assemblies.
     ///     </para>
     /// </remarks>
-    private async IAsyncEnumerable<EventRecord> ReadStreamAsync(string streamId, string? tenantId,
-        [EnumeratorCancellation] CancellationToken ct)
+    private async IAsyncEnumerable<EventRecord> ReadStreamAsync(FisherDatabase database, string streamId,
+        string? tenantPredicate, [EnumeratorCancellation] CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrEmpty(streamId);
 
@@ -151,7 +362,9 @@ public partial class DocumentStore : IEventStore
             ? Guid.Parse(streamId).ToString()
             : streamId;
 
-        var tenantFilter = tenantId == null ? "" : "and tenant_id = @tenant_id\n                   ";
+        var tenantFilter = tenantPredicate is null
+            ? ""
+            : "and tenant_id = @tenant_id\n                   ";
 
         var sql = $"""
                    select {FisherEventsRowReader.ComposeSelectColumns(EventGraph.EventOptions)}
@@ -170,11 +383,11 @@ public partial class DocumentStore : IEventStore
 
         var records = await Options.ResiliencePipeline.ExecuteAsync(async token =>
         {
-            await using var connection = await Database.OpenConnectionAsync(token).ConfigureAwait(false);
+            await using var connection = await database.OpenConnectionAsync(token).ConfigureAwait(false);
             await using var command = connection.CreateCommand();
             command.CommandText = sql;
             command.Parameters.AddWithValue("@stream_id", id);
-            if (tenantId != null) command.Parameters.AddWithValue("@tenant_id", tenantId);
+            if (tenantPredicate is not null) command.Parameters.AddWithValue("@tenant_id", tenantPredicate);
 
             var results = new List<EventRecord>();
             await using var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
@@ -193,10 +406,41 @@ public partial class DocumentStore : IEventStore
         }
     }
 
-    Task<StreamMetadata?> IEventStore.GetStreamMetadataAsync(string streamId, CancellationToken ct)
-        => GetStreamMetadataAsync(streamId, ct);
+    // ---- one stream's metadata ----
 
-    private async Task<StreamMetadata?> GetStreamMetadataAsync(string streamId, CancellationToken ct)
+    Task<StreamMetadata?> IEventStore.GetStreamMetadataAsync(string streamId, CancellationToken ct)
+        => GetStreamMetadataAsync(streamId, null, ct);
+
+    Task<StreamMetadata?> IEventStore.GetStreamMetadataAsync(string streamId, string? tenantId,
+        CancellationToken ct)
+        => GetStreamMetadataAsync(streamId, tenantId, ct);
+
+    Task<StreamMetadata?> IEventStore.GetStreamMetadataAsync(IEventDatabase database, string streamId,
+        string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+
+        return GetStreamMetadataAsync(DatabaseFrom(database), streamId, TenantColumnPredicate(tenantId), ct);
+    }
+
+    private Task<StreamMetadata?> GetStreamMetadataAsync(string streamId, string? tenantId, CancellationToken ct)
+    {
+        if (tenantId is not null)
+        {
+            var (database, predicate) = ResolveTenantScope(tenantId);
+            return GetStreamMetadataAsync(database, streamId, predicate, ct);
+        }
+
+        if (Tenancy.Cardinality != DatabaseCardinality.Single)
+        {
+            throw streamLookupNeedsAScope(nameof(IEventStore.GetStreamMetadataAsync));
+        }
+
+        return GetStreamMetadataAsync(Database, streamId, null, ct);
+    }
+
+    private async Task<StreamMetadata?> GetStreamMetadataAsync(FisherDatabase database, string streamId,
+        string? tenantPredicate, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrEmpty(streamId);
 
@@ -207,23 +451,76 @@ public partial class DocumentStore : IEventStore
             ? Guid.Parse(streamId).ToString()
             : streamId;
 
+        var tenantFilter = tenantPredicate is null ? "" : "and tenant_id = @tenant_id\n                   ";
+
         var sql = $"""
                    select {FisherStreamsRowReader.SelectColumns}
                    from {EventGraph.StreamsTableName}
-                   where id = @id;
+                   where id = @id
+                   {tenantFilter};
                    """;
 
-        var rows = await ReadStreamsAsync(sql,
-            command => command.Parameters.AddWithValue("@id", id),
+        var rows = await ReadStreamsAsync(database, sql,
+            command =>
+            {
+                command.Parameters.AddWithValue("@id", id);
+                if (tenantPredicate is not null) command.Parameters.AddWithValue("@tenant_id", tenantPredicate);
+            },
             FisherStreamsRowReader.ReadStreamMetadata,
             ct).ConfigureAwait(false);
 
-        return rows.Count == 0 ? null : rows[0];
+        if (rows.Count == 0)
+        {
+            return null;
+        }
+
+        return database.TenantId is null ? rows[0] : rows[0] with { TenantId = database.TenantId };
     }
 
+    // ---- the two reads Fisher answers at no scope ----
+
     /// <summary>
-    ///     Run a <c>fi_streams</c> read through the store's resilience pipeline, hydrating each row with
-    ///     <paramref name="read" />.
+    ///     Refused at every scope, so the database argument changes nothing — and says so.
+    /// </summary>
+    /// <remarks>
+    ///     <b>Overridden only to keep the message honest</b> (fisher#240). Fisher deliberately does not
+    ///     implement the dictionary <c>QueryByTagsAsync</c> at all — <c>EventQuery.TagValues</c> is the
+    ///     better home for that capability here, being composable and paged where the overload is
+    ///     neither, so there is no second code path to keep in step. Left to the interface default, a
+    ///     multi-database store would answer this with jasperfx#810's refusal, which blames the database
+    ///     dimension for a read that does not exist at any dimension. Forwarding reaches the accurate
+    ///     "not implemented" instead.
+    /// </remarks>
+    IAsyncEnumerable<EventRecord> IEventStore.QueryByTagsAsync(IEventDatabase database,
+        IReadOnlyDictionary<string, string> tags, string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+
+        return ((IEventStore)this).QueryByTagsAsync(tags, tenantId, ct);
+    }
+
+    /// <inheritdoc cref="IEventStore.QueryByTagsAsync(IEventDatabase, IReadOnlyDictionary{string, string}, string, CancellationToken)" />
+    /// <remarks>
+    ///     Same reasoning as <c>QueryByTagsAsync</c> above, for a read Fisher has not grown yet rather
+    ///     than one it declines: a per-shard status snapshot wants the running daemon's shard states,
+    ///     not just <c>fi_event_progression</c>'s sequences, and reporting every shard as "Stopped" to
+    ///     fill the slot would be the failure fisher#120 records rather than a fix for it. Tracked as
+    ///     fisher#243; until then the honest answer is the one the interface's own default gives.
+    /// </remarks>
+    Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(IEventDatabase database,
+        string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+
+        return ((IEventStore)this).GetProjectionStatusesAsync(tenantId, ct);
+    }
+
+    private static string WhereTenant(string? tenantPredicate)
+        => tenantPredicate is null ? "" : "where tenant_id = @tenant_id\n                   ";
+
+    /// <summary>
+    ///     Run a <c>fi_streams</c> read against one database through the store's resilience pipeline,
+    ///     hydrating each row with <paramref name="read" />.
     /// </summary>
     /// <remarks>
     ///     Rows are materialised inside the pipeline rather than streamed out of it. A retried
@@ -231,6 +528,7 @@ public partial class DocumentStore : IEventStore
     ///     would let a retry resume against a connection the previous attempt had already disposed.
     /// </remarks>
     private async Task<IReadOnlyList<T>> ReadStreamsAsync<T>(
+        FisherDatabase database,
         string sql,
         Action<Microsoft.Data.Sqlite.SqliteCommand> configure,
         Func<System.Data.Common.DbDataReader, T> read,
@@ -238,7 +536,7 @@ public partial class DocumentStore : IEventStore
     {
         return await Options.ResiliencePipeline.ExecuteAsync(async token =>
         {
-            await using var connection = await Database.OpenConnectionAsync(token).ConfigureAwait(false);
+            await using var connection = await database.OpenConnectionAsync(token).ConfigureAwait(false);
             await using var command = connection.CreateCommand();
             command.CommandText = sql;
             configure(command);
@@ -283,11 +581,7 @@ public partial class DocumentStore : IEventStore
             Subject = "Fisher.DocumentStore",
             SubjectUri = Database.Describe().DatabaseUri(),
             Version = GetType().Assembly.GetName().Version?.ToString()!,
-            Database = new DatabaseUsage
-            {
-                Cardinality = DatabaseCardinality.Single,
-                MainDatabase = Database.Describe()
-            }
+            Database = DescribeDatabases()
         };
 
         usage.AddValue(nameof(EventGraph.StreamIdentity), EventGraph.StreamIdentity);
@@ -352,6 +646,34 @@ public partial class DocumentStore : IEventStore
         // two source types of its own (CompositeIProjectionSource, FlatTableProjection) implement
         // Describe. Nothing here is Fisher-specific, which is exactly why it was easy to leave out.
         Options.Projections.Describe(usage, this);
+
+        return usage;
+    }
+
+    /// <summary>
+    ///     The store's databases, as a monitoring tool's <see cref="DatabaseUsage" />.
+    /// </summary>
+    /// <remarks>
+    ///     <b>Both usage descriptors hardcoded <see cref="DatabaseCardinality.Single" /> here</b>
+    ///     (fisher#240), which is the fisher#120 shape exactly: a console does not read that as "this
+    ///     store does not describe its tenancy", it reads it as <em>the store has one database</em>, and
+    ///     renders a hundred tenants' files as one. <see cref="DatabaseUsage.Databases" /> is filled for
+    ///     the same reason — it is where a tool finds the tenants, and an empty list claims there are
+    ///     none. A single-database store reports itself in <c>MainDatabase</c> alone, as before, because
+    ///     there listing it twice would be the noise.
+    /// </remarks>
+    private DatabaseUsage DescribeDatabases()
+    {
+        var usage = new DatabaseUsage
+        {
+            Cardinality = Tenancy.Cardinality,
+            MainDatabase = Database.Describe()
+        };
+
+        if (Tenancy.Cardinality != DatabaseCardinality.Single)
+        {
+            usage.Databases.AddRange(Tenancy.AllDatabases().Select(x => x.Describe()));
+        }
 
         return usage;
     }


### PR DESCRIPTION
Closes #240. Also bumps Weasel 9.31.2 → 9.32.0; JasperFx is already on 2.68.0, which is the latest.

## The question #240 opened with, settled

**Fisher is multi-database.** `DocumentStore.EventStore.cs` claimed in prose that "Fisher has no
database-per-tenant tenancy, so the cardinality is always `Single`" while the expression beside it
deferred to `Tenancy.Cardinality` — which has answered `StaticMultiple` since #47 and
`DynamicMultiple` since #58. The comment predates both and was never revisited;
`database_per_tenant.tooling_sees_every_tenants_database` had been asserting the opposite for as long.

So the pre-existing bug jasperfx#810 predicts was real here. Every one of these reads went to
`Database` — the store's *default* file — so a database-per-tenant store answered from one tenant and
the result was indistinguishable from the whole store's. Right for whoever owned the default file,
wrong for everybody else, silent either way.

## What a store-global read does now

The split is the shape of the signatures rather than a preference:

- **The listing fans out and merges.** "The ten most recently updated streams in this store" has an
  answer across a hundred files, and `fi_streams.timestamp` is `SqliteTimestamp`'s fixed-width UTC
  text — so it compares across databases exactly as within one, and reading `count` from each file and
  keeping the newest `count` is exact rather than approximate. The cost is one file open per database,
  which is defensible here and would not be on a sibling: these are local files, not server round
  trips.
- **A single-stream lookup refuses.** `ReadStreamAsync` and `GetStreamMetadataAsync` return **one**
  answer over an id that is unique *within* a database and not across them, so there is no merge to
  perform and "whichever file we opened" is the bug itself. Both throw, naming the tenant-scoped and
  database-scoped overloads.
- **A fanned-out summary is stamped with its database's tenant**, which is what makes that refusal
  actionable rather than a dead end: a console lists, then drills in, so the listing has to hand it the
  scope the lookup demands. It cannot come off the row — `StreamsTable` gives `tenant_id` a
  `DEFAULT '*DEFAULT*'` for a store that is not conjoined, so every row in `north.db` reads
  `*DEFAULT*`. The file is the tenant.

## The sibling audit #240 asked for

| Member | Before | Now |
| :--- | :--- | :--- |
| `GetRecentStreamsAsync` | store-global only, default file | all three scopes |
| `ReadStreamAsync` | store-global + tenant, default file, tenant predicate **always** in SQL | all three scopes |
| `GetStreamMetadataAsync` | store-global only, default file | all three scopes |
| `QueryByTagsAsync` | not implemented (deliberate) | unchanged; database overload forwards so the message stays honest |
| `GetProjectionStatusesAsync` | not implemented | unchanged; filed as #243 |

⚠️ **A tenant predicate in SQL is correct only under conjoined tenancy, and the old tenant-scoped
`ReadStreamAsync` had it backwards** — it composed `and tenant_id = @tenant_id` unconditionally
against the default file, so under database-per-tenant it matched nothing at all. `ResolveTenantScope`
is now the one place that decides: conjoined means a column predicate, everything else means the
tenant selects the *database*.

`GetRecentStreamsAsync` and `GetStreamMetadataAsync` had no tenant overload and fell through to
JasperFx's default, which **throws** for a non-null tenant, while `ReadStreamAsync` had one. One of
three implemented is exactly the asymmetry the audit item exists to catch.

The two Fisher answers at no scope are overridden only to keep the message honest. Left to the
interface default, a multi-database store meets jasperfx#810's refusal, which blames the database
dimension for a read that does not exist at any dimension.

## Two more stale `Single` claims, both of the #120 shape

- **Both usage descriptors hardcoded `Cardinality = Single`**, event and document alike. A console does
  not read that as "unknown" — it renders a hundred tenants' files as a one-file store.
  `DescribeDatabases()` is the one place both now read, and it fills `DatabaseUsage.Databases` too,
  because an empty list claims there are no tenants.
- **`HasMultipleTenants` said `false` unconditionally**, wrong in both directions a Fisher store can be
  multi-tenanted. It now matches Marten's three clauses exactly.

## Coverage

**The shared suite structurally cannot reach any of this, and says so in its own comments.** Its
fixture is single-database, so jasperfx#817's four database-scoped facts pin that the database
overload *agrees with* the store-global read — vacuously true of a store that ignores the argument.
They pass on `main` already, and still pass here.

`explorer_reads_across_databases` (14) is the multi-database arm and
`explorer_reads_under_conjoined_tenancy` (5) the column-predicate one. **16 of the 19 fail against the
previous behaviour** — verified by stashing the two production files and re-running — and the three
that pass are the regression guards for what a single-database store already did.

Also confirmed per #240's last item: `AsyncDaemonCompliance.registered_shard_names_are_reachable_from_the_non_generic_store`
(jasperfx#815) passes with no Fisher change, as the issue expected.

## The Weasel bump

9.31.2 → 9.32.0. `Weasel.Sqlite`'s public API is byte-identical between the two; `Weasel.Storage` adds
`IDocumentStorage<T>.MappedVersionFor` / `MappedRevisionFor` (weasel#590), both default-implemented to
null, so it is additive and Fisher's storage keeps its current behaviour.

> [!NOTE]
> weasel#590 was raised from marten#5372 — a member mapped with `Metadata.Version.MapTo(...)` being
> invisible to the session, so the upsert bound `DBNull` into its version guard and reported every
> cross-session write as a concurrency violation. Fisher has the same mapping surface (#11). Whether
> that shape reproduces here is not something this PR investigated and is worth its own look.

## Verification

2064 tests green on **both** net9.0 and net10.0 — 2009 / 36 / 19. `check_scoreboard.py` agrees with
both runs; `check_no_leaked_databases.py` clean; `npm run docs-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)