### PR TITLE
gh-243: answer GetProjectionStatusesAsync, with a State that can be honest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3982,6 +3982,78 @@ is the multi-database arm and `explorer_reads_under_conjoined_tenancy` the colum
 16 of their 19 tests fail against the previous behaviour, and the three that pass are the regression
 guards for what a single-database store already did.
 
+⚠️ **`explorer_reads_across_databases` needs its two streams' timestamps to actually differ, and
+arranging that is not optional.** `fi_streams.timestamp` is millisecond-precision, two back-to-back
+appends land inside one millisecond on a warm machine, and the merge's `OrderByDescending(LastUpdatedAt)`
+has no defined tiebreak — so `the_count_bounds_the_merged_listing_and_the_newest_wins` becomes a coin
+flip exactly when the suite is fastest. It was caught behaving like one: green alone, red once in the
+full class. `WaitForTheClockToMoveAsync` polls **the column's own clock** (`SqliteTimestamp.NowExpression`
+over a connection) until it leaves the millisecond, which is `modified_since_and_before`'s lesson again
+— a client-sampled bound compares two clocks that are only incidentally the same one, and a fixed sleep
+is a wall-clock assumption a loaded host can still lose. Verified by removing it: **three of six runs
+fail.**
+
+#### Projection statuses — fisher#243
+
+`IEventStore.GetProjectionStatusesAsync`, in all three scopes, in `DocumentStore.ProjectionStatus.cs`.
+The snapshot a monitoring console's projections page renders before it subscribes to
+`ShardStatesChanged` for live updates. Fisher answered none of the three until now, and the interface's
+default throws — the honest shape, and what fisher#240 deliberately left in place.
+
+**Why #240 left it, and what changed: four of `ShardStatus`'s five fields come off the database
+cheaply, and the fifth is not a database fact at all.** `State` describes the *running daemon*, which
+`fi_event_progression` does not know. Polecat fills it by reporting every shard as `"Stopped"`
+(polecat#200) — which is not a partial answer but a wrong one, because it is exactly what a real
+stopped shard reports and it is the reading an operator acts on. Filling the slot that way is the
+fisher#120 failure rather than a fix for it, so the read stayed unimplemented until there was somewhere
+honest to get the state from.
+
+- **`Unknown` is a distinct value from `Stopped`, and that distinction is the feature.** The state
+  comes from the daemon this process hosts, reached through `DocumentStore.RunningDaemons` — fisher#173's
+  seam. A store under `DaemonMode.ExternallyManaged`, a console in another process and a hand-built
+  store all genuinely cannot see the daemon, and saying so beats a confident guess.
+  `a_store_with_no_visible_daemon_reports_unknown_rather_than_stopped` is the load-bearing test;
+  replacing `Unknown` with `"Stopped"` fails three.
+- **The tracker is reached through `AllDaemonsAsync()`, never `DaemonForDatabase`.** The latter is
+  contractually allowed to go looking, and Fisher's implementation *starts daemons* for tenants that
+  have appeared since the last poll, then throws when it finds none. Neither belongs in a diagnostics
+  read: asking what is running must not change what is running, and "nothing is running here" is an
+  answer rather than an error. Matched on `FisherDatabase.Identifier`, the same key
+  `FisherDaemonHostedService.TryFindDaemon` uses.
+- **`ShardAction` is collapsed onto `ShardStatus.State`'s own vocabulary.** The enum records what last
+  *happened*; the field is what the shard *is*, so the four actions a live shard publishes — started,
+  updated, restarted, skipped-ahead — become one `Running`. A visible daemon with no state for a shard
+  is `Stopped` rather than `Unknown`, because every agent publishes `Started` as it launches.
+- ⚠️ **`EventStoreSequence` is `max(seq_id)`, not the persisted high-water row.** The two are the same
+  number on a store whose daemon is current — the mark simply *is* `max(seq_id)` here — and they differ
+  exactly when it matters: the row is where the daemon **got to**, so a stopped daemon leaves it behind
+  and reporting it would make every shard look caught up. `the_head_is_the_stores_own_rather_than_the_daemons_record_of_it`
+  arranges that state deliberately, because on a healthy store the two agree and the test would pass
+  either way. Swapping the read fails two tests.
+- **An inline or live projection is reported with an empty `Shards` list rather than omitted**, its
+  `Lifecycle` saying why. Polecat synthesises a fake single shard for these and puts the *lifecycle
+  string* in its `State` slot, which makes that field mean two different things depending on the row.
+- **Subscriptions are included**, since `AllShards()` spans them and a subscription is a daemon shard
+  with progress to report. A shard whose name matches no registered projection is a subscription's, and
+  `Async` is a fact about those rather than a guess — there is deliberately no inline equivalent
+  (fisher#21).
+- **The store-global read refuses on a multi-database store, and for a sharper reason than the stream
+  lookups above.** Those return one answer over an id unique within a database; this one *could*
+  concatenate, and `Advanced.AllProjectionProgress` does exactly that and documents why. What stops it
+  is that `ShardStatus` has no database or tenant field, so N databases' rows arrive as N entries per
+  shard with the same `ShardName` and different sequences — unattributable. `ShardState` carries a
+  `TenantId`, which is what lets the other method get away with it.
+- **A tenant scopes to a database rather than to a predicate**, and here that is what Fisher's shard
+  identity *means*: names are `(projection, shard key)` and never `(projection, tenant)`, because
+  progression lives in each tenant's file (fisher#57). So under conjoined tenancy a tenant-scoped
+  request is the store-global answer — correctly, rather than by accident.
+- **A failed head read is swallowed to zero**, the same judgement `TryCreateUsage` makes about the same
+  read: the likeliest reason it fails is that the schema does not exist yet, which is precisely when a
+  console is most likely to be pointed at the store.
+
+**There is no shared suite for any of this**, so `projection_statuses` is Fisher's own until one
+exists. Every decision above was verified by mutation rather than by inspection.
+
 #### What `TryCreateUsage` puts on the wire — fisher#120
 
 `projections list` rendered "No projections in this store." for a store with twenty registered, and

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2064 tests green on net9.0 and net10.0** — 2009 in
+**2072 tests green on net9.0 and net10.0** — 2017 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 535 of
 them are shared cross-store compliance tests — 466 event sourcing and 69 document. On JasperFx **2.68.0** / Weasel **9.32.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 50 suites and 535 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,009.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,017.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -205,10 +205,48 @@ tenant *is* the file, so naming a tenant resolves the database and adds no `wher
 an unknown tenant throws rather than falling back to the default file.
 :::
 
-Two reads on that interface Fisher does not answer at any scope, and the database overload changes
-nothing for either: the dictionary-shaped `QueryByTagsAsync` — [`EventQuery.TagValues`](/events/dcb)
-is the composable, paged home for that capability here — and `GetProjectionStatusesAsync`
-([fisher#243](https://github.com/JasperFx/fisher/issues/243)). Both refuse by name.
+One read on that interface Fisher does not answer at any scope, and the database overload changes
+nothing for it: the dictionary-shaped `QueryByTagsAsync`. [`EventQuery.TagValues`](/events/dcb) is the
+composable, paged home for that capability here, so there is no second code path to keep in step.
+
+### Projection statuses, and what `State` can honestly say
+
+`GetProjectionStatusesAsync` carries the same three scopes, and answers the snapshot a monitoring
+console's projections page renders before it subscribes to `ShardStatesChanged` for live updates.
+
+```cs
+foreach (var projection in await eventStore.GetProjectionStatusesAsync(ct))
+{
+    foreach (var shard in projection.Shards)
+    {
+        Console.WriteLine($"{shard.ShardName}: {shard.State} " +
+                          $"{shard.ProcessedSequence}/{shard.EventStoreSequence}");
+    }
+}
+```
+
+Four of `ShardStatus`'s five fields come off the database. The fifth — `State` — is a fact about the
+**running daemon**, which `fi_event_progression` does not know, and that shapes the whole feature:
+
+- **A shard's state is `Unknown` when no daemon in this process can be asked**, never `Stopped`. A
+  store under `DaemonMode.ExternallyManaged`, a console in another process, and a hand-built store all
+  genuinely cannot see the daemon. `Stopped` there is not a partial answer but a wrong one — it is
+  exactly what a real stopped shard reports, and it is the reading an operator acts on.
+- **With a daemon this process hosts**, the state is its tracker's: `Running`, `Paused`, `Stopped` or
+  `Failed`, with the latched exception's message in `Error`.
+- **`EventStoreSequence` is `max(seq_id)`, not the persisted high-water row.** The two agree on a store
+  whose daemon is current, and differ exactly when it matters — the row is where the daemon *got to*,
+  so reading it would make every shard on a stopped daemon look caught up.
+- **An inline or live projection is reported with an empty `Shards` list rather than omitted**, and its
+  `Lifecycle` is what says why the list is empty.
+
+::: warning
+The store-global overload **refuses** on a database-per-tenant store, where the two single-stream reads
+above also refuse — but for a sharper reason. Progression rows are per database, and `ShardStatus`
+carries no database or tenant field, so N databases' rows would come back as N entries per shard with
+the *same* `ShardName` and different sequences, which a consumer cannot attribute. Name a tenant or a
+database.
+:::
 
 ::: tip
 A [secondary store's](/configuration/multiple-stores) marker proxy is *not* an `IEventStore` —

--- a/src/Fisher.Tests/Events/explorer_reads_across_databases.cs
+++ b/src/Fisher.Tests/Events/explorer_reads_across_databases.cs
@@ -52,11 +52,47 @@ public class explorer_reads_across_databases : IAsyncLifetime
             await session.SaveChangesAsync(Token);
         }
 
+        await WaitForTheClockToMoveAsync();
+
         await using (var session = _store.LightweightSession("south"))
         {
             session.Events.StartStream<Quest>(_south, new QuestStarted("Chart the Solent"),
                 new MemberJoined("Darwin"));
             await session.SaveChangesAsync(Token);
+        }
+    }
+
+    /// <summary>
+    ///     Block until SQLite's own clock has left the millisecond north's row was stamped in.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Without this, <c>the_count_bounds_the_merged_listing_and_the_newest_wins</c> is a real
+    ///         intermittent</b>, and it was caught behaving like one: green on its own, red once in the
+    ///         full class. <c>fi_streams.timestamp</c> is millisecond-precision, two back-to-back
+    ///         appends land inside one millisecond on a warm machine, and
+    ///         <c>OrderByDescending(LastUpdatedAt)</c> has no defined tiebreak — so "the newest wins"
+    ///         becomes a coin flip exactly when the test is fastest.
+    ///     </para>
+    ///     <para>
+    ///         <b>Polled against the column's own clock rather than slept for</b>, which is the
+    ///         discipline <c>modified_since_and_before</c> established: a client-sampled bound compares
+    ///         two clocks that are only incidentally the same one, and a fixed delay is a wall-clock
+    ///         assumption that a loaded host can still lose. This asks the database what time it thinks
+    ///         it is, which is the value that will be written, and returns the moment it has changed.
+    ///     </para>
+    /// </remarks>
+    private async Task WaitForTheClockToMoveAsync()
+    {
+        await using var connection = await _store.Tenancy.DatabaseFor("north").OpenConnectionAsync(Token);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"select {SqliteTimestamp.NowExpression};";
+
+        var start = (string)(await command.ExecuteScalarAsync(Token))!;
+
+        while ((string)(await command.ExecuteScalarAsync(Token))! == start)
+        {
+            await Task.Yield();
         }
     }
 
@@ -262,6 +298,51 @@ public class explorer_reads_across_databases : IAsyncLifetime
     {
         await Should.ThrowAsync<UnknownTenantException>(
             () => TheExplorer.GetRecentStreamsAsync(10, "east", Token));
+    }
+
+    // ---- projection statuses (fisher#243) ----
+
+    /// <summary>
+    ///     A store-global status snapshot is refused once the store spans more than one file.
+    /// </summary>
+    /// <remarks>
+    ///     <b>The refusal here is sharper than the stream lookups', not merely consistent with them.</b>
+    ///     Those return one answer over an id that is unique within a database; this one could in
+    ///     principle concatenate — <c>Advanced.AllProjectionProgress</c> does exactly that and documents
+    ///     why. What stops it is that <c>ShardStatus</c> has no database or tenant field, so N
+    ///     databases' rows come back as N entries per shard with the <em>same</em> ShardName and
+    ///     different sequences, which a consumer cannot attribute. <c>ShardState</c> carries a TenantId,
+    ///     which is what lets the other method get away with it.
+    /// </remarks>
+    [Fact]
+    public async Task store_global_projection_statuses_are_refused_on_a_multi_database_store()
+    {
+        var ex = await Should.ThrowAsync<NotSupportedException>(
+            () => TheExplorer.GetProjectionStatusesAsync(Token));
+
+        ex.Message.ShouldContain("StaticMultiple");
+        ex.Message.ShouldContain("tenantId");
+        ex.Message.ShouldContain("database");
+    }
+
+    /// <remarks>
+    ///     And both scoped forms answer, which is what makes the refusal a signpost rather than a dead
+    ///     end. Each tenant's file has its own <c>fi_event_progression</c>, so these are not filters
+    ///     over a store-global answer — they are the answer, once per database.
+    /// </remarks>
+    [Fact]
+    public async Task the_scoped_status_reads_answer_per_database()
+    {
+        var byTenant = await TheExplorer.GetProjectionStatusesAsync("north", Token);
+        var byDatabase = await TheExplorer.GetProjectionStatusesAsync(await DatabaseFor("north"), null, Token);
+
+        byTenant.Select(x => x.ProjectionName).ShouldBe(byDatabase.Select(x => x.ProjectionName));
+
+        // No daemon is hosted here, so the state is Unknown rather than a guess at Stopped.
+        foreach (var shard in byTenant.SelectMany(x => x.Shards))
+        {
+            shard.State.ShouldBe("Unknown");
+        }
     }
 
     // ---- what a monitoring tool is told about the shape of the store ----

--- a/src/Fisher.Tests/Events/projection_statuses.cs
+++ b/src/Fisher.Tests/Events/projection_statuses.cs
@@ -1,0 +1,285 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>
+///     fisher#243 — <c>IEventStore.GetProjectionStatusesAsync</c>, the snapshot a monitoring console's
+///     projections page renders.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>There is no shared suite for this, so every fact here is Fisher's own.</b> What the tests
+///         are shaped around is the one field that is not a database read:
+///         <c>ShardStatus.State</c> is a fact about the running daemon, and the failure this feature
+///         invites is filling it with a plausible constant. Polecat reports every shard as
+///         <c>"Stopped"</c> (polecat#200) — which is not a partial answer but a wrong one, because it
+///         is exactly what a real stopped shard reports and it is the reading an operator acts on.
+///     </para>
+///     <para>
+///         So the discriminating tests are the ones that tell <c>Unknown</c>, <c>Stopped</c> and
+///         <c>Running</c> apart, and the one that stops the daemon and appends more events to prove
+///         <c>EventStoreSequence</c> is the store's head rather than the daemon's record of it.
+///     </para>
+/// </remarks>
+public class projection_statuses : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("projection-statuses");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Projections.Snapshot<StatusTally>(SnapshotLifecycle.Async);
+            options.Projections.Snapshot<InlineTally>(SnapshotLifecycle.Inline);
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private IEventStore TheExplorer => _store;
+
+    // ---- the field that is not a database read ----
+
+    /// <summary>
+    ///     With no daemon this process can ask, a shard's state is <c>Unknown</c> — never <c>Stopped</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <b>The load-bearing test of this feature.</b> A store under <c>DaemonMode.ExternallyManaged</c>,
+    ///     a console in another process and a hand-built store like this one all genuinely cannot see
+    ///     the daemon, and "I cannot tell" is a different operational situation from "it is not
+    ///     running". Reporting <c>Stopped</c> here is indistinguishable from a real stopped shard, which
+    ///     is the answer an operator would act on — so the plausible constant is worse than no field at
+    ///     all.
+    /// </remarks>
+    [Fact]
+    public async Task a_store_with_no_visible_daemon_reports_unknown_rather_than_stopped()
+    {
+        var statuses = await TheExplorer.GetProjectionStatusesAsync(Token);
+
+        var tally = statuses.Single(x => x.ProjectionName == nameof(StatusTally));
+        var shard = tally.Shards.ShouldHaveSingleItem();
+
+        shard.State.ShouldBe("Unknown");
+        shard.State.ShouldNotBe("Stopped");
+    }
+
+    /// <remarks>
+    ///     The progression row is read even with no daemon here to ask, because it is the database's
+    ///     answer rather than the daemon's — so a console pointed at a store whose daemon runs
+    ///     elsewhere still sees how far each shard has got.
+    /// </remarks>
+    [Fact]
+    public async Task progress_is_reported_without_a_daemon_to_ask()
+    {
+        await AppendAsync(Guid.NewGuid(), 2);
+
+        // Plant a progression row the way a daemon in another process would have left it.
+        await WriteProgressAsync(ShardIdentityFor(nameof(StatusTally)), 1);
+
+        var statuses = await TheExplorer.GetProjectionStatusesAsync(Token);
+        var shard = statuses.Single(x => x.ProjectionName == nameof(StatusTally)).Shards.ShouldHaveSingleItem();
+
+        shard.ProcessedSequence.ShouldBe(1);
+        shard.EventStoreSequence.ShouldBe(2);
+        shard.State.ShouldBe("Unknown");
+        shard.Error.ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     <c>EventStoreSequence</c> is <c>max(seq_id)</c>, not the persisted high-water row.
+    /// </summary>
+    /// <remarks>
+    ///     The two are the same number on a Fisher store whose daemon is current, which is why this
+    ///     needs arranging deliberately: events are appended with nothing running, so the high-water row
+    ///     is behind the table. Reading the row instead would report the head as 0 here and make every
+    ///     shard look caught up — the opposite of what a projections page is opened to find out.
+    /// </remarks>
+    [Fact]
+    public async Task the_head_is_the_stores_own_rather_than_the_daemons_record_of_it()
+    {
+        await AppendAsync(Guid.NewGuid(), 3);
+
+        var statuses = await TheExplorer.GetProjectionStatusesAsync(Token);
+        var shard = statuses.Single(x => x.ProjectionName == nameof(StatusTally)).Shards.ShouldHaveSingleItem();
+
+        // Nothing has run, so the high-water progression row does not exist and reads as zero.
+        (await _store.Database.ProjectionProgressFor(new ShardName(ShardState.HighWaterMark), Token))
+            .ShouldBe(0);
+
+        shard.EventStoreSequence.ShouldBe(3);
+    }
+
+    // ---- what appears, and what it says about itself ----
+
+    /// <remarks>
+    ///     An inline projection has no shards, and is reported with an <em>empty</em> list rather than
+    ///     omitted — the <c>Lifecycle</c> is what says why it is empty. Polecat synthesises a fake
+    ///     single shard for these and puts the lifecycle string in its <c>State</c> slot, which makes
+    ///     that field mean two different things depending on the row.
+    /// </remarks>
+    [Fact]
+    public async Task an_inline_projection_is_reported_with_no_shards()
+    {
+        var statuses = await TheExplorer.GetProjectionStatusesAsync(Token);
+
+        var inline = statuses.Single(x => x.ProjectionName == nameof(InlineTally));
+
+        inline.Lifecycle.ShouldBe(nameof(ProjectionLifecycle.Inline));
+        inline.Shards.ShouldBeEmpty();
+
+        statuses.Single(x => x.ProjectionName == nameof(StatusTally))
+            .Lifecycle.ShouldBe(nameof(ProjectionLifecycle.Async));
+    }
+
+    /// <remarks>
+    ///     A subscription is a daemon shard with progress to report, so a projections page that omitted
+    ///     it would show a store with three subscriptions as a store with none.
+    /// </remarks>
+    [Fact]
+    public async Task a_subscription_is_reported_alongside_the_projections()
+    {
+        await using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.DatabaseSchemaName = "subs";
+            options.Projections.Subscribe(new QuietSubscription());
+        });
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        var statuses = await ((IEventStore)store).GetProjectionStatusesAsync(Token);
+        var subscription = statuses.Single(x => x.ProjectionName == nameof(QuietSubscription));
+
+        subscription.Lifecycle.ShouldBe(nameof(ProjectionLifecycle.Async));
+        subscription.Shards.ShouldHaveSingleItem().State.ShouldBe("Unknown");
+    }
+
+    // ---- with a daemon this process hosts ----
+
+    /// <summary>
+    ///     A running daemon's shard reports <c>Running</c>, and the state comes from its tracker.
+    /// </summary>
+    /// <remarks>
+    ///     Needs a real host, because <c>DocumentStore.RunningDaemons</c> is set by the hosted service —
+    ///     which is also the point: that seam is the only thing in the process that knows a daemon
+    ///     exists. Asserting against <c>Unknown</c> as well as for <c>Running</c> is what makes this
+    ///     fail rather than pass vacuously if the tracker lookup is dropped.
+    /// </remarks>
+    [Fact]
+    public async Task a_running_daemon_reports_its_shard_as_running()
+    {
+        using var database = TemporaryDatabase.Create("statuses-hosted");
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddFisher(o =>
+            {
+                o.ConnectionString = database.ConnectionString;
+                o.AutoCreateSchemaObjects = AutoCreate.All;
+                o.Projections.Snapshot<StatusTally>(SnapshotLifecycle.Async);
+            })
+            .ApplyAllDatabaseChangesOnStartup()
+            .AddAsyncDaemon();
+
+        await using var provider = services.BuildServiceProvider();
+        var hosted = provider.GetServices<IHostedService>().ToArray();
+
+        foreach (var service in hosted)
+        {
+            await service.StartAsync(Token);
+        }
+
+        try
+        {
+            var store = provider.GetRequiredService<DocumentStore>();
+
+            await using (var session = store.LightweightSession())
+            {
+                session.Events.StartStream<StatusTally>(Guid.NewGuid(), new Counted(), new Counted());
+                await session.SaveChangesAsync(Token);
+            }
+
+            await store.Database.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(30));
+
+            var statuses = await ((IEventStore)store).GetProjectionStatusesAsync(Token);
+            var shard = statuses.Single(x => x.ProjectionName == nameof(StatusTally))
+                .Shards.ShouldHaveSingleItem();
+
+            shard.State.ShouldBe("Running");
+            shard.ProcessedSequence.ShouldBe(2);
+            shard.EventStoreSequence.ShouldBe(2);
+            shard.Error.ShouldBeNull();
+        }
+        finally
+        {
+            foreach (var service in hosted)
+            {
+                await service.StopAsync(Token);
+            }
+        }
+    }
+
+    private string ShardIdentityFor(string projectionName)
+        => _store.Options.Projections.AllShards()
+            .Single(x => x.Name.Name == projectionName).Name.Identity;
+
+    private async Task WriteProgressAsync(string shardIdentity, long sequence)
+    {
+        await using var connection = await _store.Database.OpenConnectionAsync(Token);
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "insert into fi_event_progression (name, last_seq_id) values (@name, @seq) "
+            + "on conflict (name) do update set last_seq_id = excluded.last_seq_id";
+        command.Parameters.AddWithValue("@name", shardIdentity);
+        command.Parameters.AddWithValue("@seq", sequence);
+        await command.ExecuteNonQueryAsync(Token);
+    }
+
+    private async Task AppendAsync(Guid streamId, int count)
+    {
+        await using var session = _store.LightweightSession();
+        session.Events.StartStream<StatusTally>(streamId,
+            Enumerable.Range(0, count).Select(object (_) => new Counted()).ToArray());
+        await session.SaveChangesAsync(Token);
+    }
+}
+
+public record Counted;
+
+public class StatusTally
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+    public void Apply(Counted _) => Count++;
+}
+
+public class InlineTally
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+    public void Apply(Counted _) => Count++;
+}
+
+public class QuietSubscription : Fisher.Subscriptions.SubscriptionBase
+{
+    public override Task<IDaemonChangeListener> ProcessEventsAsync(EventRange page,
+        ISubscriptionController controller, IDocumentSession operations, CancellationToken cancellationToken)
+        => Task.FromResult<IDaemonChangeListener>(NullDaemonChangeListener.Instance);
+}

--- a/src/Fisher/DocumentStore.EventStore.cs
+++ b/src/Fisher/DocumentStore.EventStore.cs
@@ -477,7 +477,7 @@ public partial class DocumentStore : IEventStore
         return database.TenantId is null ? rows[0] : rows[0] with { TenantId = database.TenantId };
     }
 
-    // ---- the two reads Fisher answers at no scope ----
+    // ---- the one read Fisher answers at no scope ----
 
     /// <summary>
     ///     Refused at every scope, so the database argument changes nothing — and says so.
@@ -497,22 +497,6 @@ public partial class DocumentStore : IEventStore
         ArgumentNullException.ThrowIfNull(database);
 
         return ((IEventStore)this).QueryByTagsAsync(tags, tenantId, ct);
-    }
-
-    /// <inheritdoc cref="IEventStore.QueryByTagsAsync(IEventDatabase, IReadOnlyDictionary{string, string}, string, CancellationToken)" />
-    /// <remarks>
-    ///     Same reasoning as <c>QueryByTagsAsync</c> above, for a read Fisher has not grown yet rather
-    ///     than one it declines: a per-shard status snapshot wants the running daemon's shard states,
-    ///     not just <c>fi_event_progression</c>'s sequences, and reporting every shard as "Stopped" to
-    ///     fill the slot would be the failure fisher#120 records rather than a fix for it. Tracked as
-    ///     fisher#243; until then the honest answer is the one the interface's own default gives.
-    /// </remarks>
-    Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(IEventDatabase database,
-        string? tenantId, CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(database);
-
-        return ((IEventStore)this).GetProjectionStatusesAsync(tenantId, ct);
     }
 
     private static string WhereTenant(string? tenantPredicate)

--- a/src/Fisher/DocumentStore.ProjectionStatus.cs
+++ b/src/Fisher/DocumentStore.ProjectionStatus.cs
@@ -1,0 +1,314 @@
+using Fisher.Storage;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+
+namespace Fisher;
+
+/// <summary>
+///     <see cref="IEventStore.GetProjectionStatusesAsync(CancellationToken)" /> and its two scoped
+///     siblings — the snapshot a monitoring console's projections page renders before it subscribes to
+///     <c>ShardStatesChanged</c> for live updates (fisher#243).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Fisher answered none of the three until now, and that was the honest shape rather than a
+///         silent one</b> — the interface's default throws <see cref="NotImplementedException" /> with
+///         a message saying so. What made it worth closing is that Marten and Polecat answer it, so a
+///         store-agnostic console rendered a projections page for them and an error for Fisher.
+///     </para>
+///     <para>
+///         <b>fisher#240 deliberately left it out, and the reason is the one interesting decision in
+///         this file.</b> Four of <see cref="ShardStatus" />'s five fields come off the database
+///         cheaply; the fifth — <see cref="ShardStatus.State" /> — is a fact about the <em>running
+///         daemon</em>, which <c>fi_event_progression</c> does not know. Polecat fills it by reporting
+///         every shard as <c>"Stopped"</c> (polecat#200), which is not a partial answer but a wrong
+///         one: it is indistinguishable from a daemon that really has stopped, and it is the reading an
+///         operator acts on. Filling the slot that way is the failure fisher#120 records rather than a
+///         fix for it.
+///     </para>
+///     <para>
+///         So the state comes from the daemon this process hosts, through
+///         <see cref="RunningDaemons" />, and is <see cref="Unknown" /> when there is no daemon here to
+///         ask. <b>"Unknown" and "Stopped" are different operational situations</b> and the vocabulary
+///         keeps them apart: a store under <c>DaemonMode.ExternallyManaged</c>, a console in another
+///         process, or a hand-built store all genuinely cannot see the daemon, and saying so is worth
+///         more than a confident guess.
+///     </para>
+/// </remarks>
+public partial class DocumentStore
+{
+    /// <summary>
+    ///     No daemon in this process could be asked about this shard, so its runtime state is not
+    ///     something this store can report.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately not <c>"Stopped"</c>. The two are told apart everywhere else in this file, and
+    ///     the distinction is the whole reason the state is not read off the progression table.
+    /// </remarks>
+    internal const string Unknown = "Unknown";
+
+    Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(CancellationToken ct)
+        => ProjectionStatusesAsync(null, ct);
+
+    Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(string? tenantId,
+        CancellationToken ct)
+        => ProjectionStatusesAsync(tenantId, ct);
+
+    /// <summary>
+    ///     One database's projection statuses — the overload jasperfx#810 added, and the one with real
+    ///     content on a store that spans more than one file.
+    /// </summary>
+    /// <remarks>
+    ///     Progression rows live in each database's own <c>fi_event_progression</c>, so this is not a
+    ///     filter over a store-global answer — it <em>is</em> the answer, once per database.
+    /// </remarks>
+    Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(IEventDatabase database,
+        string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+
+        return ProjectionStatusesForAsync(DatabaseFrom(database), ct);
+    }
+
+    /// <summary>
+    ///     Resolve the scope a caller named, and refuse a store-global answer the store cannot give.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>A tenant scopes to a database rather than to a predicate, and here that is not a
+    ///         dialect quirk — it is what Fisher's shard identity means.</b> Shard names are
+    ///         <c>(projection, shard key)</c> and never <c>(projection, tenant)</c>, because
+    ///         <c>fi_event_progression</c> lives in each tenant's own file and the file boundary already
+    ///         draws the distinction (fisher#57). So under conjoined tenancy, where there is one file,
+    ///         every tenant shares one set of progression rows and a tenant-scoped request is the
+    ///         store-global answer — correctly, rather than by accident.
+    ///     </para>
+    ///     <para>
+    ///         <b>The store-global read refuses on a multi-database store</b>, as fisher#240's
+    ///         single-stream lookups do, and for a sharper reason than theirs.
+    ///         <see cref="ShardStatus" /> has no database or tenant field, so concatenating N
+    ///         databases' rows yields N entries per shard with identical <see cref="ShardStatus.ShardName" />
+    ///         and different sequences, which a consumer cannot attribute. That is worse than
+    ///         <c>Advanced.AllProjectionProgress</c>, which concatenates deliberately and gets away with
+    ///         it because <see cref="ShardState" /> carries a <c>TenantId</c>.
+    ///     </para>
+    /// </remarks>
+    private async Task<IReadOnlyList<ProjectionStatus>> ProjectionStatusesAsync(string? tenantId,
+        CancellationToken ct)
+    {
+        if (tenantId is not null)
+        {
+            return await ProjectionStatusesForAsync(Tenancy.DatabaseFor(tenantId), ct).ConfigureAwait(false);
+        }
+
+        await RefreshTenantsAsync(ct).ConfigureAwait(false);
+
+        var databases = Tenancy.AllDatabases();
+
+        if (databases.Count == 1)
+        {
+            return await ProjectionStatusesForAsync(databases[0], ct).ConfigureAwait(false);
+        }
+
+        throw new NotSupportedException(
+            $"Store-global GetProjectionStatusesAsync cannot answer on this Fisher store, whose "
+            + $"DatabaseCardinality is {Tenancy.Cardinality} — it spans {databases.Count} database files, each "
+            + "with its own fi_event_progression, and ShardStatus carries no database or tenant field to "
+            + "attribute a merged answer with. Name the scope: GetProjectionStatusesAsync(tenantId, ...) "
+            + "for one tenant's file, or GetProjectionStatusesAsync(database, ...) for a database from "
+            + "AllDatabases(). See fisher#243, jasperfx#810.");
+    }
+
+    private async Task<IReadOnlyList<ProjectionStatus>> ProjectionStatusesForAsync(FisherDatabase database,
+        CancellationToken ct)
+    {
+        var progress = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var state in await database.AllProjectionProgress(ct).ConfigureAwait(false))
+        {
+            // The high-water row is not a shard's progress. It is reported as EventStoreSequence
+            // below, and from max(seq_id) rather than from this row — see HeadSequenceAsync.
+            if (!string.Equals(state.ShardName, ShardState.HighWaterMark, StringComparison.OrdinalIgnoreCase))
+            {
+                progress[state.ShardName] = state.Sequence;
+            }
+        }
+
+        var head = await HeadSequenceAsync(database, ct).ConfigureAwait(false);
+        var tracker = await TrackerForAsync(database).ConfigureAwait(false);
+
+        var statuses = new List<ProjectionStatus>();
+        var named = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // AllShards() spans asynchronous projections AND subscriptions, which is what a projections
+        // page wants: a subscription is a daemon shard with progress to report, and omitting it would
+        // make a store with three subscriptions look like a store with none.
+        foreach (var group in Options.Projections.AllShards()
+                     .GroupBy(x => x.Name.Name, StringComparer.OrdinalIgnoreCase)
+                     .OrderBy(x => x.Key, StringComparer.Ordinal))
+        {
+            named.Add(group.Key);
+
+            var shards = group
+                .OrderBy(x => x.Name.Identity, StringComparer.Ordinal)
+                .Select(shard => new ShardStatus(
+                    shard.Name.Identity,
+                    StateFor(tracker, shard.Name, daemonVisible: tracker is not null),
+                    progress.GetValueOrDefault(shard.Name.Identity),
+                    head,
+                    ErrorFor(tracker, shard.Name)))
+                .ToList();
+
+            statuses.Add(new ProjectionStatus(group.Key, LifecycleFor(group.Key), shards));
+        }
+
+        // Inline and Live projections have no shards, and are reported with an empty list rather than
+        // omitted. The Lifecycle on the status is what says why it is empty, so a console can render
+        // "Inline — no shards" instead of inferring that the projection does not exist. Polecat
+        // synthesises a fake single shard for these and puts the LIFECYCLE in its State slot, which
+        // makes the field mean two different things depending on the row.
+        foreach (var source in Options.Projections.All
+                     .Where(x => !named.Contains(x.Name))
+                     .OrderBy(x => x.Name, StringComparer.Ordinal))
+        {
+            statuses.Add(new ProjectionStatus(source.Name, source.Lifecycle.ToString(), []));
+        }
+
+        return statuses;
+    }
+
+    private string LifecycleFor(string projectionName)
+        => Options.Projections.TryFindProjection(projectionName, out var source)
+            ? source.Lifecycle.ToString()
+
+            // A shard whose name matches no registered projection is a subscription's. Subscriptions
+            // exist only as daemon shards — there is deliberately no inline equivalent (fisher#21) —
+            // so Async is a fact about them rather than a guess.
+            : ProjectionLifecycle.Async.ToString();
+
+    /// <summary>
+    ///     The head of the event store, from <c>max(seq_id)</c> rather than from the persisted
+    ///     high-water row.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The two are the same number on a Fisher store whose daemon is current — one writer per
+    ///         file plus <c>BEGIN IMMEDIATE</c> makes the mark simply <c>max(seq_id)</c>, which is why
+    ///         <c>FisherHighWaterDetector</c> has no safe-zone reasoning in it. They differ exactly when
+    ///         it matters: <b>the row is where the daemon got to, and a daemon that is not running
+    ///         leaves it behind.</b> Reporting it as <see cref="ShardStatus.EventStoreSequence" /> would
+    ///         make every shard on a stopped daemon look caught up, which is the opposite of what a
+    ///         projections page is opened to find out.
+    ///     </para>
+    ///     <para>
+    ///         A failure is swallowed to zero rather than propagated, the same judgement
+    ///         <c>TryCreateUsage</c> makes about the same read: the likeliest reason it fails is that
+    ///         the schema does not exist yet, which is precisely when a console is most likely to be
+    ///         pointed at the store, and failing the whole page over one number answers nothing at all.
+    ///     </para>
+    /// </remarks>
+    private static async Task<long> HeadSequenceAsync(FisherDatabase database, CancellationToken ct)
+    {
+        try
+        {
+            return await database.FetchHighestEventSequenceNumber(ct).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            return 0;
+        }
+    }
+
+    /// <summary>
+    ///     The shard-state tracker of the daemon this process is running against
+    ///     <paramref name="database" />, or <see langword="null" /> when there is none to ask.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Read through <see cref="IProjectionCoordinator.AllDaemonsAsync" /> rather than
+    ///         <c>DaemonForDatabase</c>, and that is deliberate.</b> The latter is contractually allowed
+    ///         to go looking — Fisher's implementation starts daemons for tenants that have appeared
+    ///         since the last poll — and it throws when it finds none. Neither belongs in a diagnostics
+    ///         read: asking a console what is running must not <em>change</em> what is running, and
+    ///         "nothing is running here" is an answer rather than an error.
+    ///     </para>
+    ///     <para>
+    ///         Matched on <see cref="FisherDatabase.Identifier" />, the same key
+    ///         <c>FisherDaemonHostedService.TryFindDaemon</c> uses, so the two cannot disagree about
+    ///         which daemon belongs to which file.
+    ///     </para>
+    /// </remarks>
+    private async Task<ShardStateTracker?> TrackerForAsync(FisherDatabase database)
+    {
+        if (RunningDaemons is null)
+        {
+            return null;
+        }
+
+        foreach (var daemon in await RunningDaemons.AllDaemonsAsync().ConfigureAwait(false))
+        {
+            if (daemon is Events.Daemon.FisherProjectionDaemon fisher
+                && string.Equals(fisher.Database.Identifier, database.Identifier,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return daemon.Tracker;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     A shard's runtime state, in <see cref="ShardStatus" />'s own vocabulary.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="ShardAction" /> is a record of what last <em>happened</em> to a shard, where
+    ///         this field is what the shard <em>is</em> — so the mapping collapses the four actions a
+    ///         live shard publishes (started, updated, restarted, and skipped-ahead) onto one
+    ///         <c>Running</c>. The vocabulary is the one <see cref="ShardStatus.State" />'s own
+    ///         documentation names.
+    ///     </para>
+    ///     <para>
+    ///         <b>A visible daemon with no state for the shard is <c>Stopped</c>, not
+    ///         <see cref="Unknown" />.</b> Every agent publishes <c>Started</c> as it launches, so a
+    ///         registered shard the tracker has never heard of is one this daemon is not running — which
+    ///         is what an operator means by stopped. <see cref="Unknown" /> is reserved for the case
+    ///         where there is no daemon to have an opinion.
+    ///     </para>
+    /// </remarks>
+    private static string StateFor(ShardStateTracker? tracker, ShardName name, bool daemonVisible)
+    {
+        if (!daemonVisible)
+        {
+            return Unknown;
+        }
+
+        var state = tracker?.CurrentState(name);
+
+        if (state is null)
+        {
+            return "Stopped";
+        }
+
+        return state.Action switch
+        {
+            ShardAction.Started or ShardAction.Updated or ShardAction.Restarted or ShardAction.Skipped
+                => "Running",
+            ShardAction.Paused => "Paused",
+            ShardAction.Stopped => "Stopped",
+            ShardAction.Faulted => "Failed",
+            _ => state.Action.ToString()
+        };
+    }
+
+    /// <remarks>
+    ///     The latched exception's message, and null for a shard that is not failed. A dead letter is a
+    ///     different thing and is read through <c>QueryDeadLetterEventsAsync</c> — this is the error
+    ///     that stopped the shard, not one it skipped past.
+    /// </remarks>
+    private static string? ErrorFor(ShardStateTracker? tracker, ShardName name)
+        => tracker?.CurrentState(name)?.Exception?.Message;
+}


### PR DESCRIPTION
Closes #243.

Fisher answered **none** of `IEventStore`'s three `GetProjectionStatusesAsync` overloads, so a
store-agnostic console rendered a projections page for Marten and Polecat and an error for Fisher.

## Why #240 left this out, and what changed

Four of `ShardStatus`'s five fields come off the database cheaply. The fifth — `State` — is a fact
about the **running daemon**, which `fi_event_progression` does not know.

Polecat fills it by reporting every shard as `"Stopped"` (polecat#200). That is **not a partial answer
but a wrong one**: it is exactly what a real stopped shard reports, and it is the reading an operator
acts on. Filling the slot that way is the #120 failure rather than a fix for it — which is why #240
declined it rather than taking the cheap version.

So the state comes from the daemon this process hosts, via `DocumentStore.RunningDaemons` (#173's
seam), and is **`Unknown`** when there is none to ask. `ExternallyManaged`, a console in another
process, and a hand-built store all genuinely cannot see the daemon — and "I cannot tell" is a
different operational situation from "it is not running".

| Source | Field |
| :--- | :--- |
| `Options.Projections.AllShards()` | shard names, grouped per projection — spans subscriptions too |
| `FisherDatabase.AllProjectionProgress` | `ProcessedSequence` |
| `FisherDatabase.FetchHighestEventSequenceNumber` | `EventStoreSequence` |
| the hosted daemon's `ShardStateTracker` | `State`, `Error` |

## Decisions

- ⚠️ **The tracker is reached through `AllDaemonsAsync()`, never `DaemonForDatabase`.** The latter is
  contractually allowed to go looking, and Fisher's implementation *starts daemons* for tenants that
  have appeared since the last poll, then throws when it finds none. Neither belongs in a diagnostics
  read: **asking what is running must not change what is running**, and "nothing is running here" is
  an answer rather than an error.
- ⚠️ **`EventStoreSequence` is `max(seq_id)`, not the persisted high-water row.** The two are the same
  number on a store whose daemon is current — the mark simply *is* `max(seq_id)` here — and they differ
  exactly when it matters: the row is where the daemon **got to**, so a stopped daemon leaves it behind
  and reading it would make every shard look caught up.
- **`ShardAction` is collapsed onto `ShardStatus.State`'s own vocabulary** (`Running` / `Paused` /
  `Stopped` / `Failed`). The enum records what last *happened*; the field is what the shard *is*. A
  visible daemon with no state for a shard is `Stopped`, since every agent publishes `Started` as it
  launches — `Unknown` is reserved for having no daemon to ask.
- **Inline and live projections are reported with an empty `Shards` list rather than omitted**, their
  `Lifecycle` saying why. Polecat synthesises a fake single shard for these and puts the *lifecycle
  string* in its `State` slot, which makes that field mean two things depending on the row.
- **The store-global read refuses on a multi-database store**, where #240's single-stream lookups also
  refuse — but for a sharper reason. This one *could* concatenate, and `Advanced.AllProjectionProgress`
  does exactly that and documents why. What stops it is that `ShardStatus` has no database or tenant
  field, so N databases' rows arrive as N entries per shard with the same `ShardName` and different
  sequences. `ShardState` carries a `TenantId`, which is what lets the other method get away with it.
- **A tenant scopes to a database rather than to a predicate**, which here is what Fisher's shard
  identity *means*: names are `(projection, shard key)` and never `(projection, tenant)`, because
  progression lives in each tenant's file (#57). Under conjoined tenancy a tenant-scoped request is
  therefore the store-global answer — correctly, rather than by accident.

The `QueryByTagsAsync` forwarding override from #240 stays; its twin for this member is deleted, as
#243 asked.

## Coverage

**There is no shared suite for any of this**, so `projection_statuses` (6) plus two multi-database
facts in `explorer_reads_across_databases` are Fisher's own. Every decision was verified by mutation
rather than inspection:

| Mutation | Tests that fail |
| :--- | :--- |
| `Unknown` → `"Stopped"` (Polecat's answer) | 3 |
| head read from the high-water row | 2 |
| tracker never resolved | the hosted-daemon fact |

## A real intermittent this surfaced, and fixed

⚠️ While running the new tests, **#240's own `the_count_bounds_the_merged_listing_and_the_newest_wins`
failed** — then passed five times in isolation. That is the "green on retry" signal CLAUDE.md names as
the worst possible one, so I chased it rather than re-running.

`fi_streams.timestamp` is millisecond-precision, the fixture's two appends land inside one millisecond
on a warm machine, and the merge's `OrderByDescending(LastUpdatedAt)` has no defined tiebreak — so the
assertion is a coin flip exactly when the suite is fastest. The fixture now polls **the column's own
clock** until it leaves the millisecond, which is `modified_since_and_before`'s lesson again: a
client-sampled bound compares two clocks that are only incidentally the same one, and a fixed sleep is
a wall-clock assumption a loaded host can still lose.

Verified both ways: **three of six full-class runs fail without it**, six of six pass with it.

## Verification

2072 tests green on both net9.0 and net10.0 — 2017 / 36 / 19. Scoreboard agrees with both runs;
`check_no_leaked_databases.py` clean; `npm run docs-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)