### PR TITLE
Fisher 1.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
              -p:Version=${TAG#v}, so this is only what a local `dotnet pack` stamps. It drifted three
              releases behind before anybody noticed, which is why it says so here. Keep it in step
              with the tag anyway: a locally packed 1.0.7 that is really 1.3.0 is its own trap. -->
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,19 @@
 Where Fisher is, what comes next, and why in this order. See [CLAUDE.md](CLAUDE.md) for
 architecture and the SQLite-specific decisions.
 
-Status: **two open issues, and neither is next-release work.**
+Status: **four open issues. Two are real work and neither is blocked; two are not next-release work.**
+
+The two that are work both came out of 1.4.0 and are recorded there rather than discovered later.
+[#243](https://github.com/JasperFx/fisher/issues/243) is `IEventStore.GetProjectionStatusesAsync`,
+which Fisher answers at no scope — so a store-agnostic console renders a projections page for Marten
+and Polecat and an error for Fisher. It was left out of #240 deliberately: the gap is shard *state*,
+which `fi_event_progression` does not know, and Polecat's answer reports every shard as `"Stopped"`
+(polecat#200). Filling the slot that way is the fisher#120 failure rather than a fix for it.
+[#245](https://github.com/JasperFx/fisher/issues/245) is a question with evidence rather than a
+confirmed bug, and wants a failing test before any code: Weasel 9.32.0's `MappedVersionFor` /
+`MappedRevisionFor` seam comes from marten#5372, and Fisher has the same mapping surface. The four
+cases to compare are in the issue.
+
 [#189](https://github.com/JasperFx/fisher/issues/189) is an unreproduced `Fisher.AspNetCore.Tests`
 failure — 12 of 36 on one loaded host, green on retry, with the failing test names never captured.
 Three hazards have been removed since — the project's only wall-clock budget, its only


### PR DESCRIPTION
Release prep for **1.4.0**. Two files: `Directory.Build.props`' `<Version>` and ROADMAP's status line,
matching the shape of #237.

## Why minor rather than patch

Post-1.0 the bump turns on **whether the release adds capability a consumer can reach**. 1.4.0 does,
twice over, both from #240:

- The **database-scoped explorer reads** are new public surface — `GetRecentStreamsAsync`,
  `ReadStreamAsync` and `GetStreamMetadataAsync` each gained an `IEventDatabase` overload, honoring
  jasperfx#810. On a database-per-tenant store there was previously no way to say "list database X"
  at all.
- The **tenant-scoped `GetRecentStreamsAsync` and `GetStreamMetadataAsync`** previously fell through
  to JasperFx's default interface member, which *throws* for a non-null tenant. Those are calls that
  now work and did not.

There is a behaviour change alongside them, and it is a correction rather than a feature: a
store-global `ReadStreamAsync` / `GetStreamMetadataAsync` on a multi-database store now **refuses**
where it used to answer from the default file. Anyone relying on the old behaviour was relying on a
silently wrong answer, and the refusal names both ways forward.

## What is in it

- **#240** — the explorer reads' database dimension, the stale `DatabaseCardinality` and
  `HasMultipleTenants` claims, both usage descriptors' hardcoded `Single`, and the tenant-scoped
  overloads that were missing. See #244.
- **Weasel 9.31.2 → 9.32.0.** `Weasel.Sqlite`'s public API is byte-identical; `Weasel.Storage` adds two
  default-implemented members, so it is additive.
- JasperFx stays on **2.68.0**, which is the latest — jasperfx#817 shipped there, so #240 was the
  store-side half of a contract already on disk.

## Status line

Two open issues become four, and the line now says which two are work rather than leaving a reader to
sort them. Both new ones came out of #240 and are recorded rather than discovered later:

- **#243** — `GetProjectionStatusesAsync`, left out of #240 deliberately. The gap is shard *state*,
  which `fi_event_progression` does not know, and the available shortcut (Polecat's, polecat#200)
  reports every shard as `"Stopped"` — which is the fisher#120 failure rather than a fix for it.
- **#245** — a question with evidence, not a confirmed bug, and it wants a failing test before any
  code. Weasel 9.32.0's `MappedVersionFor` / `MappedRevisionFor` seam comes from marten#5372, and
  Fisher has the same mapping surface.

> [!NOTE]
> ROADMAP's **Done** table has had no new rows since well before this release — #230, #238 and #241 are
> all absent too. Not fixed here, because retro-filling six releases for one entry would be worse than
> the omission and is not release-prep work. Worth its own pass if the table is still meant to be a
> live index rather than a historical one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)