### PR TITLE
gh-251: register the store-derived Event Model rung

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,9 @@ Working, with tests:
 - **The command line** — `ISystemPart` and `IDatabaseSource` registered from both `AddFisher` and
   `AddFisherStore<T>`, so `db-apply` / `db-assert` / `db-patch` / `db-dump`, the `resources` commands
   and `describe` all see a Fisher store; plus `AssertDatabaseMatchesConfigurationOnStartup()`
+- **The Event Model, derived from the store** — `AddFisher` and `AddFisherStore<T>` each register a
+  `ProjectionEventModelSource`, so every registered projection is a View slice on an Event Model canvas
+  with nothing written down by hand
 - **Schema preview, programmatically** — `Advanced.CreateMigrationAsync` (the default database, one
   tenant, or every database), `WriteMigrationFileAsync`, `WriteScriptsByTypeAsync`, `AllObjects` and
   `AllSchemaNames`, so a deployment or a test can ask what a migration *would* change without
@@ -2606,6 +2609,53 @@ third.
   that opened a scope per batch and kept it passes the first half and leaks — and
   `a_scoped_projection_runs_under_the_async_daemon` deliberately commits a second batch after the
   daemon has already run one.
+
+#### The store-derived Event Model rung — fisher#251
+
+`AddFisher` registers a `JasperFx.Events.EventModeling.ProjectionEventModelSource` (jasperfx#825), and
+`AddFisherStore<T>` registers one of its own. One `SlicePattern.View` slice per registered projection —
+event → projection → read model — read straight out of the store's own registry.
+
+**The gap was that nobody derived from the store.** Bobcat declares slices and Wolverine derives Command
+and Automation slices from its chains, so a View slice reached an Event Model canvas only when a human
+had written one down. Yet the store knows it exactly: every registered projection, the document it
+produces, and the event types its `Apply` / `Create` / `Evolve` methods take.
+
+**Almost none of this is Fisher's, and that is the finding rather than the shortcut.** The source reads
+`IEventStore.TryCreateUsage()` and `SubscriptionDescriptor`, which Fisher already fills through shared
+code in `JasperFx.Events` — so the applied-event set cannot disagree with `AggregateDescriptor.AppliedEvents`,
+because the same reader feeds both. What is Fisher's is two registrations.
+
+- **Why a store registers this rather than the library doing it.** A store registers itself under its
+  own interface, and `AddFisher` is the only place that knows which — hence the resolver overload.
+  Fisher's `DocumentStore` implements `IEventStore` **explicitly** (fisher#45), so the cast is what
+  reaches it; `IDocumentStore` does not carry the member.
+- ⚠️ **The ancillary registration unwraps the marker proxy, and that is load-bearing.** A
+  `DispatchProxy` implements only the interfaces it was asked for, so an ancillary store's marker is
+  *not* an `IEventStore` — the same reason the `IEventStore` bridge reaches through it. Verified by
+  handing the proxy over: `InvalidCastException: Unable to cast object of type 'generatedProxy_1'`.
+  Better than a silent omission and still not a failure to rely on.
+- **Each store's source carries a `Subject` of its own** (`event-model://projections/<marker>`), which
+  is why the ancillary one is registered through `AddEventModelSource` rather than
+  `AddProjectionEventModelSource`. Same distinction `FisherSystemPart<T>` draws for the command line,
+  and it matters more here for the same reason: two Fisher stores are usually two *files*. **The model
+  name stays the default for both** — slices are grouped by model name before merging, and an ancillary
+  store's read models belong on the same canvas as the primary's.
+- **The slice is named after the DOCUMENT, not the projection**, which is what makes it *merge* with a
+  spec-declared slice of the same name into one slice carrying both a `Derived` and a `Declared` claim.
+  A mis-named slice would not merge, which is the one thing the source exists to get right.
+- **Fisher matters disproportionately here, which is why jasperfx#825's acceptance names it.** A
+  store-derived Event Model that needs a Postgres or SQL Server container to demonstrate is one nobody
+  exercises while writing the feature. Every fact in `event_model_source` runs against a throwaway
+  SQLite file.
+- ⚠️ **A View slice's `ConsumedEvents` carries `Archived` and `Compacted<T>`**, because `AppliedEvents`
+  is derived from `IAggregateProjection.AllEventTypes` and every aggregation projection handles those
+  whether or not the aggregate declares an `Apply`. Nothing here is Fisher's to change; pinned rather
+  than asserted around, and reported upstream as jasperfx#829.
+
+**There is no `event-model` CLI command in JasperFx 2.69.0**, so jasperfx#825's third acceptance item
+is covered at the seam a command would read — `EventModelDiscovery.AssembleAsync` over a plain Fisher
+host, with no Bobcat reference anywhere.
 
 #### The command-line seam — fisher#172
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2102 tests green on net9.0 and net10.0** — 2047 in
+**2109 tests green on net9.0 and net10.0** — 2054 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 558 of
 them are shared cross-store compliance tests — 475 event sourcing and 83 document. On JasperFx **2.69.0** / Weasel **9.32.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 53 suites and 558 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,047.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,054.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -296,6 +296,36 @@ Several things in that surface are worth knowing:
 - **A console's id is converted through the mapping's identity type before it is bound**, because
   `fi_doc_*.id` holds the lowercase canonical Guid form under a case-sensitive collation.
 
+## The Event Model, derived from the store
+
+`AddFisher` registers a `ProjectionEventModelSource`, so every registered projection appears on an
+Event Model canvas as a **View slice** — event → projection → read model — with nothing written down
+by hand.
+
+| Role | Read from |
+|---|---|
+| Slice name | the **document** type's name |
+| Pattern | `View` |
+| Projection | the projection's implementation type |
+| Read model | the document type |
+| Consumed events | the event types the projection's `Apply` / `Create` / `Evolve` methods take |
+
+Nothing has to be configured. `AddFisherStore<T>` registers a source of its own, so an ancillary
+store's projections reach the same model under a `Subject` that says which store they came from.
+
+::: tip
+**The slice is named after the document, not the projection**, and that is what makes it *merge* with
+a spec-declared slice of the same name into one slice carrying both a `Derived` and a `Declared`
+claim — rather than two stickies that say the same thing. A bare subscription gets no slice: it has no
+read model behind it, so a sticky for one is something a reader cannot click through to.
+:::
+
+::: warning
+A View slice's consumed events include JasperFx's own `Archived` and `Compacted<T>`, because the set
+is derived from what the projection *handles* rather than from what the aggregate declares an `Apply`
+for. Reported upstream as jasperfx#829.
+:::
+
 ## Projection step-through
 
 Replay a stream one event at a time and capture the aggregate at each step:

--- a/src/Fisher.Tests/Configuration/event_model_source.cs
+++ b/src/Fisher.Tests/Configuration/event_model_source.cs
@@ -1,0 +1,345 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.EventModeling;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Fisher.Tests.Configuration;
+
+/// <summary>
+///     fisher#251 — <c>AddFisher</c> registers the store-derived rung of the Event Model
+///     (jasperfx#825): one <c>SlicePattern.View</c> slice per registered projection, read out of the
+///     store's own registry.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>The gap is that nobody derived from the store.</b> Bobcat declares slices and Wolverine
+///         derives Command and Automation slices from its chains, so a View slice — event → projection
+///         → read model — reached an Event Model canvas only when a human had written one down. Yet
+///         the store knows it exactly: every registered projection, the document it produces, and the
+///         event types its <c>Apply</c> / <c>Create</c> / <c>Evolve</c> methods take.
+///     </para>
+///     <para>
+///         <b>Fisher matters disproportionately here, which is why jasperfx#825's acceptance names
+///         it.</b> A store-derived Event Model that needs a Postgres or SQL Server container to
+///         demonstrate is one nobody exercises while writing the feature. Every test in this file runs
+///         against a throwaway SQLite file, which is what makes this the inner-loop store for the
+///         whole rung.
+///     </para>
+///     <para>
+///         <b>What is Fisher's here is the registration and nothing else.</b>
+///         <see cref="ProjectionEventModelSource" /> reads <c>IEventStore.TryCreateUsage()</c> and
+///         <c>SubscriptionDescriptor</c>, which Fisher fills through shared code in
+///         <c>JasperFx.Events</c> — so these tests are about the wiring, and about the two things the
+///         wiring can get wrong on a store that implements <c>IEventStore</c> explicitly and hands out
+///         ancillary stores as <c>DispatchProxy</c> markers.
+///     </para>
+/// </remarks>
+public class event_model_source : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _primary = TemporaryDatabase.Create("event-model-primary");
+    private readonly TemporaryDatabase _ancillary = TemporaryDatabase.Create("event-model-ancillary");
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        _primary.Dispose();
+        _ancillary.Dispose();
+
+        return ValueTask.CompletedTask;
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    ///     One single-stream projection yields one View slice carrying the projection, its document,
+    ///     and every applied event — with no container needed.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Asserted on the <em>roles</em> rather than on the slice's existence, because a slice
+    ///         with the right name and empty roles is what a canvas renders as an unclickable sticky —
+    ///         which is the outcome this rung exists to replace, not a partial version of it.
+    ///     </para>
+    ///     <para>
+    ///         ⚠️ <b>The slice is named after the DOCUMENT, not the projection.</b> That is what makes
+    ///         it merge with a spec-declared slice of the same name rather than sitting beside it — see
+    ///         <see cref="a_derived_slice_merges_with_a_declared_slice_of_the_same_name" />.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_registered_projection_becomes_a_view_slice()
+    {
+        await using var provider = BuildPrimary();
+
+        var model = await AssembleAsync(provider);
+
+        var slice = model.Slices.Single(x => x.Name == nameof(ModelLedger));
+
+        slice.Pattern.ShouldBe(SlicePattern.View);
+        slice.ReadModelTypes.Select(x => x.Name).ShouldBe([nameof(ModelLedger)]);
+        slice.ProjectionTypes.ShouldNotBeEmpty();
+
+        var consumed = slice.ConsumedEvents.Select(x => x.Name).ToArray();
+        consumed.ShouldContain(nameof(Credited));
+        consumed.ShouldContain(nameof(Debited));
+
+        // ⚠️ JasperFx's own lifecycle events come with them, because AppliedEvents is derived from
+        // IAggregateProjection.AllEventTypes and every aggregation projection handles these two
+        // whether or not the aggregate declares an Apply for them. Pinned rather than filtered:
+        // nothing here is Fisher's to change -- the same reader feeds AggregateDescriptor.AppliedEvents
+        // -- and a canvas showing stickies for events the application never wrote is worth knowing
+        // about rather than quietly asserting around. Reported upstream as jasperfx#829.
+        consumed.ShouldContain("Archived");
+    }
+
+    /// <summary>
+    ///     The claim is <c>Derived</c>, which is what lets a store-read role outrank a declaration
+    ///     that disagrees with it.
+    /// </summary>
+    /// <remarks>
+    ///     Read off the assembled model rather than off the source, because the provenance is stamped
+    ///     by <c>EventModelDiscovery</c> rather than carried on each slice — so asserting it on the
+    ///     source would pass against a registration the discovery pipeline never reached.
+    /// </remarks>
+    [Fact]
+    public async Task the_store_derived_slice_claims_derived_provenance()
+    {
+        await using var provider = BuildPrimary();
+
+        var slice = (await AssembleAsync(provider)).Slices.Single(x => x.Name == nameof(ModelLedger));
+
+        slice.ProvenanceFor(EventModelRole.ReadModelTypes).ShouldBe(EventModelProvenance.Derived);
+        slice.ProvenanceFor(EventModelRole.ProjectionTypes).ShouldBe(EventModelProvenance.Derived);
+    }
+
+    /// <summary>
+    ///     A registered <em>subscription</em> gets no slice, and neither does an inline projection's
+    ///     absence of a document.
+    /// </summary>
+    /// <remarks>
+    ///     A subscription has no read model to click through to, so inventing a green sticky for it
+    ///     would put something on the canvas a reader cannot follow. Carried here rather than left to
+    ///     the upstream unit tests because it is the one omission a Fisher reader would otherwise read
+    ///     as the registration having missed something.
+    /// </remarks>
+    [Fact]
+    public async Task a_subscription_gets_no_slice()
+    {
+        await using var provider = BuildPrimary(options
+            => options.Projections.Subscribe(new LedgerAudit()));
+
+        var model = await AssembleAsync(provider);
+
+        model.Slices.Select(x => x.Name).ShouldNotContain(nameof(LedgerAudit));
+        model.Slices.Select(x => x.Name).ShouldContain(nameof(ModelLedger));
+    }
+
+    /// <summary>
+    ///     <b>An ancillary store registers its own source, and its projections reach the same model.</b>
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         ⚠️ <b>This is the registration most likely to be wrong on Fisher specifically.</b> An
+    ///         ancillary store arrives as a <c>DispatchProxy</c> marker, which implements only the
+    ///         interfaces it was asked for — so it is <em>not</em> an <c>IEventStore</c>, and a source
+    ///         handed the proxy rather than the store behind it fails at discovery time. The same
+    ///         unwrapping the <c>IEventStore</c> bridge does, for the same reason.
+    ///     </para>
+    ///     <para>
+    ///         The two sources contribute to <b>one model</b>, deliberately: they differ by
+    ///         <c>Subject</c>, which says which store the slices came from, and agree on the model
+    ///         name, because slices are grouped by name before merging and an ancillary store's read
+    ///         models belong on the same canvas as the primary's.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task an_ancillary_stores_projections_reach_the_same_model()
+    {
+        await using var provider = BuildBothStores();
+
+        var models = await EventModelDiscovery.AssembleAsync(provider, Token);
+
+        var model = models.ShouldHaveSingleItem();
+
+        model.Slices.Select(x => x.Name).OrderBy(x => x, StringComparer.Ordinal)
+            .ShouldBe([nameof(Manifest), nameof(ModelLedger)]);
+
+        var ancillary = model.Slices.Single(x => x.Name == nameof(Manifest));
+        ancillary.Pattern.ShouldBe(SlicePattern.View);
+        ancillary.ConsumedEvents.Select(x => x.Name).ShouldContain(nameof(Filed));
+        ancillary.ReadModelTypes.Select(x => x.Name).ShouldBe([nameof(Manifest)]);
+    }
+
+    /// <summary>
+    ///     Each store's source carries a <c>Subject</c> of its own.
+    /// </summary>
+    /// <remarks>
+    ///     Two Fisher stores are usually two <em>files</em>, so collapsing them onto one subject uri
+    ///     would leave a consumer unable to say which store a slice was read out of. The same
+    ///     distinction <c>FisherSystemPart&lt;T&gt;</c> draws for the command line (fisher#172), and it
+    ///     matters more here than on either sibling for the same reason.
+    /// </remarks>
+    [Fact]
+    public async Task each_store_contributes_a_source_with_its_own_subject()
+    {
+        await using var provider = BuildBothStores();
+
+        var subjects = provider.GetServices<IEventModelDefinitionSource>()
+            .OfType<ProjectionEventModelSource>()
+            .Select(x => x.Subject.ToString())
+            .OrderBy(x => x)
+            .ToArray();
+
+        // The trailing slash on the first is Uri's own rendering of an authority with an empty path,
+        // not something either registration wrote.
+        subjects.ShouldBe([
+            "event-model://projections/",
+            "event-model://projections/iledgerarchivestore"
+        ]);
+    }
+
+    /// <summary>
+    ///     <b>The payoff.</b> A store-derived slice and a spec-declared one of the same name become
+    ///     <em>one</em> slice carrying both claims — not two stickies that say the same thing.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This is why the slice is named after the document type rather than after the projection
+    ///         class: Bobcat's <c>{readmodel}</c> capture and the curated model file already name View
+    ///         slices that way, so the two merge by name. A mis-named slice would not merge, which is
+    ///         the one thing this source exists to get right.
+    ///     </para>
+    ///     <para>
+    ///         The declaration here deliberately carries a role the store cannot know — a
+    ///         <c>Domain</c> — so the merged slice is observably richer than either half. Asserting
+    ///         only that one slice came back would pass against a merge that silently discarded the
+    ///         declared side.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_derived_slice_merges_with_a_declared_slice_of_the_same_name()
+    {
+        var builder = Host.CreateDefaultBuilder().ConfigureServices(services =>
+        {
+            services.AddFisher(options =>
+            {
+                options.ConnectionString = _primary.ConnectionString;
+                options.AutoCreateSchemaObjects = AutoCreate.All;
+                options.Projections.Snapshot<ModelLedger>(SnapshotLifecycle.Inline);
+            });
+
+            services.AddEventModel(ProjectionEventModelSource.DefaultModelName, model
+                => model.Slice(nameof(ModelLedger)).InDomain("Finance"));
+        });
+
+        using var host = await builder.StartAsync(Token);
+
+        var model = (await EventModelDiscovery.AssembleAsync(host.Services, Token)).ShouldHaveSingleItem();
+
+        var slice = model.Slices.Single(x => x.Name == nameof(ModelLedger));
+
+        // One slice, both claims.
+        slice.Domain.ShouldBe("Finance");
+        slice.ReadModelTypes.Select(x => x.Name).ShouldBe([nameof(ModelLedger)]);
+        slice.ProvenanceFor(EventModelRole.ReadModelTypes).ShouldBe(EventModelProvenance.Derived);
+
+        await host.StopAsync(Token);
+    }
+
+    /// <summary>
+    ///     A store with no projections at all contributes nothing, rather than an empty model.
+    /// </summary>
+    /// <remarks>
+    ///     "This store has no projections" and "this store was never asked" are different claims, and
+    ///     an empty descriptor would make the second read as the first on a canvas.
+    /// </remarks>
+    [Fact]
+    public async Task a_store_with_no_projections_contributes_nothing()
+    {
+        await using var provider = BuildPrimary(configure: null, withProjection: false);
+
+        (await EventModelDiscovery.AssembleAsync(provider, Token)).ShouldBeEmpty();
+    }
+
+    private ServiceProvider BuildPrimary(Action<StoreOptions>? configure = null, bool withProjection = true)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddFisher(options =>
+        {
+            options.ConnectionString = _primary.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+
+            if (withProjection)
+            {
+                options.Projections.Snapshot<ModelLedger>(SnapshotLifecycle.Inline);
+            }
+
+            configure?.Invoke(options);
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private ServiceProvider BuildBothStores()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddFisher(options =>
+        {
+            options.ConnectionString = _primary.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Projections.Snapshot<ModelLedger>(SnapshotLifecycle.Inline);
+        });
+
+        services.AddFisherStore<ILedgerArchiveStore>(options =>
+        {
+            options.ConnectionString = _ancillary.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Projections.Snapshot<Manifest>(SnapshotLifecycle.Inline);
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private async Task<EventModelDescriptor> AssembleAsync(IServiceProvider provider)
+        => (await EventModelDiscovery.AssembleAsync(provider, Token)).ShouldHaveSingleItem();
+}
+
+public interface ILedgerArchiveStore : IDocumentStore;
+
+public record Credited(decimal Amount);
+
+public record Debited(decimal Amount);
+
+public record Filed(string Port);
+
+public class ModelLedger
+{
+    public Guid Id { get; set; }
+    public decimal Balance { get; set; }
+
+    public void Apply(Credited e) => Balance += e.Amount;
+
+    public void Apply(Debited e) => Balance -= e.Amount;
+}
+
+public class Manifest
+{
+    public Guid Id { get; set; }
+    public string Port { get; set; } = string.Empty;
+
+    public void Apply(Filed e) => Port = e.Port;
+}
+
+public class LedgerAudit : Fisher.Subscriptions.SubscriptionBase
+{
+    public override Task<IDaemonChangeListener> ProcessEventsAsync(EventRange page,
+        ISubscriptionController controller, IDocumentSession operations, CancellationToken cancellationToken)
+        => Task.FromResult<IDaemonChangeListener>(NullDaemonChangeListener.Instance);
+}

--- a/src/Fisher/FisherServiceCollectionExtensions.cs
+++ b/src/Fisher/FisherServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Fisher.Projections;
 using JasperFx;
 using JasperFx.Descriptors;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.EventModeling;
 using JasperFx.Events.Projections;
 using JasperFx.Events.Subscriptions;
 using Microsoft.Extensions.DependencyInjection;
@@ -82,6 +83,19 @@ public static class FisherServiceCollectionExtensions
         // though DocumentStore implements the interface, because it does so explicitly.
         services.AddSingleton<JasperFx.Events.IEventStore>(
             sp => sp.GetRequiredService<DocumentStore>());
+
+        // fisher#251 — the store-derived rung of the Event Model (jasperfx#825): one View slice per
+        // registered projection, read straight out of this store's own registry. Bobcat declares
+        // slices and Wolverine derives Command and Automation slices from its chains; nobody derived
+        // from the STORE, so a View slice — event → projection → read model — reached a canvas only
+        // when a human had written one down. The store knows it exactly.
+        //
+        // The resolver overload is the whole reason this is a store's job rather than the library's:
+        // a store registers itself under its own interface, and AddFisher is the only place that
+        // knows which. Fisher's DocumentStore implements IEventStore EXPLICITLY (fisher#45), so the
+        // cast is what reaches it — IDocumentStore does not carry the member.
+        services.AddProjectionEventModelSource(sp
+            => [(JasperFx.Events.IEventStore)sp.GetRequiredService<DocumentStore>()]);
 
         // fisher#172 — the two halves of the command-line seam, and they are genuinely two: the
         // "resources" commands and AddResourceSetupOnStartup() go through ISystemPart, while Weasel's
@@ -176,6 +190,26 @@ public static class FisherServiceCollectionExtensions
         // secondary store carries its own StoreName.
         services.AddSingleton<JasperFx.Events.IEventStore>(sp
             => (JasperFx.Events.IEventStore)UnwrapForTooling(sp.GetRequiredService<T>()));
+
+        // fisher#251 — an ancillary store's projections are View slices too, and it needs its own
+        // source because AddFisherStore<T> can be called without AddFisher at all.
+        //
+        // ⚠️ UNWRAPPED, unlike the two command-line registrations below. The marker proxy is a
+        // DispatchProxy and implements only the interfaces it was asked for, so it is NOT an
+        // IEventStore — the same reason the IEventStore registration above reaches through it. Handing
+        // the proxy over would throw at discovery time rather than silently omitting the store, which
+        // is the better of the two failures but still not one to rely on.
+        //
+        // Registered through AddEventModelSource rather than AddProjectionEventModelSource so the
+        // Subject can say WHICH store these slices came from. Same distinction FisherSystemPart<T>
+        // draws with its own subject uri, and it matters more here than on either sibling because two
+        // Fisher stores are usually two files. The MODEL NAME stays the default: slices merge by model
+        // name, and an ancillary store's read models belong on the same canvas as the primary's.
+        services.AddEventModelSource(new ProjectionEventModelSource(sp
+            => [(JasperFx.Events.IEventStore)UnwrapForTooling(sp.GetRequiredService<T>())])
+        {
+            Subject = new Uri($"event-model://projections/{typeof(T).Name.ToLowerInvariant()}")
+        });
 
         // fisher#172 — an ancillary store contributes its own database(s) to both command-line seams,
         // under a subject uri of its own. That distinction matters more here than on either sibling:


### PR DESCRIPTION
Closes #251.

`AddFisher` and `AddFisherStore<T>` each register a `ProjectionEventModelSource` (jasperfx#825, shipped in **JasperFx 2.69.0**), so every registered projection appears on an Event Model canvas as a **View slice** — event → projection → read model — with nothing written down by hand.

**Almost none of this is Fisher's, and that is the finding rather than the shortcut.** The source reads `IEventStore.TryCreateUsage()` and `SubscriptionDescriptor`, which Fisher already fills through shared code in `JasperFx.Events` — so the applied-event set cannot disagree with `AggregateDescriptor.AppliedEvents`, because the same reader feeds both. What is Fisher's is two registrations, and each has exactly one thing it can get wrong.

## The two registrations

- **The resolver overload exists because a store registers itself under its own interface**, and `AddFisher` is the only place that knows which. Fisher's `DocumentStore` implements `IEventStore` **explicitly** (#45), so the cast is what reaches it — `IDocumentStore` does not carry the member.
- ⚠️ **The ancillary registration unwraps the marker proxy, and that is load-bearing.** A `DispatchProxy` implements only the interfaces it was asked for, so an ancillary store's marker is *not* an `IEventStore` — the same reason the `IEventStore` bridge reaches through it. **Verified by handing the proxy over**: `InvalidCastException: Unable to cast object of type 'generatedProxy_1' to type 'JasperFx.Events.IEventStore'`. Better than a silent omission and still not a failure to rely on.

**Each store's source carries a `Subject` of its own** (`event-model://projections/<marker>`), which is why the ancillary one goes through `AddEventModelSource` rather than `AddProjectionEventModelSource`. Same distinction `FisherSystemPart<T>` draws for the command line (#172), and it matters more here for the same reason: two Fisher stores are usually two *files*. **The model name stays the default for both** — slices are grouped by model name before merging, and an ancillary store's read models belong on the same canvas as the primary's.

## Acceptance

| | |
|---|---|
| `AddFisher` registers the source; an ancillary store registers its own | ✅ `an_ancillary_stores_projections_reach_the_same_model`, `each_store_contributes_a_source_with_its_own_subject` |
| One single-stream projection yields one View slice with the projection, its document and every applied event, no container | ✅ `a_registered_projection_becomes_a_view_slice` — a throwaway SQLite file |
| `event-model` CLI export shows View slices with no Bobcat reference | ⚠️ **there is no `event-model` command in JasperFx 2.69.0** — covered at the seam such a command would read, `EventModelDiscovery.AssembleAsync` over a plain Fisher host, with no Bobcat reference anywhere |
| That slice merges cleanly with a declared slice of the same name | ✅ `a_derived_slice_merges_with_a_declared_slice_of_the_same_name` — the declaration carries a `Domain` the store cannot know, so the merged slice is observably richer than either half |

Seven tests, every one against a SQLite file. That is the point of jasperfx#825's acceptance naming Fisher: a store-derived Event Model that needs a Postgres or SQL Server container to demonstrate is one nobody exercises while writing the feature.

## One upstream observation, filed rather than worked around

A View slice's `ConsumedEvents` carries JasperFx's own `Archived` and `Compacted<T>`, because `AppliedEvents` is derived from `IAggregateProjection.AllEventTypes` and every aggregation projection handles those whether or not the aggregate declares an `Apply`. Nothing here is Fisher's to change; **pinned in the test rather than asserted around**, so whichever way it goes the store notices. JasperFx/jasperfx#829.

## Verification

- `dotnet test fisher.slnx` green on both TFMs — 2,086 tests.
- `scripts/check_scoreboard.py` agrees with the run (JasperFx bumped 2.68.0 → 2.69.0; compliance enrollment unchanged at 50/535 on this branch).
- `scripts/check_no_leaked_databases.py` clean.
- `npm run docs-build` clean; `docs/diagnostics.md` gains a section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)