### PR TITLE
gh-245: seed the optimistic version guard from the document, as Marten does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2344,6 +2344,58 @@ upgrade that changes one fails there and names the column instead of presenting 
 quietly stopped being populated. All four hold as of Microsoft.Data.Sqlite 10.0.9, including a Guid in
 either casing.
 
+#### The version guard reads the document, not only the session — fisher#245
+
+⚠️ **Fisher's Guid optimistic concurrency used to work only inside one session, and that is what this
+mapping is now also for.** The guard is fed from `IStorageSession.Versions` — what *this session read*
+— so a document loaded in one session and stored through another had no entry and **failed its guard
+every time**. Correct about staleness and useless for the workflow the feature exists for: load in one
+request, save in the next. `UseOptimisticConcurrency()` was promising something it could not deliver.
+
+`FisherSession.SeedExpectedVersion` is **Marten's `storeEntity`**, deliberately: same dispatch, same
+two call sites — `Store` and `Update`, never `Insert`, which writes a new row and has no stored version
+to be checked against.
+
+- **One seam covers both ways of declaring a version, and that falls out of this section rather than
+  being arranged.** `DocumentMetadata` already maps `IVersioned.Version` onto the version column by
+  convention, exactly as Marten's `VersionedPolicy` does — so the interface route and
+  `Metadata(m => m.Version.MapTo(...))` arrive at storage identically, and
+  `FisherDocumentStorage.MappedVersionFor` (weasel#590's seam) reads one member for both. **The
+  asymmetry between them is what marten#5372 was**; here there was nothing to be asymmetric, because
+  Fisher consulted neither. Both were broken identically, which is why
+  `cross_session_optimistic_concurrency` asserts every fact for both routes — a fix seeding only one
+  would look right against whichever route a test happened to use.
+- ⚠️ **`MappedVersionFor` returns `Guid?`, not `object?`.** Declaring it `object?` compiles, does not
+  implement the interface member, and leaves the throwing-free default returning null — so the whole
+  feature silently does nothing and every test still fails in the way it did before the change. That is
+  how the first cut of this went, and the only signal was the tests staying red.
+- **The `Guid.Empty` condition is carried for parity and is not observable.** Measured, not assumed:
+  removing it changes no outcome in either direction, because an expectation of `Guid.Empty` matches no
+  stored version — a blank version inserts over a missing row and raises `ConcurrencyException` over an
+  existing one either way. It stays because Marten's dispatch has it, and **no test pins it**,
+  deliberately, rather than a test being written that would pass with it gone.
+- **A successful write moves the instance's own version on**, which is what makes seeding safe to do on
+  every store: without it, storing the same instance twice in one process would seed the second write
+  with the version the first superseded. Pinned, because the first draft of the mapped-member test got
+  this wrong and read as a product bug.
+- **The numeric half needed nothing**, and the reason is worth keeping: `CaptureExpectedRevision`
+  already reads the document (fisher#228), which is why revisions crossed sessions while Guid versions
+  did not. There is no mapped-revision route to miss either — `DocumentMetadataExpression<T>` exposes
+  `Version` and **no `Revision`**, so `IRevisioned` is the only way to declare one, and weasel#590's
+  `MappedRevisionFor` has nothing here to adopt it for.
+
+⚠️ **No shared suite reaches any of this, for any store.** The only document-concurrency suite is
+`NumericRevisionCompliance`, which is numeric-only and written against `IRevisioned` throughout; every
+other "optimistic" fact in the shared set is about the *event store* (`AppendOptimistic`,
+`FetchForWritingByTags`). **Fisher passed all fifty enrolled suites with this broken** — the
+jasperfx#700 / #718 / #732 pattern again, a capability all three stores are assumed to share with
+nothing shared holding any of them to it.
+
+**`UpdateExpectedVersion<T>(T, Guid)` is still absent**, where Marten has it as the Guid counterpart of
+`UpdateRevision`. Not needed for the above — seeding off the document covers the ordinary flow — and
+not added here; it is the separate case of guarding against a version the caller knows and the document
+does not carry.
+
 ### Strong-typed identities
 
 `Storage/StrongTypedId.cs` and `Storage/ClosedShape/StrongTypedIdentification.cs` (fisher#14) — a

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2072 tests green on net9.0 and net10.0** — 2017 in
+**2079 tests green on net9.0 and net10.0** — 2024 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 535 of
 them are shared cross-store compliance tests — 466 event sourcing and 69 document. On JasperFx **2.68.0** / Weasel **9.32.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 50 suites and 535 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,017.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,024.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/documents/metadata.md
+++ b/docs/documents/metadata.md
@@ -100,6 +100,45 @@ nothing. The converse does not hold — `UseOptimisticConcurrency()` alone maps 
 is no member named.
 :::
 
+### The version guard crosses session boundaries
+
+A mapped version member is not only read back — it is what a **guarded write in a later session**
+checks against. Load in one request, save in the next, and the version the document carries is the
+expectation the write is guarded on:
+
+```cs
+// Request 1
+Order order;
+await using (var session = store.LightweightSession())
+{
+    order = await session.LoadAsync<Order>(id);
+}
+
+// Request 2 — a different session, and the guard still applies
+order.Status = "shipped";
+await using (var session = store.LightweightSession())
+{
+    session.Store(order);
+    await session.SaveChangesAsync();   // ConcurrencyException if somebody else moved the row
+}
+```
+
+Both ways of declaring a version behave identically here, because `IVersioned.Version` is mapped onto
+the same column by convention — so a member declared through `Metadata(m => m.Version.MapTo(...))` is
+read exactly as the marker interface is.
+
+::: warning
+**Before Fisher 1.5.0 this threw** ([#245](https://github.com/JasperFx/fisher/issues/245)). The guard
+was fed only from what the *current* session had read, so a document loaded elsewhere had no recorded
+expectation and every cross-session write failed — safe about stale writes, and unusable for the
+workflow optimistic concurrency exists for. If you worked around it by reloading inside the writing
+session, that still works and is now unnecessary.
+:::
+
+A successful write moves the instance's own version member on, so the same instance can be stored
+again without tripping its own guard. `Insert` is deliberately not guarded — it writes a new row, so
+there is no stored version to check against.
+
 The interfaces are resolved through the interface map, not by name, so an explicitly implemented
 `ISoftDeleted.Deleted` is found — and a document is free to have a public `Deleted` of its own
 meaning something else.

--- a/src/Fisher.Tests/Documents/cross_session_optimistic_concurrency.cs
+++ b/src/Fisher.Tests/Documents/cross_session_optimistic_concurrency.cs
@@ -1,0 +1,351 @@
+using JasperFx;
+using JasperFx.Metadata;
+
+namespace Fisher.Tests.Documents;
+
+/// <summary>
+///     fisher#245 — a guarded write that crosses a session boundary, which is the workflow optimistic
+///     concurrency exists for.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Fisher's Guid guard used to work only inside one session.</b> It is fed from
+///         <c>IStorageSession.Versions</c> — what <em>this</em> session read — so a document loaded in
+///         one session and stored through another had no entry and failed its guard every time. Safe
+///         about staleness, useless for load-in-one-request, save-in-the-next.
+///     </para>
+///     <para>
+///         <b>Worse than the bug it was found next to.</b> marten#5372 was a mapped version member being
+///         invisible while the <see cref="IVersioned" /> marker interface worked; Fisher consulted
+///         neither, so both routes failed identically. That is why every fact here is asserted for both
+///         — a fix that seeded only one would look right against whichever route the test happened to
+///         use.
+///     </para>
+///     <para>
+///         <b>And no shared suite reaches it, for any store.</b> The only document-concurrency suite is
+///         <c>NumericRevisionCompliance</c>, which is numeric-only and written against
+///         <see cref="IRevisioned" />; every other "optimistic" fact in the shared set is about the
+///         event store. Fisher passed all fifty enrolled suites with this broken.
+///     </para>
+/// </remarks>
+public class cross_session_optimistic_concurrency : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("cross-session-concurrency");
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _database.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+
+            // The second of the two routes: no marker interface, an ordinary member mapped onto the
+            // version column. DocumentMetadata maps IVersioned.Version onto the same column by
+            // convention, so the two arrive at the storage identically.
+            options.Schema.For<MappedLedger>().UseOptimisticConcurrency(true)
+                .Metadata(m => m.Version.MapTo(x => x.Revision));
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _database.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    // ---- the marker-interface route ----
+
+    /// <summary>
+    ///     Load in one session, store through another. This threw <c>ConcurrencyException</c> before.
+    /// </summary>
+    [Fact]
+    public async Task a_versioned_document_can_be_stored_through_a_later_session()
+    {
+        var id = await CreateVersionedAsync("opening");
+
+        VersionedLedger loaded;
+        await using (var session = _store.LightweightSession())
+        {
+            loaded = (await session.LoadAsync<VersionedLedger>(id, Token))!;
+        }
+
+        loaded.Version.ShouldNotBe(Guid.Empty);
+        loaded.Entry = "amended";
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(loaded);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = _store.LightweightSession();
+        (await query.LoadAsync<VersionedLedger>(id, Token))!.Entry.ShouldBe("amended");
+    }
+
+    /// <summary>
+    ///     And a genuinely stale write is still refused, which is the half that was never broken.
+    /// </summary>
+    /// <remarks>
+    ///     Asserted alongside the one above rather than trusted, because the cheap wrong fix — seeding
+    ///     nothing, or seeding whatever the row currently holds — makes the first test pass and this one
+    ///     fail. The pair is what says the guard is real rather than absent.
+    /// </remarks>
+    [Fact]
+    public async Task a_stale_versioned_write_is_still_refused()
+    {
+        var id = await CreateVersionedAsync("opening");
+
+        VersionedLedger stale;
+        await using (var session = _store.LightweightSession())
+        {
+            stale = (await session.LoadAsync<VersionedLedger>(id, Token))!;
+        }
+
+        // Somebody else moves the row on.
+        await using (var session = _store.LightweightSession())
+        {
+            var current = (await session.LoadAsync<VersionedLedger>(id, Token))!;
+            current.Entry = "theirs";
+            session.Store(current);
+            await session.SaveChangesAsync(Token);
+        }
+
+        stale.Entry = "mine";
+
+        await using (var loser = _store.LightweightSession())
+        {
+            loser.Store(stale);
+            await Should.ThrowAsync<ConcurrencyException>(() => loser.SaveChangesAsync(Token));
+        }
+
+        await using var query = _store.LightweightSession();
+        (await query.LoadAsync<VersionedLedger>(id, Token))!.Entry.ShouldBe("theirs");
+    }
+
+    // ---- the mapped-member route ----
+
+    /// <remarks>
+    ///     The same two facts against a type that declares its version through the mapping DSL instead.
+    ///     This is the route marten#5372 was filed about; on Fisher both routes were broken, so both are
+    ///     pinned.
+    /// </remarks>
+    [Fact]
+    public async Task a_mapped_version_member_behaves_exactly_as_the_interface_does()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new MappedLedger { Id = id, Entry = "opening" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        MappedLedger loaded;
+        await using (var session = _store.LightweightSession())
+        {
+            loaded = (await session.LoadAsync<MappedLedger>(id, Token))!;
+        }
+
+        loaded.Revision.ShouldNotBe(Guid.Empty);
+        loaded.Entry = "amended";
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(loaded);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using (var query = _store.LightweightSession())
+        {
+            (await query.LoadAsync<MappedLedger>(id, Token))!.Entry.ShouldBe("amended");
+        }
+
+        // ...and a stale instance is refused. Loaded fresh rather than reusing the one above, because a
+        // successful write moves that instance's version on — see
+        // a_successful_write_moves_the_instances_own_version_on, which is what makes storing the same
+        // instance twice in a row work at all.
+        MappedLedger stale;
+        await using (var reader = _store.LightweightSession())
+        {
+            stale = (await reader.LoadAsync<MappedLedger>(id, Token))!;
+        }
+
+        await using (var other = _store.LightweightSession())
+        {
+            var current = (await other.LoadAsync<MappedLedger>(id, Token))!;
+            current.Entry = "theirs";
+            other.Store(current);
+            await other.SaveChangesAsync(Token);
+        }
+
+        stale.Entry = "mine";
+
+        await using (var loser = _store.LightweightSession())
+        {
+            loser.Store(stale);
+            await Should.ThrowAsync<ConcurrencyException>(() => loser.SaveChangesAsync(Token));
+        }
+    }
+
+    /// <summary>
+    ///     A successful guarded write moves the stored instance's own version member on.
+    /// </summary>
+    /// <remarks>
+    ///     <b>Not a detail — it is what makes seeding safe to do on every store.</b> Without it, storing
+    ///     the same instance twice in one process would seed the second write with the version the first
+    ///     one superseded, and a perfectly ordinary "save, edit, save again" would fail its guard. It is
+    ///     also the behaviour that made the first version of the mapped-member test above wrong, which is
+    ///     why it is now pinned rather than relied on silently.
+    /// </remarks>
+    [Fact]
+    public async Task a_successful_write_moves_the_instances_own_version_on()
+    {
+        var id = await CreateVersionedAsync("opening");
+
+        VersionedLedger loaded;
+        await using (var reader = _store.LightweightSession())
+        {
+            loaded = (await reader.LoadAsync<VersionedLedger>(id, Token))!;
+        }
+
+        var asLoaded = loaded.Version;
+
+        await using (var session = _store.LightweightSession())
+        {
+            loaded.Entry = "second";
+            session.Store(loaded);
+            await session.SaveChangesAsync(Token);
+        }
+
+        loaded.Version.ShouldNotBe(asLoaded);
+
+        // So the same instance can be stored again without tripping its own guard.
+        await using (var session = _store.LightweightSession())
+        {
+            loaded.Entry = "third";
+            session.Store(loaded);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = _store.LightweightSession();
+        (await query.LoadAsync<VersionedLedger>(id, Token))!.Entry.ShouldBe("third");
+    }
+
+    // ---- the conditions the seeding turns on ----
+
+    /// <summary>
+    ///     Creating a versioned document still works — the seeding does not turn every insert into a
+    ///     guarded write.
+    /// </summary>
+    /// <remarks>
+    ///     <b>This does not pin the <c>!= Guid.Empty</c> condition, and saying so is the point.</b> The
+    ///     obvious reading is that the condition is what keeps creates working, and it is not: removing
+    ///     it changes no outcome, because an expectation of <see cref="Guid.Empty" /> matches no stored
+    ///     version, so a blank version inserts over a missing row and raises
+    ///     <c>ConcurrencyException</c> over an existing one either way. Measured both ways rather than
+    ///     reasoned about. What this test does pin is the behaviour a reader actually cares about —
+    ///     that a create on a versioned type is not collateral damage from the fix.
+    /// </remarks>
+    [Fact]
+    public async Task a_document_that_has_never_been_stored_is_not_guarded()
+    {
+        var fresh = new VersionedLedger { Id = Guid.NewGuid(), Entry = "first" };
+        fresh.Version.ShouldBe(Guid.Empty);
+
+        await using var session = _store.LightweightSession();
+        session.Store(fresh);
+        await session.SaveChangesAsync(Token);
+
+        await using var query = _store.LightweightSession();
+        (await query.LoadAsync<VersionedLedger>(fresh.Id, Token)).ShouldNotBeNull();
+    }
+
+    /// <remarks>
+    ///     <c>Update</c> seeds too, and <c>Insert</c> deliberately does not — an insert writes a new row,
+    ///     so there is no stored version for a guard to compare against. Marten draws the line in the
+    ///     same place.
+    /// </remarks>
+    [Fact]
+    public async Task update_crosses_a_session_boundary_as_well_as_store()
+    {
+        var id = await CreateVersionedAsync("opening");
+
+        VersionedLedger loaded;
+        await using (var session = _store.LightweightSession())
+        {
+            loaded = (await session.LoadAsync<VersionedLedger>(id, Token))!;
+        }
+
+        loaded.Entry = "amended";
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Update(loaded);
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = _store.LightweightSession();
+        (await query.LoadAsync<VersionedLedger>(id, Token))!.Entry.ShouldBe("amended");
+    }
+
+    /// <remarks>
+    ///     A type with no version member at all is untouched by any of this — nothing to read, nothing
+    ///     to seed, and no guard in its SQL.
+    /// </remarks>
+    [Fact]
+    public async Task a_type_with_no_version_member_is_unaffected()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new PlainLedger { Id = id, Entry = "opening" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new PlainLedger { Id = id, Entry = "overwritten" });
+            await session.SaveChangesAsync(Token);
+        }
+
+        await using var query = _store.LightweightSession();
+        (await query.LoadAsync<PlainLedger>(id, Token))!.Entry.ShouldBe("overwritten");
+    }
+
+    private async Task<Guid> CreateVersionedAsync(string entry)
+    {
+        var id = Guid.NewGuid();
+
+        await using var session = _store.LightweightSession();
+        session.Store(new VersionedLedger { Id = id, Entry = entry });
+        await session.SaveChangesAsync(Token);
+
+        return id;
+    }
+}
+
+public class VersionedLedger : IVersioned
+{
+    public Guid Id { get; set; }
+    public string Entry { get; set; } = string.Empty;
+    public Guid Version { get; set; }
+}
+
+public class MappedLedger
+{
+    public Guid Id { get; set; }
+    public string Entry { get; set; } = string.Empty;
+    public Guid Revision { get; set; }
+}
+
+public class PlainLedger
+{
+    public Guid Id { get; set; }
+    public string Entry { get; set; } = string.Empty;
+}

--- a/src/Fisher/Internal/FisherSession.Documents.cs
+++ b/src/Fisher/Internal/FisherSession.Documents.cs
@@ -112,7 +112,7 @@ internal partial class FisherSession
         }
 
         var storage = StorageFor<T>();
-        storage.Store(this, document);
+        SeedExpectedVersion(storage, document);
 
         var operation = storage.Upsert(document, this, TenantId);
 
@@ -150,6 +150,56 @@ internal partial class FisherSession
     ///         disagree with the statement being built.
     ///     </para>
     /// </remarks>
+    /// <summary>
+    ///     Seed the session's expected version for this write from the version the document itself
+    ///     carries, so a guarded write can cross a session boundary (fisher#245).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Without this, Fisher's Guid optimistic concurrency worked only inside one session.</b>
+    ///         The guard is fed from <see cref="IStorageSession.Versions" /> — what <em>this</em> session
+    ///         read — so a document loaded in one session and stored through another had no entry and
+    ///         failed its guard every time. It refused stale writes correctly and refused legitimate ones
+    ///         too, which is the whole workflow the feature exists for: load in one request, save in the
+    ///         next.
+    ///     </para>
+    ///     <para>
+    ///         <b>This is Marten's <c>storeEntity</c>, and deliberately so</b> — same dispatch, same
+    ///         guard on the default value, same two call sites (<c>Store</c> and <c>Update</c>, never
+    ///         <c>Insert</c>, which writes a new row and has no stored version to be checked against).
+    ///     </para>
+    ///     <para>
+    ///         <b>The <see cref="Guid.Empty" /> condition is carried for parity and is not observable —
+    ///         measured, not assumed.</b> It is what a document that has never been stored carries, and
+    ///         the obvious worry is that seeding it would guard a first insert against a version no row
+    ///         has. It does not: removing the condition changes no outcome in either direction. A blank
+    ///         version over a missing row inserts either way, and a blank version over an existing row
+    ///         raises <c>ConcurrencyException</c> either way, because an expectation of
+    ///         <c>Guid.Empty</c> matches no stored version. It stays because Marten's dispatch has it
+    ///         and because recording an expectation that means "none" is worth avoiding — but no test
+    ///         here pins it, deliberately, rather than a test being written that would pass with it
+    ///         gone.
+    ///     </para>
+    ///     <para>
+    ///         The numeric half needs nothing here: <see cref="CaptureExpectedRevision" /> already reads
+    ///         the document, which is why revisions crossed sessions while Guid versions did not. There
+    ///         is no mapped-revision route to miss either — <c>DocumentMetadataExpression&lt;T&gt;</c>
+    ///         exposes no <c>Revision</c>, so <see cref="JasperFx.IRevisioned" /> is the only way to
+    ///         declare one.
+    ///     </para>
+    /// </remarks>
+    private void SeedExpectedVersion<T>(Weasel.Storage.IDocumentStorage<T> storage, T document)
+        where T : notnull
+    {
+        if (storage.MappedVersionFor(document) is Guid version && version != Guid.Empty)
+        {
+            storage.Store(this, document, version);
+            return;
+        }
+
+        storage.Store(this, document);
+    }
+
     private static Weasel.Storage.IStorageOperation CaptureExpectedRevision(
         Weasel.Storage.IStorageOperation operation, object document, int? revision = null)
     {
@@ -217,7 +267,7 @@ internal partial class FisherSession
         ArgumentNullException.ThrowIfNull(document);
 
         var storage = StorageFor<T>();
-        storage.Store(this, document);
+        SeedExpectedVersion(storage, document);
 
         QueueOperation(CaptureExpectedRevision(storage.Update(document, this, TenantId), document));
     }

--- a/src/Fisher/Storage/ClosedShape/FisherDocumentStorage.cs
+++ b/src/Fisher/Storage/ClosedShape/FisherDocumentStorage.cs
@@ -42,6 +42,8 @@ internal abstract class FisherDocumentStorage<TDoc, TId> : IDocumentStorage<TDoc
     protected FisherDocumentStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
     {
         _mapping = mapping;
+
+        ResolveVersionGetter();
         _descriptor = descriptor;
 
         var readColumns = new List<string>();
@@ -268,6 +270,45 @@ internal abstract class FisherDocumentStorage<TDoc, TId> : IDocumentStorage<TDoc
 
     public Guid? VersionFor(TDoc document, IStorageSession session)
         => session.Versions.VersionFor<TDoc, TId>(Identity(document));
+
+    /// <summary>
+    ///     The Guid version the document itself carries, or <see langword="null" /> when the mapping has
+    ///     no version member to read (fisher#245, weasel#590).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>This is what lets a guarded write cross a session boundary.</b> Fisher's optimistic
+    ///         guard is fed from <c>IStorageSession.Versions</c> — what <em>this session read</em> — so
+    ///         a document loaded in one session and stored through another had no entry, and every such
+    ///         write failed its guard. Correct about staleness and useless for the workflow optimistic
+    ///         concurrency exists for. See <c>FisherSession.SeedExpectedVersion</c> for the other half.
+    ///     </para>
+    ///     <para>
+    ///         <b>One member covers both ways of declaring a version</b>, because
+    ///         <see cref="Metadata.DocumentMetadata" /> already maps <c>IVersioned.Version</c> onto this
+    ///         column by convention — the same thing Marten's <c>VersionedPolicy</c> does. So the
+    ///         interface route and <c>Metadata(m =&gt; m.Version.MapTo(...))</c> arrive here identically,
+    ///         which is the asymmetry marten#5372 was and the reason this is a mapping read rather than
+    ///         a type test on <c>IVersioned</c>.
+    ///     </para>
+    ///     <para>
+    ///         The getter is compiled once per storage instance and only when a member is mapped, so a
+    ///         type with no version member costs one null check per store.
+    ///     </para>
+    /// </remarks>
+    public Guid? MappedVersionFor(TDoc document) => _versionGetter?.Invoke(document);
+
+    private Func<TDoc, Guid>? _versionGetter;
+
+    private void ResolveVersionGetter()
+    {
+        var member = _mapping.Metadata.Version.Member;
+
+        if (member is not null)
+        {
+            _versionGetter = JasperFx.Core.Reflection.LambdaBuilder.Getter<TDoc, Guid>(member);
+        }
+    }
 
     public abstract void Store(IStorageSession session, TDoc document);
     public abstract void Store(IStorageSession session, TDoc document, Guid? version);


### PR DESCRIPTION
Closes #245.

**Fisher's Guid optimistic concurrency worked only inside one session.** The guard is fed from
`IStorageSession.Versions` — what *this session read* — so a document loaded in one session and stored
through another had no recorded expectation and **failed its guard every time**. Correct about
staleness, and useless for the workflow the feature exists for: load in one request, save in the next.
`UseOptimisticConcurrency()` was promising something it could not deliver.

## Probed before fixing

| Route | Cross-session `Store(doc)` carrying its version — before |
| :--- | :--- |
| `IVersioned` | `ConcurrencyException` |
| `Metadata(m => m.Version.MapTo(...))` | `ConcurrencyException` |
| `IRevisioned` (numeric) | works |

marten#5372 was the *mapped member* being invisible while the marker interface worked. **Fisher
consulted neither**, so this is that bug's shape with both halves broken — which is why every fact in
the new tests is asserted for both routes. A fix seeding only one would look right against whichever
route a test happened to use.

## The fix is Marten's `storeEntity`

Same dispatch, same guard on the default value, same two call sites — `Store` and `Update`, **never
`Insert`**, which writes a new row and has no stored version to check against.

**One seam covers both declaration routes, and that falls out of the existing metadata mapping rather
than being arranged.** `DocumentMetadata` already maps `IVersioned.Version` onto the version column by
convention — exactly what Marten's `VersionedPolicy` does — so `FisherDocumentStorage.MappedVersionFor`
(weasel#590's seam, which the 1.4.0 Weasel bump brought in) reads one member for both.

## Two things worth knowing

- ⚠️ **`MappedVersionFor` returns `Guid?`, not `object?`.** Declaring it `object?` compiles, does *not*
  implement the interface member, and leaves the default returning null — so the whole feature silently
  does nothing. That is how the first cut of this went, and the only signal was the tests staying red.
- ⚠️ **The `Guid.Empty` condition is carried for parity and is *not* observable.** I assumed it was
  load-bearing, wrote a comment saying so, then mutated it: removing it changes **no outcome in either
  direction**, because an expectation of `Guid.Empty` matches no stored version — a blank version
  inserts over a missing row and raises `ConcurrencyException` over an existing one either way. It
  stays because Marten's dispatch has it, and **no test pins it** — deliberately, rather than writing
  one that would pass with it gone. The comments now say that instead of the claim I started with.

## The numeric half needed nothing

`CaptureExpectedRevision` already reads the document (#228), which is why revisions crossed sessions
while Guid versions did not. There is **no mapped-revision route to miss** either:
`DocumentMetadataExpression<T>` exposes `Version` and no `Revision`, so `IRevisioned` is the only way
to declare one — and weasel#590's `MappedRevisionFor` has nothing here to adopt it for. That closes the
half of #245's original framing that turned out to be wrong.

## Coverage

`cross_session_optimistic_concurrency` (7). **Four fail against the previous behaviour**; the three
that pass are the regression guards — a stale write still refused, a create on a versioned type still
working, a type with no version member unaffected.

One of the seven exists because I got the test wrong first: **a successful write moves the instance's
own version on**, so reusing that instance for the "stale" assertion isn't stale at all. That read as a
product bug for a minute, so it is now pinned rather than relied on silently — it is also what makes
seeding safe to do on every store.

⚠️ **No shared suite reaches any of this, for any store.** The only document-concurrency suite is
`NumericRevisionCompliance`, which is numeric-only and written against `IRevisioned`; every other
"optimistic" fact in the shared set is about the **event store**. Fisher passed all fifty enrolled
suites with this broken — the jasperfx#700 / #718 / #732 pattern again. Worth filing upstream: the
suite that would have caught it is about four facts long and would pin the behaviour for Marten and
Polecat too.

## Not in scope

`UpdateExpectedVersion<T>(T, Guid)` is still absent, where Marten has it as the Guid counterpart of
`UpdateRevision`. Not needed here — seeding off the document covers the ordinary flow — and it is the
separate case of guarding against a version the caller knows and the document does not carry.

## Verification

2079 tests green on both net9.0 and net10.0 — 2024 / 36 / 19. Scoreboard agrees with both runs;
`check_no_leaked_databases.py` clean; `npm run docs-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)