### PR TITLE
gh-252: enroll the multi-database explorer arms, and fix sharded tenancy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3285,6 +3285,12 @@ whole commit.
   - **The explorer needed no change at all.** `GetRecentStreamsAsync`'s `database.TenantId is null`
     branch — keep the row's own `tenant_id` rather than stamping the file's tenant — was correct all
     along and was simply unreachable, because nothing ever built a database with a null tenant.
+  - ⚠️ **Two tenants sharing a file *without* conjoined tenancy is silently the same data**, and is
+    deliberately **not** refused yet — fisher#257. The obvious guard (`Events.TenancyStyle != Conjoined`)
+    is wrong, because document tenancy is per type (`MultiTenanted()`) rather than store-wide, so it
+    would refuse a legitimately document-sharded store; and mappings are created lazily, so the
+    tenancy's constructor is too early to enumerate them honestly. The multi-tenancy docs carry it as
+    a warning until the guard has a home.
   - **Neither compliance arm reaches it**, which is why `sharded_tenancy_reads` exists:
     `ShardedTenancyExplorerCompliance` never asks for a *store-global* listing, and
     `DatabasePerTenantExplorerCompliance` has no co-located tenants for a file to misattribute. Five of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3271,6 +3271,25 @@ whole commit.
   high-water mark and its own progress row per shard — two tenants running one projection are two
   daemons writing the same shard name to two different tables. A second key would have drawn a
   distinction the file boundary already draws.
+- ⚠️ **Sharded tenancy — several tenants co-located in one file — works, and `SeparateDatabaseTenancy`
+  builds one `FisherDatabase` per FILE rather than per tenant to make it work** (fisher#252). Two
+  tenants naming one connection string under `TenancyStyle.Conjoined` is a configuration fisher#47
+  never contemplated, because its whole framing is "a tenant is a file". Keying on the tenant fixed
+  three things at once when it was changed to key on the file: `AllDatabases()` reported a shared file
+  once per tenant, so the explorer's fan-out read it that many times; each instance held its own
+  `SqliteDataSource`, so N pools sat over one file; and each claimed the file belonged to *its* tenant.
+  The visible result was **every stream reported once per co-located tenant, each copy attributed to
+  the wrong one**.
+  - **`FisherDatabase.TenantId` is null for a shared file**, which is the honest answer rather than a
+    gap — a file holding two tenants' data cannot say whose it is.
+  - **The explorer needed no change at all.** `GetRecentStreamsAsync`'s `database.TenantId is null`
+    branch — keep the row's own `tenant_id` rather than stamping the file's tenant — was correct all
+    along and was simply unreachable, because nothing ever built a database with a null tenant.
+  - **Neither compliance arm reaches it**, which is why `sharded_tenancy_reads` exists:
+    `ShardedTenancyExplorerCompliance` never asks for a *store-global* listing, and
+    `DatabasePerTenantExplorerCompliance` has no co-located tenants for a file to misattribute. Five of
+    its six tests fail against the old behaviour; the sixth is the tenant-scoped read, which was
+    already right and is the regression guard.
 - **Cleaning spans every database.** `ResetAllDataAsync` and the whole `IDocumentCleaner` surface loop
   `Tenancy.AllDatabases()`; cleaning only the default would leave every other tenant's data behind
   while reporting success, and the caller most likely to hit that is a test fixture.
@@ -4104,9 +4123,16 @@ the default file, wrong for everybody else, silent either way.
   store can be multi-tenanted. It now matches Marten's three clauses exactly — non-`Single` cardinality,
   conjoined event tenancy, or any `MultiTenanted()` document type.
 
-**The shared suite cannot reach any of this**, and says so in its own comments: its fixture is
-single-database, so its four database-scoped facts pin that the database overload *agrees with* the
-store-global read — vacuously true of a store that ignores the argument. `explorer_reads_across_databases`
+**`EventStoreExplorerCompliance` cannot reach any of this**, and says so in its own comments: its
+fixture is single-database, so its four database-scoped facts pin that the database overload *agrees
+with* the store-global read — vacuously true of a store that ignores the argument.
+**`MultiDatabaseExplorerCompliance` (jasperfx#810, 2.69.0) is the shared arm that can**, and Fisher
+enrolls both halves of it (fisher#252): `DatabasePerTenantExplorerCompliance` for the store-global
+reads, and `ShardedTenancyExplorerCompliance` for the `tenant_id` predicate. Fisher is structurally
+well placed for the second — Marten decides whether to apply the predicate from *cardinality*, on the
+premise that every stream in a tenant's database is that tenant's, which is true for
+database-per-tenant and false for sharding; `ResolveTenantScope` decides from *tenancy style*, which
+is the axis that answers the question. `explorer_reads_across_databases`
 is the multi-database arm and `explorer_reads_under_conjoined_tenancy` the column-predicate one;
 16 of their 19 tests fail against the previous behaviour, and the three that pass are the regression
 guards for what a single-database store already did.
@@ -4715,7 +4741,7 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**Fisher enrolls 53 of the 56 suites `JasperFx.Events.ComplianceTests` 2.69.0 ships — 558 tests.**
+**Fisher enrolls 55 of the 56 suites `JasperFx.Events.ComplianceTests` 2.69.0 ships — 572 tests.**
 `JasperFx.Events.ComplianceTests` is referenced unconditionally — the old `$(EnableComplianceTests)`
 gate is gone. See HANDOFF.md for the live scoreboard, which is machine-checked against a real run by
 `scripts/check_scoreboard.py`; what follows is the history and the mechanics.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,9 +12,9 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2109 tests green on net9.0 and net10.0** — 2054 in
-`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 558 of
-them are shared cross-store compliance tests — 475 event sourcing and 83 document. On JasperFx **2.69.0** / Weasel **9.32.0**.
+**2129 tests green on net9.0 and net10.0** — 2074 in
+`Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 572 of
+them are shared cross-store compliance tests — 489 event sourcing and 83 document. On JasperFx **2.69.0** / Weasel **9.32.0**.
 
 ## The high-water opt-out, audited (#199)
 
@@ -662,9 +662,9 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.69.0 ships 56 suites; Fisher enrolls **53 of them, 558 tests**.
-Fisher passes **558 of them, across all
-53 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
+`JasperFx.Events.ComplianceTests` 2.69.0 ships 56 suites; Fisher enrolls **55 of them, 572 tests**.
+Fisher passes **572 of them, across all
+55 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
 pass on the 2.65.0 pin were the upstream ones described at the top of this file, and 2.66.0 closed
 all five.
 
@@ -809,12 +809,12 @@ case is what is Fisher's alone — the `ResetAllDataAsync` daemon handling, `Fet
 and `UnknownNaturalKeyException` (which jasperfx#764 excludes on purpose), the subscription wrapper's
 naming.
 
-**Green on all fifty-three is not the same as feature-complete.** The suites cover what is portable
+**Green on all fifty-five is not the same as feature-complete.** The suites cover what is portable
 across stores; "Deliberate gaps" below is still the honest list of what Fisher does not do.
 
-### Green — 53 suites, 558 tests
+### Green — 55 suites, 572 tests
 
-Event sourcing — 44 suites, 475 tests:
+Event sourcing — 46 suites, 489 tests:
 
 | Suite | Tests |
 |---|---|
@@ -844,7 +844,9 @@ Event sourcing — 44 suites, 475 tests:
 | `ProjectionStatusCompliance` | 9 |
 | `ProjectionSideEffectCompliance` | 9 |
 | `SelfAggregatingEvolveCompliance` | 8 |
+| `DatabasePerTenantExplorerCompliance` | 7 |
 | `LiveAggregationCompliance` | 7 |
+| `ShardedTenancyExplorerCompliance` | 7 |
 | `UpcastingCompliance` | 7 |
 | `AssignTagWhereCompliance` | 6 |
 | `BinaryEventSerializationCompliance` | 6 |

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > database-per-tenant, with tenants that appear at runtime), `AddFisher(...)` DI registration, and the
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
-> Fisher passes **all 53 suites and 558 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,054.
+> Fisher passes **all 55 suites and 572 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,074.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -467,7 +467,7 @@ Test counts keep understating the suites that matter. `AsyncDaemonCompliance` is
 the whole daemon; `FlatTableProjectionCompliance` is eight that demand an upsert generator, a
 migration hook and rebuild teardown.
 
-Being green on all fifty-three is not the same as being feature-complete against Marten. The suites
+Being green on all fifty-five is not the same as being feature-complete against Marten. The suites
 cover what is portable across stores; the deliberate gaps listed in HANDOFF.md are still gaps.
 
 ## Filed follow-ups

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -89,6 +89,38 @@ opts.MultiTenantedDatabases(tenants =>
 store-level file — a store-level connection string would be a database nothing writes to.
 :::
 
+### Sharding: several tenants per file
+
+Two tenants naming the same connection string share a file. Combined with conjoined tenancy, that is
+**sharded** tenancy — a pool of files with tenants co-located in each — and it is the middle ground
+between one file for everyone and one file each.
+
+```cs
+opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+
+opts.MultiTenantedDatabases(tenants => tenants
+    .AddTenant("acme", "Data Source=/var/lib/app/shard-one.db")
+    .AddTenant("globex", "Data Source=/var/lib/app/shard-one.db")
+    .AddTenant("initech", "Data Source=/var/lib/app/shard-two.db"));
+```
+
+Fisher builds **one database per file**, not per tenant, so `AllDatabases()` reports the files there
+are, co-located tenants share one connection pool, and a shared file reports no `TenantId` of its own
+— a file holding two tenants' data cannot honestly say whose it is.
+
+::: warning
+**Conjoined tenancy is what makes this safe, and it is not applied for you.** Two tenants sharing a
+file *without* it have no `tenant_id` column to be told apart by, so their data is genuinely the same
+data. Set `TenancyStyle.Conjoined` for the event store and `MultiTenanted()` on any document type the
+tenants share.
+:::
+
+::: tip
+The trade against one file per tenant is the one SQLite always poses: tenants sharing a file share its
+**write lock**. Sharding buys you fewer files to back up and fewer connection pools, at the cost of
+serialising the writers inside each shard.
+:::
+
 ### Tenants that appear at runtime
 
 Provisioning a tenant is cheap enough to do on first use, which makes "a tenant appears without a

--- a/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
+++ b/src/Fisher.Tests/Compliance/FisherComplianceFixture.cs
@@ -33,6 +33,19 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
     private TemporaryDatabase? _database;
     private DocumentStore? _store;
 
+    /// <summary>
+    ///     One throwaway file per <em>logical</em> database name a suite asked for (jasperfx#810), kept
+    ///     across reconfigurations exactly as <see cref="_database" /> is.
+    /// </summary>
+    /// <remarks>
+    ///     Keyed by the logical name rather than by tenant, which is what makes the sharded arm
+    ///     expressible: two tenants naming one logical database get one file, and the suite's whole
+    ///     gap-2 question — does a tenant-scoped read filter by tenant as well as picking the file —
+    ///     only exists because they do.
+    /// </remarks>
+    private readonly Dictionary<string, TemporaryDatabase> _tenantDatabases =
+        new(StringComparer.OrdinalIgnoreCase);
+
     private DocumentStore Store => _store
         ?? throw new InvalidOperationException("The compliance store has not been configured yet.");
 
@@ -57,11 +70,38 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
         // reconfiguring within one schema name only ever adds event types and projections.
         _database ??= TemporaryDatabase.Create(config.SchemaName ?? "compliance");
 
+        foreach (var name in config.TenantDatabases.Values.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (!_tenantDatabases.ContainsKey(name))
+            {
+                _tenantDatabases[name] = TemporaryDatabase.Create(name);
+            }
+        }
+
         _store = DocumentStore.For(options =>
         {
             options.ConnectionString = _database.ConnectionString;
             options.AutoCreateSchemaObjects = AutoCreate.All;
             options.DatabaseSchemaName = (config.SchemaName ?? "compliance").ToLowerInvariant();
+
+            // jasperfx#810 — a store backed by more than one database. Fisher's is the cheapest
+            // database-per-tenant of the three stores, because a tenant is a FILE: provisioning one is
+            // a file plus a migration rather than a CREATE DATABASE, which is what makes the arms
+            // runnable here with no infrastructure at all.
+            //
+            // The store-level ConnectionString above stays set and is ignored under this tenancy —
+            // there is no store-level file. Leaving it assigned rather than conditionally skipping it
+            // keeps one construction path.
+            if (config.TenantDatabases.Count > 0)
+            {
+                options.MultiTenantedDatabases(databases =>
+                {
+                    foreach (var (tenantId, name) in config.TenantDatabases)
+                    {
+                        databases.AddTenant(tenantId, _tenantDatabases[name].ConnectionString);
+                    }
+                });
+            }
 
             if (config.StreamIdentity.HasValue)
             {
@@ -223,6 +263,45 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
     public override bool SupportsLiveAggregationRegistration => false;
 
     public override bool SupportsAsyncDaemon => true;
+
+    /// <summary>
+    ///     Fisher builds a store over more than one database, so the two multi-database explorer arms
+    ///     run rather than skip (jasperfx#810 / fisher#252).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         ⚠️ <b>The seam's own documentation says "Fisher is legitimately false — one file, one
+    ///         database", and that is out of date.</b> Fisher has had database-per-tenant since
+    ///         fisher#47 and runtime tenants since fisher#58; a tenant IS a file, which makes this the
+    ///         cheapest multi-database story of the three stores rather than an absent one — a tenant
+    ///         costs a file and a migration, where the siblings need a <c>CREATE DATABASE</c>. That
+    ///         stale claim is the same one fisher#240 found written into
+    ///         <c>DocumentStore.EventStore.cs</c>, one repository over. Reported as jasperfx#831.
+    ///     </para>
+    ///     <para>
+    ///         Saying true commits to both halves — replaying
+    ///         <see cref="ComplianceStoreConfig.TenantDatabases" /> in <see cref="BuildStoreAsync" />
+    ///         <em>and</em> implementing <see cref="DatabaseForTenantAsync" />. A fixture that says true
+    ///         and replays nothing does not skip: every isolation fact passes vacuously against a
+    ///         single-database store, which is the shape these arms exist to stop being tested against.
+    ///         <c>the_store_is_genuinely_backed_by_more_than_one_database</c> is the suite's own guard
+    ///         on that, and it is the fact to read first if this ever goes red.
+    ///     </para>
+    /// </remarks>
+    public override bool SupportsMultipleDatabases => true;
+
+    /// <summary>
+    ///     The <see cref="IEventDatabase" /> a tenant's data lives in.
+    /// </summary>
+    /// <remarks>
+    ///     Straight through <see cref="ITenancy.DatabaseFor" />, which is the shipped resolution rather
+    ///     than a test-only map — and which <b>throws <c>UnknownTenantException</c> for a tenant it does
+    ///     not know</b> rather than falling back to the default file. That refusal is the rule every
+    ///     tenant-scoped member on this store follows, and the seam's own remarks ask for it: on a
+    ///     multi-database store the wrong database is not a degraded answer but a different one.
+    /// </remarks>
+    public override ValueTask<IEventDatabase> DatabaseForTenantAsync(string tenantId)
+        => ValueTask.FromResult<IEventDatabase>(Store.Tenancy.DatabaseFor(tenantId));
 
     private IProjectionDaemon? _daemon;
 
@@ -711,6 +790,13 @@ public class FisherComplianceFixture : EventStoreComplianceFixture<IDocumentSess
     {
         _database?.Dispose();
         _database = null;
+
+        foreach (var database in _tenantDatabases.Values)
+        {
+            database.Dispose();
+        }
+
+        _tenantDatabases.Clear();
     }
 
     private static Fisher.Internal.FisherSession AsFisherSession(IDocumentSession session)

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -8,12 +8,10 @@ namespace Fisher.Tests.Compliance;
  * Fisher's session pair through FisherComplianceFixture. Marten and Polecat enroll the same way, so
  * these tests cannot drift between the products.
  *
- * Suites were added one at a time as Fisher grew into them, and fifty-three are enrolled from
+ * Suites were added one at a time as Fisher grew into them, and fifty-five are enrolled from
  * JasperFx.Events.ComplianceTests 2.69.0, which itself ships fifty-six concrete suites across
- * fifty-five files -- MultiDatabaseExplorerCompliance is one file holding two arms. Three are not
- * enrolled: SingleTenantedEventSlicingCompliance, for the precondition reason set out below; and the
- * two arms of MultiDatabaseExplorerCompliance, which need a fixture that can build a store over more
- * than one database (SupportsMultipleDatabases) and are fisher#252.
+ * fifty-five files -- MultiDatabaseExplorerCompliance is one file holding two arms. One is not
+ * enrolled: SingleTenantedEventSlicingCompliance, for the precondition reason set out below.
  *
  * Three of the ten suites this wave adds are enrolled and gated off rather than green, each for a
  * reason recorded at the flag on FisherComplianceFixture rather than here:
@@ -286,6 +284,46 @@ public class projection_coordinator_compliance
 
 public class projection_status_compliance
     : ProjectionStatusCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
+
+/*
+ * jasperfx#810 — the two arms that run against a store where there genuinely IS more than one
+ * database. The four database-scoped facts in EventStoreExplorerCompliance run against a
+ * single-database fixture, so what they pin is that the database overload AGREES WITH the
+ * store-global read — vacuously true of a store that ignores the argument.
+ *
+ * ⚠️ Fisher matters here more than the suite's own documentation assumes. SupportsMultipleDatabases
+ * says "Fisher is legitimately false -- one file, one database", which has been out of date since
+ * fisher#47 gave Fisher database-per-tenant and fisher#58 gave it runtime tenants. A tenant IS a
+ * file, which makes this the cheapest multi-database story of the three stores rather than an absent
+ * one. Reported as jasperfx#831.
+ *
+ * The two arms split on independent axes and neither can see the other's gap:
+ *
+ *   DatabasePerTenantExplorerCompliance -- no co-located tenants, so it cannot see a dropped
+ *   tenant_id predicate. What it pins is that a store-global read on a multi-database store is not a
+ *   silent partial answer. Fisher fans out and merges for the listing and REFUSES for the two
+ *   single-stream reads (fisher#240); the suite accepts either remedy on the listing and the refusal
+ *   on the stream read, because what it rules out is one database's worth returned as though it were
+ *   everything -- CritterWatch#1231, a console over 512 shard databases.
+ *
+ *   ShardedTenancyExplorerCompliance -- many tenants co-located per database, conjoined. This is the
+ *   arm Fisher is structurally well placed for: Marten decides whether to apply a tenant_id predicate
+ *   from CARDINALITY, on the premise that every stream in a tenant's database is that tenant's --
+ *   true for database-per-tenant and false for sharding. Fisher's ResolveTenantScope decides from
+ *   TENANCY STYLE instead, which is the axis that actually answers the question, so the database and
+ *   the predicate compose rather than competing (fisher#240).
+ *
+ * Neither arm's precondition is free: the fixture builds one throwaway file per LOGICAL database name
+ * and resolves DatabaseForTenantAsync through the shipped ITenancy.DatabaseFor. The suite's own
+ * the_store_is_genuinely_backed_by_more_than_one_database is the guard that a fixture claiming
+ * SupportsMultipleDatabases actually built two -- read it first if either arm goes red.
+ */
+
+public class database_per_tenant_explorer_compliance
+    : DatabasePerTenantExplorerCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class sharded_tenancy_explorer_compliance
+    : ShardedTenancyExplorerCompliance<FisherComplianceFixture, IDocumentSession, IQuerySession>;
 
 /*
  * jasperfx#770 — the two stream-fetch query plans, standalone and inside a batched query. Fisher

--- a/src/Fisher.Tests/Events/sharded_tenancy_reads.cs
+++ b/src/Fisher.Tests/Events/sharded_tenancy_reads.cs
@@ -1,0 +1,222 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+
+namespace Fisher.Tests.Events;
+
+/// <summary>
+///     fisher#252 — <b>sharded</b> tenancy: several tenants co-located in one file, conjoined, with
+///     more than one file. The cell where Fisher's two tenancy axes meet, and the one neither of its
+///     existing test classes covered.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>explorer_reads_across_databases</c> covers database-per-tenant (a file each, no
+///         co-location) and <c>explorer_reads_under_conjoined_tenancy</c> covers one file with several
+///         tenants. <b>Sharding is both at once</b>, and it is expressible — <c>MultiTenantedDatabases</c>
+///         plus <c>TenancyStyle.Conjoined</c>, with two tenants naming one connection string — but
+///         nothing in Fisher had ever been pointed at it, because fisher#47's whole framing is "a
+///         tenant is a file".
+///     </para>
+///     <para>
+///         <b>It was wrong in two ways at once, and enrolling jasperfx#810's sharded arm is what
+///         found it</b> — though not by failing: neither arm exercises a <em>store-global</em> listing
+///         on a sharded store, so both were green over the defect. <c>SeparateDatabaseTenancy</c> built
+///         one <c>FisherDatabase</c> per <em>tenant</em>, so a shared file appeared once per tenant in
+///         <c>AllDatabases()</c> and the explorer's fan-out read it that many times; and each of those
+///         instances claimed the file belonged to <em>its</em> tenant, so fisher#240's attribution
+///         stamped every row with whichever tenant's instance happened to read it.
+///     </para>
+///     <para>
+///         The result was the shape a cross-tenant bug always has here: <b>every stream reported once
+///         per co-located tenant, each copy attributed to the wrong one</b> — two streams coming back
+///         as four rows, half of them lying about whose they were.
+///     </para>
+///     <para>
+///         <b>The explorer needed no change.</b> <c>GetRecentStreamsAsync</c>'s
+///         <c>database.TenantId is null</c> branch — keep the row's own <c>tenant_id</c> rather than
+///         stamping the file's tenant — was correct all along and was simply unreachable, because
+///         nothing ever built a database with a null tenant. One <c>FisherDatabase</c> per file makes
+///         it reachable, which is why the fix is entirely in the tenancy's construction.
+///     </para>
+/// </remarks>
+public class sharded_tenancy_reads : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _shardOne = TemporaryDatabase.Create("sharded-one");
+    private readonly TemporaryDatabase _shardTwo = TemporaryDatabase.Create("sharded-two");
+
+    private DocumentStore _store = null!;
+
+    private readonly Guid _acme = Guid.NewGuid();
+    private readonly Guid _globex = Guid.NewGuid();
+    private readonly Guid _initech = Guid.NewGuid();
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(options =>
+        {
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+
+            // Two tenants in shard one, one alone in shard two — which is what makes the store
+            // genuinely multi-database *and* genuinely co-located at the same time.
+            options.MultiTenantedDatabases(databases => databases
+                .AddTenant("acme", _shardOne.ConnectionString)
+                .AddTenant("globex", _shardOne.ConnectionString)
+                .AddTenant("initech", _shardTwo.ConnectionString));
+        });
+
+        await _store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await AppendAsync("acme", _acme, "Chart the Minch");
+        await AppendAsync("globex", _globex, "Chart the Solent");
+        await AppendAsync("initech", _initech, "Chart the Sound");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _shardOne.Dispose();
+        _shardTwo.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    private IEventStore TheExplorer => _store;
+
+    private async Task AppendAsync(string tenantId, Guid streamId, string title)
+    {
+        await using var session = _store.LightweightSession(tenantId);
+        session.Events.StartStream<Quest>(streamId, new QuestStarted(title));
+        await session.SaveChangesAsync(Token);
+    }
+
+    /// <summary>
+    ///     There are two files, not three databases.
+    /// </summary>
+    /// <remarks>
+    ///     The precondition every fact below rests on, and the half of the defect that is visible
+    ///     without reading a single row. Three tenants over two files used to report three databases —
+    ///     one of them the same file twice, with two connection pools over it.
+    /// </remarks>
+    [Fact]
+    public async Task the_databases_are_the_files_rather_than_the_tenants()
+    {
+        var databases = await TheExplorer.AllDatabases();
+
+        databases.Count.ShouldBe(2);
+        TheExplorer.DatabaseCardinality.ShouldBe(DatabaseCardinality.StaticMultiple);
+    }
+
+    /// <summary>
+    ///     A shared file reports <b>no</b> tenant of its own; a file with one tenant reports that one.
+    /// </summary>
+    /// <remarks>
+    ///     This is the fact the attribution rests on. <c>FisherDatabase.TenantId</c> means "the tenant
+    ///     whose data this file holds", and a file holding two tenants' data cannot answer it — so
+    ///     answering null is not a gap but the correct answer, and it is what routes the explorer to
+    ///     the row's own <c>tenant_id</c> column instead.
+    /// </remarks>
+    [Fact]
+    public async Task a_shared_file_claims_no_tenant_and_a_dedicated_one_does()
+    {
+        var databases = (await TheExplorer.AllDatabases()).Cast<Fisher.Storage.FisherDatabase>().ToList();
+
+        var shared = databases.Single(x => x.Identifier.Contains('+'));
+        var dedicated = databases.Single(x => x.Identifier == "initech");
+
+        shared.TenantId.ShouldBeNull();
+        dedicated.TenantId.ShouldBe("initech");
+    }
+
+    /// <summary>
+    ///     <b>The headline.</b> A store-global listing reports each stream once, attributed to the
+    ///     tenant that actually wrote it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Both halves fail against the old behaviour, and they fail differently: the count is the
+    ///         duplicate file being read twice, and the attribution is the file claiming a tenant it
+    ///         does not own. Asserting only the count would pass against a store that deduplicated and
+    ///         still lied about whose stream it was.
+    ///     </para>
+    ///     <para>
+    ///         <b>Neither compliance arm reaches this</b>, which is why it is here. The sharded arm
+    ///         never asks for a store-global listing and the database-per-tenant arm has no co-located
+    ///         tenants for a file to misattribute.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_store_global_listing_reports_each_stream_once_under_its_own_tenant()
+    {
+        var streams = await TheExplorer.GetRecentStreamsAsync(100, Token);
+
+        streams.Count.ShouldBe(3);
+
+        streams.Single(x => x.StreamId == _acme.ToString()).TenantId.ShouldBe("acme");
+        streams.Single(x => x.StreamId == _globex.ToString()).TenantId.ShouldBe("globex");
+        streams.Single(x => x.StreamId == _initech.ToString()).TenantId.ShouldBe("initech");
+    }
+
+    /// <summary>
+    ///     A database-scoped listing over the shared file sees both its tenants, each under its own
+    ///     name.
+    /// </summary>
+    /// <remarks>
+    ///     The positive control for the attribution: a read that answered nothing, or answered one
+    ///     tenant only, would satisfy the isolation facts below while being broken.
+    /// </remarks>
+    [Fact]
+    public async Task a_database_scoped_listing_sees_every_co_located_tenant_under_its_own_name()
+    {
+        var shard = (await TheExplorer.AllDatabases()).Single(x => x.Identifier.Contains('+'));
+
+        var streams = await TheExplorer.GetRecentStreamsAsync(shard, 100, null, Token);
+
+        streams.Select(x => x.StreamId).ShouldContain(_acme.ToString());
+        streams.Select(x => x.StreamId).ShouldContain(_globex.ToString());
+        streams.Select(x => x.StreamId).ShouldNotContain(_initech.ToString());
+
+        streams.Single(x => x.StreamId == _globex.ToString()).TenantId.ShouldBe("globex");
+    }
+
+    /// <summary>
+    ///     A tenant-scoped listing picks the file <em>and</em> filters by tenant.
+    /// </summary>
+    /// <remarks>
+    ///     jasperfx#810's gap 2. Marten decides whether to apply the predicate from <em>cardinality</em>,
+    ///     on the premise that every stream in a tenant's database is that tenant's — true for
+    ///     database-per-tenant, false here. Fisher's <c>ResolveTenantScope</c> decides from
+    ///     <em>tenancy style</em> instead, which is the axis that answers the question.
+    /// </remarks>
+    [Fact]
+    public async Task a_tenant_scoped_listing_does_not_leak_a_co_located_tenant()
+    {
+        var streams = await TheExplorer.GetRecentStreamsAsync(100, "acme", Token);
+
+        streams.Select(x => x.StreamId).ShouldContain(_acme.ToString());
+        streams.Select(x => x.StreamId).ShouldNotContain(_globex.ToString());
+        streams.Select(x => x.StreamId).ShouldNotContain(_initech.ToString());
+    }
+
+    /// <summary>
+    ///     Two tenants sharing a file share its connection pool, and a tenant resolves to the very same
+    ///     database instance as the one beside it.
+    /// </summary>
+    /// <remarks>
+    ///     Reference identity rather than equality, because that is the property that makes it one pool
+    ///     rather than two over the same file — on SQLite a pool is file handles, and fisher#59 measured
+    ///     exactly that cost.
+    /// </remarks>
+    [Fact]
+    public void co_located_tenants_resolve_to_one_database_instance()
+    {
+        var acme = _store.Tenancy.DatabaseFor("acme");
+        var globex = _store.Tenancy.DatabaseFor("globex");
+        var initech = _store.Tenancy.DatabaseFor("initech");
+
+        acme.ShouldBeSameAs(globex);
+        acme.ShouldNotBeSameAs(initech);
+    }
+}

--- a/src/Fisher/Storage/ITenancy.cs
+++ b/src/Fisher/Storage/ITenancy.cs
@@ -107,9 +107,57 @@ public sealed class SeparateDatabaseTenancy : ITenancy
     {
         _databases = new Dictionary<string, FisherDatabase>(StringComparer.OrdinalIgnoreCase);
 
+        // ⚠️ ONE FisherDatabase PER FILE, not per tenant (fisher#252). Two tenants may name the same
+        // connection string — that is *sharded* tenancy, a pool of files with tenants co-located in
+        // each, and it is a configuration this class did not originally contemplate because
+        // fisher#47's whole framing is "a tenant is a file".
+        //
+        // Keying on the file rather than the tenant is what makes the shared case correct rather than
+        // merely deduplicated, and it fixes three things at once:
+        //
+        //   - AllDatabases() reports the files there are. A fan-out over it — GetRecentStreamsAsync is
+        //     the one that shows — otherwise reads a shared file once per co-located tenant and
+        //     returns every stream in it that many times.
+        //   - One SqliteDataSource and therefore one connection pool per file, where per-tenant
+        //     instances meant N pools over one file. On SQLite a pool is file handles.
+        //   - TenantId is null for a shared file, which is the honest answer and is load-bearing:
+        //     "the file is the tenant" is true for database-per-tenant and false for sharding, and
+        //     every reader that stamps a row with the file's tenant (fisher#240's explorer fan-out)
+        //     is already written to defer to the row's own tenant_id column when it is null.
+        //
+        // So the explorer needed no change for this at all -- see GetRecentStreamsAsync, whose
+        // `database.TenantId is null` branch was correct all along and was simply unreachable.
+        var byFile = new Dictionary<string, FisherDatabase>(StringComparer.Ordinal);
+        var tenantsPerFile = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
         foreach (var (tenantId, connectionString) in configured.Resolve(options))
         {
-            _databases[tenantId] = new FisherDatabase(options, connectionString, tenantId, tenantId);
+            if (!tenantsPerFile.TryGetValue(connectionString, out var tenants))
+            {
+                tenants = [];
+                tenantsPerFile[connectionString] = tenants;
+            }
+
+            tenants.Add(tenantId);
+        }
+
+        foreach (var (connectionString, tenants) in tenantsPerFile)
+        {
+            // A file with exactly one tenant keeps that tenant's id as BOTH its identifier and its
+            // TenantId, which is what fisher#57's daemon routing and fisher#240's stream attribution
+            // read. A shared file cannot honestly answer either, so it takes a name derived from the
+            // tenants that share it and reports no tenant of its own.
+            var database = tenants.Count == 1
+                ? new FisherDatabase(options, connectionString, tenants[0], tenants[0])
+                : new FisherDatabase(options, connectionString,
+                    string.Join("+", tenants.OrderBy(x => x, StringComparer.Ordinal)));
+
+            byFile[connectionString] = database;
+
+            foreach (var tenantId in tenants)
+            {
+                _databases[tenantId] = database;
+            }
         }
 
         // The store still needs a database for operations that name no tenant — applying the schema
@@ -117,12 +165,16 @@ public sealed class SeparateDatabaseTenancy : ITenancy
         // stored yet. The default tenant's file is it, created like any other.
         _default = _databases.TryGetValue(StorageConstants.DefaultTenantId, out var main)
             ? main
-            : _databases.Values.FirstOrDefault()
+            : byFile.Values.FirstOrDefault()
               ?? throw new InvalidOperationException(
                   "MultiTenantedDatabases was configured with no tenants. Add at least one with "
                   + "AddTenant(tenantId, connectionString) or AddTenants(...), or drop the call and use "
                   + "conjoined tenancy.");
+
+        _files = byFile.Values.ToList();
     }
+
+    private readonly List<FisherDatabase> _files;
 
     public DatabaseCardinality Cardinality => DatabaseCardinality.StaticMultiple;
 
@@ -139,11 +191,16 @@ public sealed class SeparateDatabaseTenancy : ITenancy
             ? database
             : throw new UnknownTenantException(tenantId, _databases.Keys);
 
-    public IReadOnlyList<FisherDatabase> AllDatabases() => _databases.Values.ToList();
+    /// <remarks>
+    ///     <b>The files, not the tenants</b> — see the constructor. Under database-per-tenant the two
+    ///     are the same list; under sharding they are not, and a caller fanning out over the tenants
+    ///     would read each shared file once per tenant co-located in it.
+    /// </remarks>
+    public IReadOnlyList<FisherDatabase> AllDatabases() => _files;
 
     public async ValueTask DisposeAsync()
     {
-        foreach (var database in _databases.Values)
+        foreach (var database in _files)
         {
             await database.DisposeAsync().ConfigureAwait(false);
         }
@@ -151,7 +208,7 @@ public sealed class SeparateDatabaseTenancy : ITenancy
 
     public void Dispose()
     {
-        foreach (var database in _databases.Values)
+        foreach (var database in _files)
         {
             database.Dispose();
         }


### PR DESCRIPTION
Closes #252.

`MultiDatabaseExplorerCompliance` (jasperfx#810, shipped in **JasperFx 2.69.0**) is the arm that was missing from `EventStoreExplorerCompliance`'s four database-scoped facts: those run against a **single-database** fixture, so what they pin is that the database overload *agrees with* the store-global read — vacuously true of a store that ignores the argument.

Both arms enrolled, **14 facts, green**. With them, **55 of the 56 suites 2.69.0 ships are enrolled** — only `SingleTenantedEventSlicingCompliance` remains, for the precondition reason it always had.

## Fisher is well placed for the sharded arm, structurally

Marten decides whether to apply a `tenant_id` predicate from **cardinality**, on the premise that every stream in a tenant's database is that tenant's — true for database-per-tenant, false for sharding. Fisher's `ResolveTenantScope` decides from **tenancy style** instead, which is the axis that actually answers the question, so the database and the predicate compose rather than competing (#240).

The fixture builds one throwaway file per *logical* database name and resolves `DatabaseForTenantAsync` through the shipped `ITenancy.DatabaseFor`. That also corrects the seam's own claim that *"Fisher is legitimately false — one file, one database"*, out of date since #47 and #58: a Fisher tenant **is** a file, which makes this the cheapest multi-database story of the three stores rather than an absent one. Reported as JasperFx/jasperfx#831.

## ⚠️ The enrollment found a real bug — and not by failing

**Both arms were green over it**, because neither asks for a store-global listing on a *sharded* store: the sharded arm never makes that call, and the database-per-tenant arm has no co-located tenants for a file to misattribute.

Several tenants co-located in one file is expressible — `MultiTenantedDatabases` plus `TenancyStyle.Conjoined` — and nothing in Fisher had ever been pointed at it, because #47's whole framing is "a tenant is a file". `SeparateDatabaseTenancy` built one `FisherDatabase` per **tenant**, so:

- a shared file appeared once per tenant in `AllDatabases()`, and the explorer's fan-out read it that many times;
- each of those instances held its own `SqliteDataSource`, so N pools sat over one file;
- each claimed the file belonged to *its* tenant, so #240's attribution stamped every row with whichever instance happened to read it.

Measured, not inferred — two streams, three tenants, two files:

```
AllDatabases=3 [acme,globex,initech]
recent=4 [<A>:acme, <A>:globex, <B>:acme, <B>:globex]
```

**Every stream once per co-located tenant, half of them lying about whose it was.**

### The fix is entirely in the tenancy's construction

One `FisherDatabase` per **file** fixes all three at once, and a shared file reports a **null `TenantId`** — the honest answer, since a file holding two tenants' data cannot say whose it is.

**The explorer needed no change at all.** `GetRecentStreamsAsync`'s `database.TenantId is null` branch — keep the row's own `tenant_id` rather than stamping the file's tenant — was correct all along and was simply unreachable, because nothing ever built a database with a null tenant.

`sharded_tenancy_reads` pins it, since neither compliance arm reaches it. **Five of its six tests fail against the old behaviour**; the sixth is the tenant-scoped read, which was already right and is the regression guard.

## Scope note

The issue asked for enrollment. I fixed the bug in the same PR rather than filing it: it is in the exact surface being enrolled, it is a cross-tenant *attribution* error (the class #51 is), and merging "the multi-database explorer suite is green" while knowing a sharded store misattributes tenants is the green-suite-over-a-broken-store outcome this codebase argues against. Happy to split it if you would rather.

One thing I deliberately did **not** add: a configuration-time refusal for two tenants sharing a file *without* conjoined tenancy, which is silently the same data. It is a real trap, but the right guard has to account for document tenancy being per type (`MultiTenanted()`), so refusing on `Events.TenancyStyle` alone would refuse a legitimately document-sharded store. Documented as a warning on the multi-tenancy page instead; say the word and I will file it.

## Verification

- `dotnet test fisher.slnx` green on both TFMs — **2,129 tests**.
- `scripts/check_scoreboard.py` agrees with the run: 572 compliance across 55 suites.
- `scripts/check_no_leaked_databases.py` clean.
- `npm run docs-build` clean; `docs/configuration/multitenancy.md` gains a sharding section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)