### PR TITLE
gh-249: the projection inventory is projections, not shards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4638,7 +4638,7 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**Fisher enrolls 51 of the 55 suites `JasperFx.Events.ComplianceTests` 2.69.0 ships — 544 tests.**
+**Fisher enrolls 51 of the 56 suites `JasperFx.Events.ComplianceTests` 2.69.0 ships — 544 tests.**
 `JasperFx.Events.ComplianceTests` is referenced unconditionally — the old `$(EnableComplianceTests)`
 gate is gone. See HANDOFF.md for the live scoreboard, which is machine-checked against a real run by
 `scripts/check_scoreboard.py`; what follows is the history and the mechanics.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4072,10 +4072,15 @@ honest to get the state from.
   read: asking what is running must not change what is running, and "nothing is running here" is an
   answer rather than an error. Matched on `FisherDatabase.Identifier`, the same key
   `FisherDaemonHostedService.TryFindDaemon` uses.
-- **`ShardAction` is collapsed onto `ShardStatus.State`'s own vocabulary.** The enum records what last
-  *happened*; the field is what the shard *is*, so the four actions a live shard publishes — started,
-  updated, restarted, skipped-ahead — become one `Running`. A visible daemon with no state for a shard
-  is `Stopped` rather than `Unknown`, because every agent publishes `Started` as it launches.
+- **`ShardAction` is collapsed onto `ShardStatusState`, the closed four-value vocabulary.** The enum
+  records what last *happened*; the field is what the shard *is*, so the four actions a live shard
+  publishes — started, updated, restarted, skipped-ahead — become one `Running`. A visible daemon with
+  no state for a shard is `Stopped` rather than `Unknown`, because every agent publishes `Started` as
+  it launches. **Every arm now lands inside `ShardStatusState.All`** (fisher#249): a faulted shard used
+  to answer `"Failed"` and an unrecognised action `Action.ToString()`, both outside the vocabulary — a
+  console renders this string and *filters* on it, so a fifth value is a row that matches no filter
+  rather than a more precise answer. A faulted shard is one a daemon reached and is no longer running,
+  which is `Stopped`; what it faulted on is `Error`, which is why nothing is lost.
 - ⚠️ **`EventStoreSequence` is `max(seq_id)`, not the persisted high-water row.** The two are the same
   number on a store whose daemon is current — the mark simply *is* `max(seq_id)` here — and they differ
   exactly when it matters: the row is where the daemon **got to**, so a stopped daemon leaves it behind
@@ -4085,10 +4090,22 @@ honest to get the state from.
 - **An inline or live projection is reported with an empty `Shards` list rather than omitted**, its
   `Lifecycle` saying why. Polecat synthesises a fake single shard for these and puts the *lifecycle
   string* in its `State` slot, which makes that field mean two different things depending on the row.
-- **Subscriptions are included**, since `AllShards()` spans them and a subscription is a daemon shard
-  with progress to report. A shard whose name matches no registered projection is a subscription's, and
-  `Async` is a fact about those rather than a guess — there is deliberately no inline equivalent
-  (fisher#21).
+- ⚠️ **Subscriptions are NOT included, and fisher#249 reversed that.** This answers from
+  `Projections.All`, where it used to answer from `AllShards()` — which spans subscriptions too. The
+  original argument was real and is why jasperfx#818 needed a ruling rather than a test: a subscription
+  genuinely is a daemon shard with progress worth watching, and omitting it makes a store with three
+  subscriptions look like a store with none. It went the other way because this is the page an operator
+  opens to ask about **read models**, and a subscription has no document behind it — a row for one is
+  something a reader cannot click through to. **Nothing is lost**: subscription progress stays reachable
+  non-generically through `IEventStore.RegisteredShardNames()` correlated against
+  `IEventDatabase.FetchProjectionLagAsync`, the pairing jasperfx#815 built for exactly that question,
+  and `a_subscription_is_not_in_the_projection_inventory_and_is_still_reachable` asserts both halves —
+  because "dropped from a list" and "no longer answerable" are different outcomes and only the first
+  was ruled on.
+  - **The registry drives the inventory; the shards are attributed to it.** Joining from that side is
+    what drops a subscription from *both* halves of the answer at once — the top-level list and the
+    shards inside a status — and the shared suite is shaped to catch the partial fix that filters only
+    the outer list.
 - **The store-global read refuses on a multi-database store, and for a sharper reason than the stream
   lookups above.** Those return one answer over an id unique within a database; this one *could*
   concatenate, and `Advanced.AllProjectionProgress` does exactly that and documents why. What stops it
@@ -4103,8 +4120,24 @@ honest to get the state from.
   read: the likeliest reason it fails is that the schema does not exist yet, which is precisely when a
   console is most likely to be pointed at the store.
 
-**There is no shared suite for any of this**, so `projection_statuses` is Fisher's own until one
-exists. Every decision above was verified by mutation rather than by inspection.
+**There is a shared suite now — `ProjectionStatusCompliance` (jasperfx#818) — and it adopted Fisher's
+reading of the field this whole section turns on.** `Unknown` means "no daemon here to ask" and is a
+different operational situation from `Stopped`; Fisher was the only store reading it that way, and both
+siblings change (marten#5383, polecat#589). Fisher passed 8 of 9 on the bump, and the one it failed was
+the inventory ruling above.
+
+**`projection_statuses` stays, because the suite cannot see most of what it asserts.** Its fixture
+drives one hand-built store and one hosted one; the planted progression row, the deliberately stale
+high-water row, and the subscription's survival on the lag surface all need a store arranged into a
+state a portable fixture has no vocabulary for. Every decision above was verified by mutation rather
+than by inspection.
+
+One requirement of jasperfx#818 was **dropped** rather than adopted, and it is worth knowing which way:
+it proposed that an Inline projection report an **empty shard list** — Fisher's answer, and the only
+store that gives it. Marten reports `SignalBoard:All / Unknown / 0 / 0`, which is a coherent answer of
+a different kind, and Marten's stands. Fisher's empty list is still legal and the suite says nothing
+either way. What *is* pinned is that the `State` slot never carries a lifecycle, which is Polecat's
+answer and which Fisher already satisfied.
 
 #### What `TryCreateUsage` puts on the wire — fisher#120
 
@@ -4605,7 +4638,7 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**Fisher enrolls 50 of the 52 suites `JasperFx.Events.ComplianceTests` 2.68.0 ships — 535 tests.**
+**Fisher enrolls 51 of the 55 suites `JasperFx.Events.ComplianceTests` 2.69.0 ships — 544 tests.**
 `JasperFx.Events.ComplianceTests` is referenced unconditionally — the old `$(EnableComplianceTests)`
 gate is gone. See HANDOFF.md for the live scoreboard, which is machine-checked against a real run by
 `scripts/check_scoreboard.py`; what follows is the history and the mechanics.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.68.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.68.0" />
+        <PackageVersion Include="JasperFx" Version="2.69.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.69.0" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.68.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.68.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.0" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,9 +12,9 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2079 tests green on net9.0 and net10.0** — 2024 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 535 of
-them are shared cross-store compliance tests — 466 event sourcing and 69 document. On JasperFx **2.68.0** / Weasel **9.32.0**.
+**2088 tests green on net9.0 and net10.0** — 2033 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 544 of
+them are shared cross-store compliance tests — 475 event sourcing and 69 document. On JasperFx **2.69.0** / Weasel **9.32.0**.
 
 ## The high-water opt-out, audited (#199)
 
@@ -662,9 +662,9 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.68.0 ships 52 suites; Fisher enrolls **50 of them, 535 tests**.
-Fisher passes **535 of them, across all
-50 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
+`JasperFx.Events.ComplianceTests` 2.69.0 ships 55 suites; Fisher enrolls **51 of them, 544 tests**.
+Fisher passes **544 of them, across all
+51 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
 pass on the 2.65.0 pin were the upstream ones described at the top of this file, and 2.66.0 closed
 all five.
 
@@ -809,12 +809,12 @@ case is what is Fisher's alone — the `ResetAllDataAsync` daemon handling, `Fet
 and `UnknownNaturalKeyException` (which jasperfx#764 excludes on purpose), the subscription wrapper's
 naming.
 
-**Green on all fifty is not the same as feature-complete.** The suites cover what is portable
+**Green on all fifty-one is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 50 suites, 535 tests
+### Green — 51 suites, 544 tests
 
-Event sourcing — 43 suites, 466 tests:
+Event sourcing — 44 suites, 475 tests:
 
 | Suite | Tests |
 |---|---|
@@ -841,6 +841,7 @@ Event sourcing — 43 suites, 466 tests:
 | `FlatTableProjectionCompliance` | 10 |
 | `MultiStreamProjectionCompliance` | 10 |
 | `EventMetadataCompliance` | 9 |
+| `ProjectionStatusCompliance` | 9 |
 | `ProjectionSideEffectCompliance` | 9 |
 | `SelfAggregatingEvolveCompliance` | 8 |
 | `LiveAggregationCompliance` | 7 |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -662,7 +662,7 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.69.0 ships 55 suites; Fisher enrolls **51 of them, 544 tests**.
+`JasperFx.Events.ComplianceTests` 2.69.0 ships 56 suites; Fisher enrolls **51 of them, 544 tests**.
 Fisher passes **544 of them, across all
 51 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
 pass on the 2.65.0 pin were the upstream ones described at the top of this file, and 2.66.0 closed

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 50 suites and 535 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,024.
+> Fisher passes **all 51 suites and 544 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,033.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -467,7 +467,7 @@ Test counts keep understating the suites that matter. `AsyncDaemonCompliance` is
 the whole daemon; `FlatTableProjectionCompliance` is eight that demand an upsert generator, a
 migration hook and rebuild teardown.
 
-Being green on all fifty is not the same as being feature-complete against Marten. The suites
+Being green on all fifty-one is not the same as being feature-complete against Marten. The suites
 cover what is portable across stores; the deliberate gaps listed in HANDOFF.md are still gaps.
 
 ## Filed follow-ups

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -232,13 +232,25 @@ Four of `ShardStatus`'s five fields come off the database. The fifth — `State`
   store under `DaemonMode.ExternallyManaged`, a console in another process, and a hand-built store all
   genuinely cannot see the daemon. `Stopped` there is not a partial answer but a wrong one — it is
   exactly what a real stopped shard reports, and it is the reading an operator acts on.
-- **With a daemon this process hosts**, the state is its tracker's: `Running`, `Paused`, `Stopped` or
-  `Failed`, with the latched exception's message in `Error`.
+- **With a daemon this process hosts**, the state is its tracker's. The vocabulary is closed at four
+  values — `Running`, `Paused`, `Stopped`, `Unknown` — and a faulted shard reports `Stopped` with the
+  latched exception's message in `Error`. A console renders this string and filters on it, so a fifth
+  value would be a row that matches no filter rather than a more precise answer.
 - **`EventStoreSequence` is `max(seq_id)`, not the persisted high-water row.** The two agree on a store
   whose daemon is current, and differ exactly when it matters — the row is where the daemon *got to*,
   so reading it would make every shard on a stopped daemon look caught up.
 - **An inline or live projection is reported with an empty `Shards` list rather than omitted**, and its
   `Lifecycle` is what says why the list is empty.
+- **The inventory is the registered projections, so a subscription is not in it.** A subscription
+  genuinely is a daemon shard with progress worth watching, but this is the page you open to ask about
+  read models and a subscription has no document behind it. Its progress is reachable through
+  `IEventStore.RegisteredShardNames()` correlated against `IEventDatabase.FetchProjectionLagAsync` —
+  the pairing built for that question.
+
+::: tip
+This surface is held to a shared definition across Marten, Polecat and Fisher by
+`ProjectionStatusCompliance`, and the `Unknown`-means-no-daemon reading above is the one it adopted.
+:::
 
 ::: warning
 The store-global overload **refuses** on a database-per-tenant store, where the two single-stream reads

--- a/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
+++ b/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
@@ -640,6 +640,27 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
         public IDocumentSession OpenSession()
             => _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
 
+        /// <summary>
+        ///     The hosted store as <see cref="IEventStore" /> — jasperfx#818's seam member, and the one
+        ///     store in the suite set with a genuinely reachable running daemon.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         <b>The cast is what makes this worth a member at all.</b> Fisher implements
+        ///         <see cref="IEventStore" /> <em>explicitly</em> (fisher#45), so it is not on
+        ///         <see cref="IDocumentStore" /> and a consumer reaches it by casting — which is also why
+        ///         a generic suite cannot resolve it out of <see cref="Services" />: no store registers
+        ///         itself under the shared interface, each registers its own <c>IDocumentStore</c>.
+        ///     </para>
+        ///     <para>
+        ///         Resolved through the container rather than closed over the fixture's own store on
+        ///         purpose: the fixture's is built by hand and has no coordinator, which is exactly the
+        ///         case <c>ShardStatusState.Unknown</c> describes, so answering with it would make the
+        ///         daemon-visible half of the contract untestable.
+        ///     </para>
+        /// </remarks>
+        public IEventStore EventStore => (IEventStore)_host.Services.GetRequiredService<IDocumentStore>();
+
         /// <remarks>
         ///     <c>IHost.Dispose</c> alone does not call <c>StopAsync</c>, so an abandoned host would
         ///     leave its daemon polling the fixture's file into the next test — two writers on one file,

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -8,9 +8,12 @@ namespace Fisher.Tests.Compliance;
  * Fisher's session pair through FisherComplianceFixture. Marten and Polecat enroll the same way, so
  * these tests cannot drift between the products.
  *
- * Suites were added one at a time as Fisher grew into them, and fifty are enrolled from
- * JasperFx.Events.ComplianceTests 2.68.0, which itself ships fifty-two. One is not enrolled:
- * SingleTenantedEventSlicingCompliance, for the precondition reason set out below.
+ * Suites were added one at a time as Fisher grew into them, and fifty-one are enrolled from
+ * JasperFx.Events.ComplianceTests 2.69.0, which itself ships fifty-five. Three are not enrolled:
+ * SingleTenantedEventSlicingCompliance, for the precondition reason set out below;
+ * GuidOptimisticConcurrencyCompliance, which is fisher#250; and the two arms of
+ * MultiDatabaseExplorerCompliance, which need a fixture that can build a store over more than one
+ * database (SupportsMultipleDatabases) and is fisher#252.
  *
  * Three of the ten suites this wave adds are enrolled and gated off rather than green, each for a
  * reason recorded at the flag on FisherComplianceFixture rather than here:
@@ -258,6 +261,31 @@ public class projection_scenario_compliance
 
 public class projection_coordinator_compliance
     : ProjectionCoordinatorCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
+
+/*
+ * jasperfx#818 — what the five fields of a ShardStatus mean. Three stores implemented
+ * GetProjectionStatusesAsync with nothing shared holding any of them to it, so each decided
+ * independently and reasonably and arrived at three different answers.
+ *
+ * Fisher is the closest of the three to the contract and the reason is recorded in
+ * DocumentStore.ProjectionStatus.cs at length: it is the only store that already reported the real
+ * shard state from a reachable daemon, and Unknown-means-no-daemon is the ruling the suite adopted.
+ * Marten answered Unknown unconditionally and Polecat hardcoded Stopped; both change.
+ *
+ * The one fact Fisher failed is the inventory ruling, and it went against Fisher deliberately rather
+ * than by weight of implementations — see fisher#249. A subscription is a daemon shard with progress
+ * worth watching, and it is still not on this page, because this is where an operator asks about read
+ * models. Its progress moved to RegisteredShardNames() against FetchProjectionLagAsync (jasperfx#815),
+ * which is the pairing built for that question.
+ *
+ * ⚠️ The daemon-visible fact is the one that makes the rest non-vacuous: without it a store passes
+ * every other assertion by hardcoding Unknown, which is what Marten did. It runs against
+ * IComplianceCoordinatorHost.EventStore — a default-THROWING seam member, so nothing broke on the
+ * bump and what tells you it is unimplemented is this suite rather than the compiler.
+ */
+
+public class projection_status_compliance
+    : ProjectionStatusCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
 
 /*
  * jasperfx#770 — the two stream-fetch query plans, standalone and inside a batched query. Fisher

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -9,11 +9,12 @@ namespace Fisher.Tests.Compliance;
  * these tests cannot drift between the products.
  *
  * Suites were added one at a time as Fisher grew into them, and fifty-one are enrolled from
- * JasperFx.Events.ComplianceTests 2.69.0, which itself ships fifty-five. Three are not enrolled:
- * SingleTenantedEventSlicingCompliance, for the precondition reason set out below;
- * GuidOptimisticConcurrencyCompliance, which is fisher#250; and the two arms of
- * MultiDatabaseExplorerCompliance, which need a fixture that can build a store over more than one
- * database (SupportsMultipleDatabases) and is fisher#252.
+ * JasperFx.Events.ComplianceTests 2.69.0, which itself ships fifty-six concrete suites across
+ * fifty-five files -- MultiDatabaseExplorerCompliance is one file holding two arms. Five are not
+ * enrolled: SingleTenantedEventSlicingCompliance, for the precondition reason set out below;
+ * NumericRevisionCompliance and GuidOptimisticConcurrencyCompliance, which are fisher#250; and the
+ * two arms of MultiDatabaseExplorerCompliance, which need a fixture that can build a store over more
+ * than one database (SupportsMultipleDatabases) and are fisher#252.
  *
  * Three of the ten suites this wave adds are enrolled and gated off rather than green, each for a
  * reason recorded at the flag on FisherComplianceFixture rather than here:

--- a/src/Fisher.Tests/Events/projection_statuses.cs
+++ b/src/Fisher.Tests/Events/projection_statuses.cs
@@ -14,12 +14,21 @@ namespace Fisher.Tests.Events;
 /// </summary>
 /// <remarks>
 ///     <para>
-///         <b>There is no shared suite for this, so every fact here is Fisher's own.</b> What the tests
-///         are shaped around is the one field that is not a database read:
+///         <b>There is a shared suite now — <c>ProjectionStatusCompliance</c> (jasperfx#818) — and it
+///         adopted Fisher's reading of the field these tests are shaped around.</b>
 ///         <c>ShardStatus.State</c> is a fact about the running daemon, and the failure this feature
-///         invites is filling it with a plausible constant. Polecat reports every shard as
-///         <c>"Stopped"</c> (polecat#200) — which is not a partial answer but a wrong one, because it
-///         is exactly what a real stopped shard reports and it is the reading an operator acts on.
+///         invites is filling it with a plausible constant. Polecat reported every shard as
+///         <c>"Stopped"</c> (polecat#200) — not a partial answer but a wrong one, because it is exactly
+///         what a real stopped shard reports and it is the reading an operator acts on — and Marten
+///         answered <c>Unknown</c> unconditionally, never reading a daemon at all. Both change
+///         (polecat#589, marten#5383).
+///     </para>
+///     <para>
+///         <b>These stay because the suite cannot see most of what they assert.</b> Its fixture drives
+///         one hand-built store and one hosted one; the planted progression row, the deliberately
+///         stale high-water row, and the subscription's survival on the lag surface below all need a
+///         store arranged into a state a portable fixture has no vocabulary for. The one fact that
+///         moved rather than stayed is the inventory ruling — see below.
 ///     </para>
 ///     <para>
 ///         So the discriminating tests are the ones that tell <c>Unknown</c>, <c>Stopped</c> and
@@ -76,8 +85,8 @@ public class projection_statuses : IAsyncLifetime
         var tally = statuses.Single(x => x.ProjectionName == nameof(StatusTally));
         var shard = tally.Shards.ShouldHaveSingleItem();
 
-        shard.State.ShouldBe("Unknown");
-        shard.State.ShouldNotBe("Stopped");
+        shard.State.ShouldBe(ShardStatusState.Unknown);
+        shard.State.ShouldNotBe(ShardStatusState.Stopped);
     }
 
     /// <remarks>
@@ -98,7 +107,7 @@ public class projection_statuses : IAsyncLifetime
 
         shard.ProcessedSequence.ShouldBe(1);
         shard.EventStoreSequence.ShouldBe(2);
-        shard.State.ShouldBe("Unknown");
+        shard.State.ShouldBe(ShardStatusState.Unknown);
         shard.Error.ShouldBeNull();
     }
 
@@ -148,28 +157,63 @@ public class projection_statuses : IAsyncLifetime
             .Lifecycle.ShouldBe(nameof(ProjectionLifecycle.Async));
     }
 
+    /// <summary>
+    ///     A registered subscription is not a projection and is not in this inventory — and its
+    ///     progress is still reachable, one surface over.
+    /// </summary>
     /// <remarks>
-    ///     A subscription is a daemon shard with progress to report, so a projections page that omitted
-    ///     it would show a store with three subscriptions as a store with none.
+    ///     <para>
+    ///         <b>fisher#249 reversed this test</b>, which used to assert the opposite. The argument it
+    ///         was written on is unchanged and was never wrong: a subscription genuinely is a daemon
+    ///         shard with progress to report. What the shared ruling (jasperfx#818) decided is that this
+    ///         is not the page for it — a projections page is where an operator asks about <em>read
+    ///         models</em>, and a subscription has no document behind it, so a row for one is something
+    ///         a reader cannot click through to.
+    ///     </para>
+    ///     <para>
+    ///         <b>So this asserts the replacement as well as the omission</b>, because "dropped from a
+    ///         list" and "no longer answerable" are different outcomes and only the first was ruled on.
+    ///         <c>RegisteredShardNames()</c> against <c>FetchProjectionLagAsync</c> is the pairing
+    ///         jasperfx#815 built for exactly this question, and it reports the subscription's shard
+    ///         with the progress this page used to carry.
+    ///     </para>
+    ///     <para>
+    ///         Asserted on the shards as well as on the top-level names, because a store that filtered
+    ///         only the outer list would leave the subscription's shard inside somebody else's status —
+    ///         which is the partial fix the shared suite is shaped to catch.
+    ///     </para>
     /// </remarks>
     [Fact]
-    public async Task a_subscription_is_reported_alongside_the_projections()
+    public async Task a_subscription_is_not_in_the_projection_inventory_and_is_still_reachable()
     {
         await using var store = DocumentStore.For(options =>
         {
             options.ConnectionString = _database.ConnectionString;
             options.AutoCreateSchemaObjects = AutoCreate.All;
             options.DatabaseSchemaName = "subs";
+            options.Projections.Snapshot<StatusTally>(SnapshotLifecycle.Async);
             options.Projections.Subscribe(new QuietSubscription());
         });
 
         await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
 
-        var statuses = await ((IEventStore)store).GetProjectionStatusesAsync(Token);
-        var subscription = statuses.Single(x => x.ProjectionName == nameof(QuietSubscription));
+        var explorer = (IEventStore)store;
+        var statuses = await explorer.GetProjectionStatusesAsync(Token);
 
-        subscription.Lifecycle.ShouldBe(nameof(ProjectionLifecycle.Async));
-        subscription.Shards.ShouldHaveSingleItem().State.ShouldBe("Unknown");
+        statuses.Select(x => x.ProjectionName).ShouldNotContain(nameof(QuietSubscription));
+        statuses.SelectMany(x => x.Shards).Select(x => x.ShardName)
+            .ShouldNotContain(x => x.StartsWith(nameof(QuietSubscription), StringComparison.Ordinal));
+
+        // The registered projection beside it is still there, so this is the inventory rule rather
+        // than an empty answer.
+        statuses.Select(x => x.ProjectionName).ShouldContain(nameof(StatusTally));
+
+        // ...and the subscription's progress is reachable through the surface designed for it.
+        var registered = explorer.RegisteredShardNames();
+        registered.Select(x => x.Name).ShouldContain(nameof(QuietSubscription));
+
+        var lag = await ((IEventDatabase)store.Database).FetchProjectionLagAsync(registered, Token);
+        lag.Select(x => x.Shard.Name).ShouldContain(nameof(QuietSubscription));
     }
 
     // ---- with a daemon this process hosts ----
@@ -222,7 +266,7 @@ public class projection_statuses : IAsyncLifetime
             var shard = statuses.Single(x => x.ProjectionName == nameof(StatusTally))
                 .Shards.ShouldHaveSingleItem();
 
-            shard.State.ShouldBe("Running");
+            shard.State.ShouldBe(ShardStatusState.Running);
             shard.ProcessedSequence.ShouldBe(2);
             shard.EventStoreSequence.ShouldBe(2);
             shard.Error.ShouldBeNull();

--- a/src/Fisher/DocumentStore.ProjectionStatus.cs
+++ b/src/Fisher/DocumentStore.ProjectionStatus.cs
@@ -30,25 +30,33 @@ namespace Fisher;
 ///     </para>
 ///     <para>
 ///         So the state comes from the daemon this process hosts, through
-///         <see cref="RunningDaemons" />, and is <see cref="Unknown" /> when there is no daemon here to
-///         ask. <b>"Unknown" and "Stopped" are different operational situations</b> and the vocabulary
-///         keeps them apart: a store under <c>DaemonMode.ExternallyManaged</c>, a console in another
-///         process, or a hand-built store all genuinely cannot see the daemon, and saying so is worth
-///         more than a confident guess.
+///         <see cref="RunningDaemons" />, and is <see cref="ShardStatusState.Unknown" /> when there is
+///         no daemon here to ask. <b>"Unknown" and "Stopped" are different operational situations</b>
+///         and the vocabulary keeps them apart: a store under <c>DaemonMode.ExternallyManaged</c>, a
+///         console in another process, or a hand-built store all genuinely cannot see the daemon, and
+///         saying so is worth more than a confident guess. <b>That reading is now the shared one</b> —
+///         <c>ProjectionStatusCompliance</c> (jasperfx#818) adopted it against both siblings, each of
+///         which changes (marten#5383, polecat#589), and <see cref="ShardStatusState" /> is the closed
+///         four-value vocabulary it holds the field to. Fisher spells those constants rather than
+///         retyping the strings.
+///     </para>
+///     <para>
+///         <b>The inventory is projections, not shards, and that is the one place Fisher was the odd
+///         one out (fisher#249).</b> This answers from <c>Projections.All</c>, so a registered
+///         <em>subscription</em> is not in it — where it used to answer from <c>AllShards()</c>, which
+///         spans both. The argument for the old reading is real, which is why this needed a ruling
+///         rather than a test: a subscription genuinely is a daemon shard with progress worth watching,
+///         and omitting it makes a store with three subscriptions look like a store with none. It went
+///         the other way because this is the page an operator opens to ask about <em>read models</em>,
+///         and a subscription has no document behind it — a row for one is something a reader cannot
+///         click through to. <b>Nothing is lost</b>: subscription progress stays reachable
+///         non-generically through <see cref="IEventStore.RegisteredShardNames" /> correlated against
+///         <c>IEventDatabase.FetchProjectionLagAsync</c>, which is the pairing jasperfx#815 built for
+///         exactly that question.
 ///     </para>
 /// </remarks>
 public partial class DocumentStore
 {
-    /// <summary>
-    ///     No daemon in this process could be asked about this shard, so its runtime state is not
-    ///     something this store can report.
-    /// </summary>
-    /// <remarks>
-    ///     Deliberately not <c>"Stopped"</c>. The two are told apart everywhere else in this file, and
-    ///     the distinction is the whole reason the state is not read off the progression table.
-    /// </remarks>
-    internal const string Unknown = "Unknown";
-
     Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(CancellationToken ct)
         => ProjectionStatusesAsync(null, ct);
 
@@ -139,54 +147,43 @@ public partial class DocumentStore
         var head = await HeadSequenceAsync(database, ct).ConfigureAwait(false);
         var tracker = await TrackerForAsync(database).ConfigureAwait(false);
 
+        // The registry drives the inventory and the shards are attributed TO it, rather than the
+        // shards driving the inventory. AllShards() spans asynchronous projections AND subscriptions;
+        // joining from the registry side is what drops a subscription from both halves of the answer
+        // at once — the top-level list and the shards inside a status — which is the partial fix the
+        // shared suite is shaped to catch.
+        var shardsByProjection = Options.Projections.AllShards()
+            .GroupBy(x => x.Name.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(x => x.Key, x => x.ToList(), StringComparer.OrdinalIgnoreCase);
+
         var statuses = new List<ProjectionStatus>();
-        var named = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        // AllShards() spans asynchronous projections AND subscriptions, which is what a projections
-        // page wants: a subscription is a daemon shard with progress to report, and omitting it would
-        // make a store with three subscriptions look like a store with none.
-        foreach (var group in Options.Projections.AllShards()
-                     .GroupBy(x => x.Name.Name, StringComparer.OrdinalIgnoreCase)
-                     .OrderBy(x => x.Key, StringComparer.Ordinal))
+        foreach (var source in Options.Projections.All.OrderBy(x => x.Name, StringComparer.Ordinal))
         {
-            named.Add(group.Key);
+            // Inline and Live projections run no daemon agent, so they have no shards and are reported
+            // with an empty list rather than omitted. The Lifecycle on the status is what says why it
+            // is empty, so a console can render "Inline — no shards" instead of inferring that the
+            // projection does not exist. Marten instead reports a shard in Unknown, which the suite
+            // deliberately permits as a coherent answer of a different kind; what it refuses is putting
+            // the LIFECYCLE in the State slot, which is Polecat's answer and makes that field mean a
+            // daemon state on some rows and a lifecycle on others.
+            var shards = shardsByProjection.TryGetValue(source.Name, out var group)
+                ? group
+                    .OrderBy(x => x.Name.Identity, StringComparer.Ordinal)
+                    .Select(shard => new ShardStatus(
+                        shard.Name.Identity,
+                        StateFor(tracker, shard.Name, daemonVisible: tracker is not null),
+                        progress.GetValueOrDefault(shard.Name.Identity),
+                        head,
+                        ErrorFor(tracker, shard.Name)))
+                    .ToList()
+                : [];
 
-            var shards = group
-                .OrderBy(x => x.Name.Identity, StringComparer.Ordinal)
-                .Select(shard => new ShardStatus(
-                    shard.Name.Identity,
-                    StateFor(tracker, shard.Name, daemonVisible: tracker is not null),
-                    progress.GetValueOrDefault(shard.Name.Identity),
-                    head,
-                    ErrorFor(tracker, shard.Name)))
-                .ToList();
-
-            statuses.Add(new ProjectionStatus(group.Key, LifecycleFor(group.Key), shards));
-        }
-
-        // Inline and Live projections have no shards, and are reported with an empty list rather than
-        // omitted. The Lifecycle on the status is what says why it is empty, so a console can render
-        // "Inline — no shards" instead of inferring that the projection does not exist. Polecat
-        // synthesises a fake single shard for these and puts the LIFECYCLE in its State slot, which
-        // makes the field mean two different things depending on the row.
-        foreach (var source in Options.Projections.All
-                     .Where(x => !named.Contains(x.Name))
-                     .OrderBy(x => x.Name, StringComparer.Ordinal))
-        {
-            statuses.Add(new ProjectionStatus(source.Name, source.Lifecycle.ToString(), []));
+            statuses.Add(new ProjectionStatus(source.Name, source.Lifecycle.ToString(), shards));
         }
 
         return statuses;
     }
-
-    private string LifecycleFor(string projectionName)
-        => Options.Projections.TryFindProjection(projectionName, out var source)
-            ? source.Lifecycle.ToString()
-
-            // A shard whose name matches no registered projection is a subscription's. Subscriptions
-            // exist only as daemon shards — there is deliberately no inline equivalent (fisher#21) —
-            // so Async is a fact about them rather than a guess.
-            : ProjectionLifecycle.Async.ToString();
 
     /// <summary>
     ///     The head of the event store, from <c>max(seq_id)</c> rather than from the persisted
@@ -272,35 +269,47 @@ public partial class DocumentStore
     ///         documentation names.
     ///     </para>
     ///     <para>
-    ///         <b>A visible daemon with no state for the shard is <c>Stopped</c>, not
-    ///         <see cref="Unknown" />.</b> Every agent publishes <c>Started</c> as it launches, so a
-    ///         registered shard the tracker has never heard of is one this daemon is not running — which
-    ///         is what an operator means by stopped. <see cref="Unknown" /> is reserved for the case
-    ///         where there is no daemon to have an opinion.
+    ///         <b>A visible daemon with no state for the shard is
+    ///         <see cref="ShardStatusState.Stopped" />, not <see cref="ShardStatusState.Unknown" />.</b>
+    ///         Every agent publishes <c>Started</c> as it launches, so a registered shard the tracker has
+    ///         never heard of is one this daemon is not running — which is what an operator means by
+    ///         stopped. <see cref="ShardStatusState.Unknown" /> is reserved for the case where there is
+    ///         no daemon to have an opinion.
+    ///     </para>
+    ///     <para>
+    ///         <b>The vocabulary is closed at four values, and every arm lands inside it (fisher#249).</b>
+    ///         This used to answer <c>"Failed"</c> for a faulted shard and <c>Action.ToString()</c> for
+    ///         anything it did not recognise — both outside <see cref="ShardStatusState.All" />, and a
+    ///         console renders this string and <em>filters</em> on it, so a fifth value is a row that
+    ///         matches no filter rather than a more precise answer. A faulted shard is one a daemon
+    ///         reached and is no longer running, which is <see cref="ShardStatusState.Stopped" />; what it
+    ///         faulted on is <see cref="ShardStatus.Error" />, which is the slot that carries it and the
+    ///         reason nothing is lost by collapsing the state. The default arm is unreachable — every
+    ///         <see cref="ShardAction" /> is covered — and exists so a value added upstream stays inside
+    ///         the vocabulary; <see cref="ShardStatusState.Running" /> is the one answer it must not be,
+    ///         since a shard claimed to be consuming events is one an operator stops looking at.
     ///     </para>
     /// </remarks>
     private static string StateFor(ShardStateTracker? tracker, ShardName name, bool daemonVisible)
     {
         if (!daemonVisible)
         {
-            return Unknown;
+            return ShardStatusState.Unknown;
         }
 
         var state = tracker?.CurrentState(name);
 
         if (state is null)
         {
-            return "Stopped";
+            return ShardStatusState.Stopped;
         }
 
         return state.Action switch
         {
             ShardAction.Started or ShardAction.Updated or ShardAction.Restarted or ShardAction.Skipped
-                => "Running",
-            ShardAction.Paused => "Paused",
-            ShardAction.Stopped => "Stopped",
-            ShardAction.Faulted => "Failed",
-            _ => state.Action.ToString()
+                => ShardStatusState.Running,
+            ShardAction.Paused => ShardStatusState.Paused,
+            _ => ShardStatusState.Stopped
         };
     }
 


### PR DESCRIPTION
Closes #249.

`ProjectionStatusCompliance` (jasperfx#818, shipped in **JasperFx 2.69.0**) rules that `GetProjectionStatusesAsync` reports `Projections.All`, so a registered **subscription** is not in it. Fisher answered from `AllShards()`, which spans both, and is the store that changes.

**Fisher was 8 of 9 on the suite before this**, and is otherwise the closest of the three stores to the contract — it is the only one that already reported the real shard state from a reachable daemon, which is the reading the suite adopted and which costs Marten (marten#5383) and Polecat (polecat#589) work. This is the one place Fisher was the odd one out.

## The ruling, and why it went against the better argument

The argument for the old reading is real, which is why jasperfx#818 needed a ruling rather than a test: a subscription genuinely *is* a daemon shard with progress worth watching, and omitting it makes a store with three subscriptions look like a store with none. It went the other way because this is the page an operator opens to ask about **read models**, and a subscription has no document behind it — a row for one is something a reader cannot click through to.

**Nothing is lost.** Subscription progress stays reachable non-generically through `IEventStore.RegisteredShardNames()` correlated against `IEventDatabase.FetchProjectionLagAsync` — the pairing jasperfx#815 built for exactly that question.

## What changed

- **The registry drives the inventory and the shards are attributed to it**, rather than the shards driving the inventory. That is what drops a subscription from *both* halves of the answer at once — the top-level list and the shards inside a status. Filtering only the outer list is the partial fix the suite is shaped to catch.
- **`ShardStatus.State` is closed over `ShardStatusState`**, the four-value vocabulary new in 2.69.0. Two arms were outside it: a faulted shard answered `"Failed"` and an unrecognised action `Action.ToString()`. A console renders this string and *filters* on it, so a fifth value is a row that matches no filter rather than a more precise answer — a faulted shard is one a daemon reached and is no longer running, and what it faulted on is already in `Error`.
- **`projection_statuses.a_subscription_is_reported_alongside_the_projections` is reversed** into `..._is_not_in_the_projection_inventory_and_is_still_reachable`, which asserts the replacement as well as the omission. "Dropped from a list" and "no longer answerable" are different outcomes and only the first was ruled on.
- `IComplianceCoordinatorHost.EventStore` on `FisherCoordinatorHost` — a default-**throwing** seam member, so nothing broke on the bump and what tells you it is unimplemented is the suite rather than the compiler. It casts, because Fisher implements `IEventStore` explicitly (fisher#45) and no store registers itself under the shared interface.

One requirement of jasperfx#818 was **dropped** rather than adopted: it proposed that an Inline projection report an empty shard list — Fisher's answer, and the only store that gives it. Marten's `SignalBoard:All / Unknown / 0 / 0` is a coherent answer of a different kind and stands. Fisher's empty list is still legal.

## Scoreboard

JasperFx bumped 2.68.0 → 2.69.0. **51 suites, 544 tests** (was 50 / 535), machine-checked by `scripts/check_scoreboard.py` against a real Release run.

`MultiDatabaseExplorerCompliance` also ships in 2.69.0 and is **not** enrolled — it needs a fixture that can build a store over more than one database. Filed as #252.

## Verification

- `dotnet test fisher.slnx` green on both TFMs — 2,088 tests.
- `scripts/check_scoreboard.py` agrees with the run.
- `scripts/check_no_leaked_databases.py` clean.
- `npm run docs-build` clean; `docs/diagnostics.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)