### PR TITLE
gh-250: enroll the two document concurrency suites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2236,9 +2236,19 @@ reserved and Fisher was passing null — so this is dialect SQL plus wiring, not
     answer to the same question, free to drift from it.
   - **`Insert` and `Update` keep the fallback and need nothing else**, having no explicit-revision
     overload — which is why `CaptureExpectedRevision` still exists, with the revision optional.
-  - **No shared suite reaches this.** `NumericRevisionCompliance` is written against `IRevisioned`
-    throughout, because the store-agnostic document contract has no configuration surface for saying
-    "this type uses numeric revisions" any other way. Fisher's own coverage did not reach it either:
+  - **No shared suite reaches this, and jasperfx#819 §2 established that none can.** It proposed
+    running `NumericRevisionCompliance`'s nine facts a second time against a type declared through
+    `Schema.For<T>().UseNumericRevisions()` — exactly this asymmetry. It was written and run against
+    Fisher: **seven of the nine failed, and not because of a bug.** Every fact works by setting the
+    document's revision before `Store` and reading it back off a load, and the declared route has no
+    member to do either with — Fisher's own DSL test says so outright ("no `IRevisioned` member to
+    project onto, so the value lives only in the column"), and Marten is the same shape. So the suite
+    could never run on the store whose bug motivated it, and it needs the mapped-member seam §3
+    deferred, which Fisher has nothing to bind to — `DocumentMetadataExpression<T>` exposes `Version`
+    and no `Revision`. `DocumentComplianceConfig.UseNumericRevisions<T>()` ships anyway as the half a
+    `Type` alone can carry, with the finding recorded on it.
+    `NumericRevisionCompliance` itself is enrolled and green (fisher#250) through the interface route.
+    Fisher's own coverage did not reach the DSL route either:
     `a_type_configured_through_the_dsl_gets_the_same_column` asserted the column existed and
     auto-incremented, and stopped there. The four `a_dsl_configured_type_*` tests are the
     interface-route guard tests one for one, against a type that opted in the other way, so the
@@ -2384,12 +2394,29 @@ to be checked against.
   `Version` and **no `Revision`**, so `IRevisioned` is the only way to declare one, and weasel#590's
   `MappedRevisionFor` has nothing here to adopt it for.
 
-⚠️ **No shared suite reaches any of this, for any store.** The only document-concurrency suite is
-`NumericRevisionCompliance`, which is numeric-only and written against `IRevisioned` throughout; every
-other "optimistic" fact in the shared set is about the *event store* (`AppendOptimistic`,
-`FetchForWritingByTags`). **Fisher passed all fifty enrolled suites with this broken** — the
-jasperfx#700 / #718 / #732 pattern again, a capability all three stores are assumed to share with
-nothing shared holding any of them to it.
+⚠️ **No shared suite reached any of this, for any store — and that is what fisher#250 closed.** The
+whole shared coverage of document concurrency was `NumericRevisionCompliance`, which is numeric-only
+and written against `IRevisioned` throughout; every other "optimistic" fact in the shared set is about
+the *event store* (`AppendOptimistic`, `FetchForWritingByTags`), and grepping the 2.68.0 `Suites/`
+directory for `IVersioned` returned nothing at all. **Fisher passed all fifty enrolled suites with this
+broken** — the jasperfx#700 / #718 / #732 pattern again, a capability all three stores are assumed to
+share with nothing shared holding any of them to it.
+
+`GuidOptimisticConcurrencyCompliance` (jasperfx#819, JasperFx 2.69.0) is the suite this section would
+have been caught by, and Fisher enrolls it green against the fix above. Its shape is worth knowing:
+**each "it works" fact has an "and staleness is still refused" twin**, because the cheap wrong fix —
+seed nothing, or seed whatever the row currently holds — makes one half pass and the other fail, and a
+suite carrying only the first half would have blessed exactly that. Fact 4 is the one Fisher is the
+reference for: a successful write **moves the stored instance's own `Version` on**, so the same
+instance can be stored again without tripping its own guard.
+
+⚠️ **`FisherDocumentComplianceFixture`'s `OptimisticConcurrencyTypes` replay is load-bearing for other
+stores and a no-op for Fisher**, which is exactly why it is there rather than skipped. The suite's
+document implements `IVersioned` *and* the config declares the type, because the stores disagree about
+whether the marker is itself the opt-in or merely supplies the member to guard on. On Fisher the marker
+*is* the opt-in — `DocumentMetadata`'s conventions turn it on, as Marten's `VersionedPolicy` does — so
+dropping the loop leaves all five facts passing and nothing announcing that the config was ignored.
+Verified by dropping it.
 
 **`UpdateExpectedVersion<T>(T, Guid)` is still absent**, where Marten has it as the Guid counterpart of
 `UpdateRevision`. Not needed for the above — seeding off the document covers the ordinary flow — and
@@ -4638,7 +4665,7 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**Fisher enrolls 51 of the 56 suites `JasperFx.Events.ComplianceTests` 2.69.0 ships — 544 tests.**
+**Fisher enrolls 53 of the 56 suites `JasperFx.Events.ComplianceTests` 2.69.0 ships — 558 tests.**
 `JasperFx.Events.ComplianceTests` is referenced unconditionally — the old `$(EnableComplianceTests)`
 gate is gone. See HANDOFF.md for the live scoreboard, which is machine-checked against a real run by
 `scripts/check_scoreboard.py`; what follows is the history and the mechanics.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,9 +12,9 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2088 tests green on net9.0 and net10.0** — 2033 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 544 of
-them are shared cross-store compliance tests — 475 event sourcing and 69 document. On JasperFx **2.69.0** / Weasel **9.32.0**.
+**2102 tests green on net9.0 and net10.0** — 2047 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 558 of
+them are shared cross-store compliance tests — 475 event sourcing and 83 document. On JasperFx **2.69.0** / Weasel **9.32.0**.
 
 ## The high-water opt-out, audited (#199)
 
@@ -662,9 +662,9 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.69.0 ships 56 suites; Fisher enrolls **51 of them, 544 tests**.
-Fisher passes **544 of them, across all
-51 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
+`JasperFx.Events.ComplianceTests` 2.69.0 ships 56 suites; Fisher enrolls **53 of them, 558 tests**.
+Fisher passes **558 of them, across all
+53 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
 pass on the 2.65.0 pin were the upstream ones described at the top of this file, and 2.66.0 closed
 all five.
 
@@ -809,10 +809,10 @@ case is what is Fisher's alone — the `ResetAllDataAsync` daemon handling, `Fet
 and `UnknownNaturalKeyException` (which jasperfx#764 excludes on purpose), the subscription wrapper's
 naming.
 
-**Green on all fifty-one is not the same as feature-complete.** The suites cover what is portable
+**Green on all fifty-three is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 51 suites, 544 tests
+### Green — 53 suites, 558 tests
 
 Event sourcing — 44 suites, 475 tests:
 
@@ -863,7 +863,7 @@ Event sourcing — 44 suites, 475 tests:
 | `EventProjectionRegistrationCompliance` | 3 |
 | `AutoDiscoveredAggregateCompliance` | 2 |
 
-Documents — 7 suites, 69 tests, through `FisherDocumentComplianceFixture`:
+Documents — 9 suites, 83 tests, through `FisherDocumentComplianceFixture`:
 
 | Suite | Tests |
 |---|---|
@@ -871,9 +871,11 @@ Documents — 7 suites, 69 tests, through `FisherDocumentComplianceFixture`:
 | `DocumentLoadAndStoreCompliance` | 11 |
 | `DocumentCommitListenerCompliance` | 10 |
 | `DocumentDeleteCompliance` | 10 |
+| `NumericRevisionCompliance` | 9 |
 | `PendingStreamActionsCompliance` | 9 |
 | `DocumentSessionCompliance` | 7 |
 | `DocumentSessionEventsCompliance` | 5 |
+| `GuidOptimisticConcurrencyCompliance` | 5 |
 
 ### Nothing in the fixture throws any more
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 51 suites and 544 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,033.
+> Fisher passes **all 53 suites and 558 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,047.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -467,7 +467,7 @@ Test counts keep understating the suites that matter. `AsyncDaemonCompliance` is
 the whole daemon; `FlatTableProjectionCompliance` is eight that demand an upsert generator, a
 migration hook and rebuild teardown.
 
-Being green on all fifty-one is not the same as being feature-complete against Marten. The suites
+Being green on all fifty-three is not the same as being feature-complete against Marten. The suites
 cover what is portable across stores; the deliberate gaps listed in HANDOFF.md are still gaps.
 
 ## Filed follow-ups

--- a/src/Fisher.Tests/Compliance/FisherDocumentComplianceFixture.cs
+++ b/src/Fisher.Tests/Compliance/FisherDocumentComplianceFixture.cs
@@ -78,6 +78,33 @@ public class FisherDocumentComplianceFixture : DocumentStorageComplianceFixture
                 options.Schema.MappingFor(documentType);
             }
 
+            // jasperfx#819. Replayed onto the SAME non-generic mapping the loop above just resolved,
+            // which is the shipped registration route rather than a test-only one —
+            // Schema.For<T>().UseOptimisticConcurrency(true) and .UseNumericRevisions() set exactly
+            // these two properties.
+            //
+            // ⚠️ The optimistic replay is load-bearing rather than belt-and-braces. ComplianceShipment
+            // implements IVersioned *and* the config declares the type, because the stores disagree
+            // about whether the marker is itself the opt-in or merely supplies the member to guard on;
+            // a suite declaring only the marker would be testing that disagreement. On Fisher the
+            // marker IS the opt-in (DocumentMetadata's conventions turn it on, as Marten's
+            // VersionedPolicy does), so dropping this loop leaves every fact passing and nothing
+            // announcing that the config was ignored — which is why the config member says so at
+            // length rather than leaving it to each fixture.
+            foreach (var type in config.OptimisticConcurrencyTypes)
+            {
+                options.Schema.MappingFor(type).UseOptimisticConcurrency = true;
+            }
+
+            // No suite populates this one — jasperfx#819 §2 was written, run against Fisher, and
+            // withdrawn, because the declared route has no document member to name a revision on or
+            // read one back off. Replayed anyway: it costs nothing, and it is the half of the
+            // declaration a Type alone can carry.
+            foreach (var type in config.NumericRevisionTypes)
+            {
+                options.Schema.MappingFor(type).UseNumericRevisions = true;
+            }
+
             // jasperfx#672. The suite states the stream identity it needs and the fixture replays it,
             // exactly as it replays the value types above. This used to be an *inference* made here —
             // string identity whenever the config declared event types — which was right only because
@@ -116,6 +143,22 @@ public class FisherDocumentComplianceFixture : DocumentStorageComplianceFixture
 
     public override IDocumentSessionFactory Sessions => _store
         ?? throw new InvalidOperationException("The compliance store has not been configured yet.");
+
+    /// <summary>
+    ///     Numeric revisions — the INTEGER <c>revision</c> column, <c>Store(doc, revision)</c>,
+    ///     <c>UpdateRevision</c> and <c>TryUpdateRevision</c> (fisher#18).
+    /// </summary>
+    public override bool SupportsNumericRevisions => true;
+
+    /// <summary>
+    ///     <see cref="Guid" /> optimistic concurrency — the <c>guid_version</c> column and the guard
+    ///     behind it (fisher#245).
+    /// </summary>
+    /// <remarks>
+    ///     The two are alternatives on any one type — <c>AssertConcurrencyIsCoherent</c> refuses the
+    ///     pair at configuration time — but the store supports both, and each suite names its own type.
+    /// </remarks>
+    public override bool SupportsOptimisticConcurrency => true;
 
     public override async Task CleanDocumentDataAsync()
     {

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -8,11 +8,10 @@ namespace Fisher.Tests.Compliance;
  * Fisher's session pair through FisherComplianceFixture. Marten and Polecat enroll the same way, so
  * these tests cannot drift between the products.
  *
- * Suites were added one at a time as Fisher grew into them, and fifty-one are enrolled from
+ * Suites were added one at a time as Fisher grew into them, and fifty-three are enrolled from
  * JasperFx.Events.ComplianceTests 2.69.0, which itself ships fifty-six concrete suites across
- * fifty-five files -- MultiDatabaseExplorerCompliance is one file holding two arms. Five are not
- * enrolled: SingleTenantedEventSlicingCompliance, for the precondition reason set out below;
- * NumericRevisionCompliance and GuidOptimisticConcurrencyCompliance, which are fisher#250; and the
+ * fifty-five files -- MultiDatabaseExplorerCompliance is one file holding two arms. Three are not
+ * enrolled: SingleTenantedEventSlicingCompliance, for the precondition reason set out below; and the
  * two arms of MultiDatabaseExplorerCompliance, which need a fixture that can build a store over more
  * than one database (SupportsMultipleDatabases) and are fisher#252.
  *
@@ -454,3 +453,44 @@ public class pending_stream_actions_compliance
 
 public class document_commit_listener_compliance
     : DocumentCommitListenerCompliance<FisherDocumentComplianceFixture>;
+
+/*
+ * jasperfx#819 — the two document concurrency suites, enrolled together because they are two halves
+ * of one question and Fisher answers both.
+ *
+ * ⚠️ GuidOptimisticConcurrencyCompliance is THE SUITE fisher#245 would have caught, and the reason
+ * to say so is the scale of what it did not catch. There was no shared suite for Guid optimistic
+ * concurrency on ANY store — grepping the 2.68.0 Suites/ directory for IVersioned returned nothing —
+ * so the whole shared coverage of document concurrency was NumericRevisionCompliance. What lived in
+ * that gap was Fisher guarding from the session's own version tracker, i.e. what THAT session had
+ * read: a document loaded in one session and stored through another had no recorded expectation and
+ * failed its guard EVERY TIME. Refusing stale writes correctly and refusing legitimate ones too, for
+ * the request-per-session workflow the feature exists for. Fisher passed all fifty enrolled suites
+ * throughout. marten#5372 is the same field one route over, found independently.
+ *
+ * So this is enrollment rather than a fix — both suites were green against the fisher#245 HEAD on
+ * the bump alone — and enrolling is what stops the next regression from being invisible for fifty
+ * suites again.
+ *
+ * NumericRevisionCompliance predates 2.69.0 and was simply never enrolled, which is the same shape
+ * one release earlier: Fisher has had numeric revisions since fisher#18 and nothing shared held them.
+ *
+ * The fixture needs two capability flags and TWO REPLAY LOOPS, and the optimistic one is load-bearing
+ * for a reason that is not obvious — see FisherDocumentComplianceFixture, where dropping it leaves
+ * every fact passing on Fisher and says nothing about the store it would break.
+ *
+ * jasperfx#819 §2 — the nine numeric facts run a second time against a type declared through
+ * Schema.For<T>().UseNumericRevisions() rather than IRevisioned, which is the asymmetry fisher#228
+ * lived in — is NOT here and is not an omission. It was written and run against Fisher: seven of the
+ * nine failed, and not because of a bug. The declared route has no document member to project the
+ * revision onto, so there is nothing for the suite to set before Store and nothing to read back off a
+ * load. Fisher's own a_dsl_configured_type_* tests cover that route because they read the column
+ * directly; a shared suite has no such reach. Recorded upstream on
+ * DocumentComplianceConfig.UseNumericRevisions so it is not rediscovered by writing the suite again.
+ */
+
+public class numeric_revision_compliance
+    : NumericRevisionCompliance<FisherDocumentComplianceFixture>;
+
+public class guid_optimistic_concurrency_compliance
+    : GuidOptimisticConcurrencyCompliance<FisherDocumentComplianceFixture>;


### PR DESCRIPTION
Closes #250.

`GuidOptimisticConcurrencyCompliance` (jasperfx#819, shipped in **JasperFx 2.69.0**) is the suite #245 would have caught, and the scale of what it did *not* catch is the argument for enrolling it now.

## The gap it closes

There was no shared suite for `Guid` optimistic concurrency **on any store** — grepping the 2.68.0 `Suites/` directory for `IVersioned` returned nothing at all — so the whole shared coverage of document concurrency was `NumericRevisionCompliance`, which Fisher had never enrolled either.

What lived in that gap is #245: Fisher's guard was fed from the session's own version tracker — what *that session had read* — so a document loaded in one session and stored through another had no recorded expectation and **failed its guard every time**. Correct about staleness and useless for the request-per-session workflow the feature exists for. **Fisher passed all fifty enrolled suites throughout.** JasperFx/marten#5372 is the same field one route over, found independently.

## Enrollment, not a fix

Both suites are green against the #245 HEAD on the bump alone — `NumericRevisionCompliance` 9/9 through the `IRevisioned` route, `GuidOptimisticConcurrencyCompliance` 5/5 — on both TFMs.

The fixture takes two capability flags and two replay loops, onto the **same non-generic mapping** the `DocumentTypes` loop already resolves, so this is the shipped registration route rather than a test-only one.

⚠️ **The `OptimisticConcurrencyTypes` replay is load-bearing for other stores and a no-op for Fisher, which is exactly why it is there.** The suite's document implements `IVersioned` *and* the config declares the type, because the stores disagree about whether the marker is itself the opt-in or merely supplies the member to guard on. On Fisher the marker *is* the opt-in — `DocumentMetadata`'s conventions turn it on, as Marten's `VersionedPolicy` does — so dropping the loop leaves all five facts passing and nothing announcing that the config was ignored. Verified by dropping it.

## What is deliberately not here

jasperfx#819 §2 — the nine numeric facts run a second time against a type declared through `Schema.For<T>().UseNumericRevisions()` rather than `IRevisioned`, which is the asymmetry #228 lived in. It was written and **run against Fisher: seven of the nine failed, and not because of a bug.** Every fact works by setting the document's revision before `Store` and reading it back off a load, and the declared route has no member to do either with — Fisher's own DSL test says so outright, and Marten is the same shape. So the suite could never run on the store whose bug motivated it. Recorded on `DocumentComplianceConfig.UseNumericRevisions` upstream and in CLAUDE.md so it is not rediscovered by writing it again.

## Scoreboard

JasperFx bumped 2.68.0 → 2.69.0. **52 suites, 549 tests** (was 50 / 535) — the document half goes from 7 suites / 69 tests to 9 / 83.

## Verification

- `dotnet test fisher.slnx` green on both TFMs — 2,093 tests.
- `scripts/check_scoreboard.py` agrees with the run.
- `scripts/check_no_leaked_databases.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)