### PR TITLE
gh-257: refuse a shared file that cannot tell its tenants apart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3285,12 +3285,33 @@ whole commit.
   - **The explorer needed no change at all.** `GetRecentStreamsAsync`'s `database.TenantId is null`
     branch — keep the row's own `tenant_id` rather than stamping the file's tenant — was correct all
     along and was simply unreachable, because nothing ever built a database with a null tenant.
-  - ⚠️ **Two tenants sharing a file *without* conjoined tenancy is silently the same data**, and is
-    deliberately **not** refused yet — fisher#257. The obvious guard (`Events.TenancyStyle != Conjoined`)
-    is wrong, because document tenancy is per type (`MultiTenanted()`) rather than store-wide, so it
-    would refuse a legitimately document-sharded store; and mappings are created lazily, so the
-    tenancy's constructor is too early to enumerate them honestly. The multi-tenancy docs carry it as
-    a warning until the guard has a home.
+  - ⚠️ **Two tenants sharing a file *without* conjoined tenancy is silently the same data, and is
+    refused** — `SharedFileTenancyGuard` (fisher#257). A shared file requires conjoined event tenancy
+    **and** `MultiTenanted()` on every document type; the trap is silent in the fisher#51 direction,
+    where the tenant owning most of the data sees a correct-looking answer with extras. Same rule as
+    fisher#46's refusal of two stores over one file with one schema name, a layer down.
+    - ⚠️ **Conjoined event tenancy is required even for a store that never appends an event**, and
+      that is a decision. The conditional rule cannot be decided honestly: the event tables are
+      created by every migration whether anything writes to them or not, and an append does not need
+      its event type registered — so "does this store use events" has no reliable answer at
+      configuration time, and a rule that guessed would refuse some safe stores and admit some unsafe
+      ones. `a_documents_only_store_still_has_to_say_conjoined` pins it as a decision rather than
+      leaving it to read as over-reach.
+    - **Two checkpoints, because one cannot be complete.** `DocumentStore`'s constructor covers
+      everything registered at configuration time — beside `AssertEveryMappingHasIdentity`, and for
+      its reason: that is the first moment the configuration is final. A document mapping created
+      lazily is invisible there, so the guard runs again where such a type's table is provisioned, on
+      both the write and the read path (fisher#74's two entry points). Removing either checkpoint
+      fails tests — two for the second, three for the first.
+    - ⚠️ **The check cannot live in `DocumentSchema.MappingFor`**, which is the placement that
+      suggests itself. `Schema.For<T>().MultiTenanted()` creates the mapping and *then* sets the flag,
+      so a refusal at creation fires before the line that satisfies it could run — the trap fisher#218
+      moved `AssertEveryMappingHasIdentity` out of `DocumentMapping`'s constructor for.
+    - **`ITenancy.SharedFiles()` is a default interface method returning empty**, because `ITenancy`
+      is public and implementable outside this repo — an abstract member would be a breaking change,
+      the reason fisher#172 adapted onto `IDatabaseSource` rather than widening it. The empty default
+      is also the safe one: a tenancy Fisher does not know about is read as sharing nothing, so the
+      guard refuses nothing it cannot see.
   - **Neither compliance arm reaches it**, which is why `sharded_tenancy_reads` exists:
     `ShardedTenancyExplorerCompliance` never asks for a *store-global* listing, and
     `DatabasePerTenantExplorerCompliance` has no co-located tenants for a file to misattribute. Five of

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,7 +12,7 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2129 tests green on net9.0 and net10.0** — 2074 in
+**2137 tests green on net9.0 and net10.0** — 2082 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 572 of
 them are shared cross-store compliance tests — 489 event sourcing and 83 document. On JasperFx **2.69.0** / Weasel **9.32.0**.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 55 suites and 572 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,074.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,082.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -109,10 +109,19 @@ are, co-located tenants share one connection pool, and a shared file reports no 
 — a file holding two tenants' data cannot honestly say whose it is.
 
 ::: warning
-**Conjoined tenancy is what makes this safe, and it is not applied for you.** Two tenants sharing a
-file *without* it have no `tenant_id` column to be told apart by, so their data is genuinely the same
-data. Set `TenancyStyle.Conjoined` for the event store and `MultiTenanted()` on any document type the
-tenants share.
+**Conjoined tenancy is what makes this safe, and Fisher refuses the store without it.** Two tenants
+sharing a file with no `tenant_id` column to be told apart by are not two tenants — they are one
+tenant with two names, writing the same rows. So a shared file requires
+`options.Events.TenancyStyle = TenancyStyle.Conjoined` *and* `MultiTenanted()` on every document type,
+and a store that says otherwise fails to build with the tenants and the file named.
+
+The event-store half is required **even for a store that never appends an event**: the event tables
+are created by every migration, and an append does not need its event type registered, so "does this
+store use events" has no honest answer at configuration time. One line and an unused column is the
+price of a rule that cannot guess wrong.
+
+A document type nothing registered at configuration time is caught the first time it is read or
+written, which is the first moment it exists at all.
 :::
 
 ::: tip

--- a/src/Fisher.Tests/Events/sharded_tenancy_reads.cs
+++ b/src/Fisher.Tests/Events/sharded_tenancy_reads.cs
@@ -220,3 +220,239 @@ public class sharded_tenancy_reads : IAsyncLifetime
         acme.ShouldNotBeSameAs(initech);
     }
 }
+
+/// <summary>
+///     fisher#257 — a store where two tenants share a file and nothing in that file can tell them
+///     apart is refused, rather than silently storing them as one tenant with two names.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>The trap is silent in the worst direction</b>, which is why it is a refusal rather than a
+///         note: every read returns plausible data, each tenant sees a superset that looks like its own
+///         plus some, and the first visible symptom is one tenant's row turning up in another's report.
+///         Same shape as fisher#51, and the <c>AddFisherStore&lt;T&gt;</c> precedent one layer down —
+///         two stores over one file with the same <c>DatabaseSchemaName</c> are refused for exactly
+///         this reason (fisher#46).
+///     </para>
+///     <para>
+///         <b>Two checkpoints, because one cannot be complete.</b> Document mappings are created
+///         lazily, so a type nothing registered is invisible at configuration time; the second
+///         checkpoint is where such a type's table is provisioned, on both the read and the write path.
+///         The check deliberately does <em>not</em> live in <c>DocumentSchema.MappingFor</c>, which is
+///         the placement that suggests itself: <c>Schema.For&lt;T&gt;().MultiTenanted()</c> creates the
+///         mapping and <em>then</em> sets the flag, so a refusal there would fire before the line that
+///         satisfies it could run — the trap fisher#218 moved <c>AssertEveryMappingHasIdentity</c> out
+///         of a constructor for.
+///     </para>
+/// </remarks>
+public class shared_file_refusal : IDisposable
+{
+    private readonly TemporaryDatabase _shared = TemporaryDatabase.Create("refusal-shared");
+    private readonly TemporaryDatabase _other = TemporaryDatabase.Create("refusal-other");
+
+    public void Dispose()
+    {
+        _shared.Dispose();
+        _other.Dispose();
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    ///     Two tenants on one file with a non-conjoined event store is refused, naming both tenants and
+    ///     the file.
+    /// </summary>
+    /// <remarks>
+    ///     The message is asserted rather than merely the throw, because the configuration that
+    ///     produces this is usually a loop over a tenant list rather than two visible lines — a reader
+    ///     needs to be told <em>which</em> tenants collided and in which file.
+    /// </remarks>
+    [Fact]
+    public void sharing_a_file_without_conjoined_events_is_refused()
+    {
+        var message = Should.Throw<InvalidOperationException>(() => DocumentStore.For(options =>
+        {
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.MultiTenantedDatabases(d => d
+                .AddTenant("acme", _shared.ConnectionString)
+                .AddTenant("globex", _shared.ConnectionString));
+        })).Message;
+
+        message.ShouldContain("'acme'");
+        message.ShouldContain("'globex'");
+        message.ShouldContain("TenancyStyle.Conjoined");
+    }
+
+    /// <summary>
+    ///     ⚠️ Conjoined event tenancy is required even for a store that never appends an event.
+    /// </summary>
+    /// <remarks>
+    ///     <b>A decision, not an oversight, and this test is what says so.</b> The conditional rule —
+    ///     require it only when the store uses events — cannot be decided honestly: the event tables
+    ///     are created by every migration whether or not anything writes to them, and an append does
+    ///     not need its event type registered, so "does this store use events" has no reliable answer
+    ///     at configuration time. A rule that guessed would refuse some safe stores and admit some
+    ///     unsafe ones. The unconditional rule costs a documents-only sharded store one line and an
+    ///     unused column.
+    /// </remarks>
+    [Fact]
+    public void a_documents_only_store_still_has_to_say_conjoined()
+    {
+        Should.Throw<InvalidOperationException>(() => DocumentStore.For(options =>
+        {
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<ShardedNote>().MultiTenanted();
+            options.MultiTenantedDatabases(d => d
+                .AddTenant("acme", _shared.ConnectionString)
+                .AddTenant("globex", _shared.ConnectionString));
+        })).Message.ShouldContain("TenancyStyle.Conjoined");
+    }
+
+    /// <summary>
+    ///     A document type registered at configuration time and not multi-tenanted is refused there,
+    ///     naming the type.
+    /// </summary>
+    [Fact]
+    public void a_registered_single_tenant_document_type_is_refused_at_configuration_time()
+    {
+        var message = Should.Throw<InvalidOperationException>(() => DocumentStore.For(options =>
+        {
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+            options.Schema.For<ShardedNote>();
+            options.MultiTenantedDatabases(d => d
+                .AddTenant("acme", _shared.ConnectionString)
+                .AddTenant("globex", _shared.ConnectionString));
+        })).Message;
+
+        message.ShouldContain(nameof(ShardedNote));
+        message.ShouldContain("MultiTenanted");
+    }
+
+    /// <summary>
+    ///     The legitimate shape builds, which is the control every refusal above rests on.
+    /// </summary>
+    [Fact]
+    public async Task the_safe_shape_is_accepted()
+    {
+        await using var store = DocumentStore.For(options =>
+        {
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+            options.Schema.For<ShardedNote>().MultiTenanted();
+            options.MultiTenantedDatabases(d => d
+                .AddTenant("acme", _shared.ConnectionString)
+                .AddTenant("globex", _shared.ConnectionString)
+                .AddTenant("initech", _other.ConnectionString));
+        });
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = store.LightweightSession("acme");
+        session.Store(new ShardedNote { Id = Guid.NewGuid(), Text = "fine" });
+        await session.SaveChangesAsync(Token);
+    }
+
+    /// <summary>
+    ///     <b>The second checkpoint.</b> A document type nothing registered is refused when its table is
+    ///     provisioned, which is the first moment it exists at all.
+    /// </summary>
+    /// <remarks>
+    ///     The store builds cleanly here — the configuration-time sweep has no mapping to look at — so
+    ///     this is the half that makes the guard complete rather than merely early. Asserted on both
+    ///     the write and the read path, because fisher#74 established they are two entry points and
+    ///     the one nobody exercises is the one that would be forgotten.
+    /// </remarks>
+    [Fact]
+    public async Task a_lazily_mapped_single_tenant_document_type_is_refused_on_first_write()
+    {
+        await using var store = BuildWithNoDocumentTypesRegistered();
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = store.LightweightSession("acme");
+        session.Store(new ShardedNote { Id = Guid.NewGuid(), Text = "late" });
+
+        (await Should.ThrowAsync<InvalidOperationException>(() => session.SaveChangesAsync(Token)))
+            .Message.ShouldContain(nameof(ShardedNote));
+    }
+
+    /// <inheritdoc cref="a_lazily_mapped_single_tenant_document_type_is_refused_on_first_write" />
+    [Fact]
+    public async Task a_lazily_mapped_single_tenant_document_type_is_refused_on_first_read()
+    {
+        await using var store = BuildWithNoDocumentTypesRegistered();
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = store.QuerySession("acme");
+
+        (await Should.ThrowAsync<InvalidOperationException>(
+                () => session.LoadAsync<ShardedNote>(Guid.NewGuid(), Token)))
+            .Message.ShouldContain(nameof(ShardedNote));
+    }
+
+    /// <summary>
+    ///     Nothing is refused where nothing is shared.
+    /// </summary>
+    /// <remarks>
+    ///     <b>The fact that stops this guard becoming a regression for ordinary database-per-tenant.</b>
+    ///     A tenant with a file to itself needs neither conjoined events nor a multi-tenanted document
+    ///     type — the file boundary is the isolation — and a guard that fired here would refuse the
+    ///     configuration fisher#47 exists for.
+    /// </remarks>
+    [Fact]
+    public async Task a_file_per_tenant_is_untouched()
+    {
+        await using var store = DocumentStore.For(options =>
+        {
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<ShardedNote>();
+            options.MultiTenantedDatabases(d => d
+                .AddTenant("acme", _shared.ConnectionString)
+                .AddTenant("globex", _other.ConnectionString));
+        });
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = store.LightweightSession("acme");
+        session.Store(new ShardedNote { Id = Guid.NewGuid(), Text = "mine alone" });
+        await session.SaveChangesAsync(Token);
+    }
+
+    /// <summary>
+    ///     A single-database store has no shared file and is untouched, whatever it stores.
+    /// </summary>
+    [Fact]
+    public async Task a_single_database_store_is_untouched()
+    {
+        await using var store = DocumentStore.For(options =>
+        {
+            options.ConnectionString = _shared.ConnectionString;
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Schema.For<ShardedNote>();
+        });
+
+        await store.ApplyAllConfiguredChangesToDatabaseAsync(Token);
+
+        await using var session = store.LightweightSession();
+        session.Store(new ShardedNote { Id = Guid.NewGuid(), Text = "one file" });
+        await session.SaveChangesAsync(Token);
+    }
+
+    private DocumentStore BuildWithNoDocumentTypesRegistered()
+        => DocumentStore.For(options =>
+        {
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+            options.MultiTenantedDatabases(d => d
+                .AddTenant("acme", _shared.ConnectionString)
+                .AddTenant("globex", _shared.ConnectionString));
+        });
+}
+
+public class ShardedNote
+{
+    public Guid Id { get; set; }
+    public string Text { get; set; } = string.Empty;
+}

--- a/src/Fisher/DocumentStore.cs
+++ b/src/Fisher/DocumentStore.cs
@@ -33,6 +33,7 @@ public partial class DocumentStore : IDocumentStore
 
         Database = Tenancy.Default;
         options.StorageDatabase = Database;
+        options.SharedTenantFiles = Tenancy.SharedFiles();
 
         // Register the self-aggregating types whose evolvers the source generator emitted, so
         // Projections.AllAggregateTypes() reports an aggregate that was never registered by hand.
@@ -68,6 +69,14 @@ public partial class DocumentStore : IDocumentStore
         // that mattered — a document type Fisher cannot store is a configuration-time error naming the
         // type, rather than an InvalidOperationException on somebody's first save.
         options.Schema.AssertEveryMappingHasIdentity();
+
+        // fisher#257. Beside AssertEveryMappingHasIdentity for the same reason: this is the first
+        // moment the configuration is final — an IConfigureFisher contribution may have added a
+        // document type or turned conjoined tenancy on long after the configuration lambda ran — and
+        // a configuration error belongs here rather than on somebody's first save. It covers every
+        // type the schema has mapped by now; a type mapped lazily later is caught where its table is
+        // provisioned, which is the only place it can be.
+        SharedFileTenancyGuard.AssertTenantsSharingAFileCanBeToldApart(options, Tenancy);
 
         // Builds the async shard registry and fails fast on duplicate projection names.
         options.Projections.AssertValidity(options);

--- a/src/Fisher/Internal/FisherSession.cs
+++ b/src/Fisher/Internal/FisherSession.cs
@@ -988,6 +988,13 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
                 continue;
             }
 
+            // fisher#257's second checkpoint. A document type registered at configuration time was
+            // already checked in DocumentStore's constructor; one mapped lazily could not have been,
+            // and this is where it first becomes real. A store that is not sharded reads an empty list
+            // and returns.
+            Storage.SharedFileTenancyGuard.AssertDocumentTypeCanBeToldApart(
+                Options.SharedTenantFiles, Options.Schema.MappingFor(documentType));
+
             if (EnlistedTransaction is not null)
             {
                 await AssertDocumentTableExistsAsync(documentType, token).ConfigureAwait(false);
@@ -1042,6 +1049,11 @@ internal partial class FisherSession : IDocumentSession, ITenantOperations, ISto
         {
             return;
         }
+
+        // fisher#257, the read half — the same rule the commit loop applies, and a read reaches a
+        // lazily-mapped type just as a write does (fisher#74).
+        Storage.SharedFileTenancyGuard.AssertDocumentTypeCanBeToldApart(
+            Options.SharedTenantFiles, Options.Schema.MappingFor(documentType));
 
         if (EnlistedTransaction is not null)
         {

--- a/src/Fisher/Storage/ITenancy.cs
+++ b/src/Fisher/Storage/ITenancy.cs
@@ -47,6 +47,61 @@ public interface ITenancy : IAsyncDisposable, IDisposable
 
     /// <summary>Every database this store spans.</summary>
     IReadOnlyList<FisherDatabase> AllDatabases();
+
+    /// <summary>
+    ///     The files this tenancy has more than one tenant sharing, if any (fisher#257).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Sharded tenancy is the configuration this answers about</b> — several tenants
+    ///         co-located in one file, which fisher#252 established works and made
+    ///         <see cref="SeparateDatabaseTenancy" /> build one database per <em>file</em> to support.
+    ///         It is safe only while everything stored in that file can be told apart by tenant, and
+    ///         <see cref="SharedFileTenancyGuard" /> is what holds a store to that.
+    ///     </para>
+    ///     <para>
+    ///         <b>A default interface method returning empty, rather than a member every implementation
+    ///         must write.</b> <see cref="ITenancy" /> is public and implementable outside this
+    ///         repository, so adding an abstract member would be a breaking change — the same reason
+    ///         fisher#172 adapted onto <c>IDatabaseSource</c> rather than widening this interface. The
+    ///         empty default is also the safe one: a tenancy Fisher does not know about is read as
+    ///         sharing nothing, so the guard refuses nothing it cannot see rather than guessing.
+    ///     </para>
+    /// </remarks>
+    IReadOnlyList<SharedTenantFile> SharedFiles() => [];
+}
+
+/// <summary>
+///     One database file and the tenants sharing it (fisher#257).
+/// </summary>
+/// <param name="ConnectionString">The connection string the tenants agree on.</param>
+/// <param name="TenantIds">Every tenant resolving to it — always more than one, or it is not shared.</param>
+public sealed record SharedTenantFile(string ConnectionString, IReadOnlyList<string> TenantIds)
+{
+    /// <summary>
+    ///     The file itself, for a message a reader can act on.
+    /// </summary>
+    /// <remarks>
+    ///     The <c>Data Source</c> rather than the whole connection string: the path is the part that
+    ///     identifies the file, and the rest is pragma and pooling noise that makes an error message
+    ///     harder to read rather than more precise.
+    /// </remarks>
+    public string DataSource
+    {
+        get
+        {
+            try
+            {
+                return new Microsoft.Data.Sqlite.SqliteConnectionStringBuilder(ConnectionString).DataSource;
+            }
+            catch (Exception)
+            {
+                // A connection string Fisher did not parse is still worth naming; the guard's message
+                // is better with something in it than with nothing.
+                return ConnectionString;
+            }
+        }
+    }
 }
 
 /// <summary>
@@ -172,9 +227,16 @@ public sealed class SeparateDatabaseTenancy : ITenancy
                   + "conjoined tenancy.");
 
         _files = byFile.Values.ToList();
+
+        _sharedFiles = tenantsPerFile
+            .Where(x => x.Value.Count > 1)
+            .Select(x => new SharedTenantFile(x.Key,
+                x.Value.OrderBy(t => t, StringComparer.Ordinal).ToList()))
+            .ToList();
     }
 
     private readonly List<FisherDatabase> _files;
+    private readonly List<SharedTenantFile> _sharedFiles;
 
     public DatabaseCardinality Cardinality => DatabaseCardinality.StaticMultiple;
 
@@ -197,6 +259,12 @@ public sealed class SeparateDatabaseTenancy : ITenancy
     ///     would read each shared file once per tenant co-located in it.
     /// </remarks>
     public IReadOnlyList<FisherDatabase> AllDatabases() => _files;
+
+    /// <remarks>
+    ///     Computed once, from the configured map — the tenant set here is fixed when the store is
+    ///     built, so this is exhaustive rather than a snapshot.
+    /// </remarks>
+    public IReadOnlyList<SharedTenantFile> SharedFiles() => _sharedFiles;
 
     public async ValueTask DisposeAsync()
     {

--- a/src/Fisher/Storage/SharedFileTenancyGuard.cs
+++ b/src/Fisher/Storage/SharedFileTenancyGuard.cs
@@ -1,0 +1,133 @@
+using JasperFx.MultiTenancy;
+
+namespace Fisher.Storage;
+
+/// <summary>
+///     fisher#257 — refuses a store where two tenants share a database file and nothing in that file
+///     can tell them apart.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Sharded tenancy is a real configuration</b> — several tenants co-located in one file,
+///         with more than one file — and fisher#252 made it work correctly. What makes it work is a
+///         <c>tenant_id</c> the storage can filter on: conjoined event tenancy puts one in the primary
+///         key of <c>fi_streams</c> and <c>fi_events</c>, and <c>MultiTenanted()</c> puts one on a
+///         document table. <b>Without them the tenants are not sharing a file — they are one tenant
+///         with two names</b>, writing the same rows, and the configuration says otherwise.
+///     </para>
+///     <para>
+///         <b>It is silent in the worst direction</b>, which is the whole reason for a refusal rather
+///         than a note. Every read returns plausible data, each tenant sees a superset that looks like
+///         its own plus some, and the first visible symptom is one tenant's row turning up in another's
+///         report. Same shape as fisher#51 — a cross-tenant read where the tenant owning most of the
+///         data sees a correct-looking answer with extras and the tenant with none sees somebody
+///         else's. This is the <c>AddFisherStore&lt;T&gt;</c> precedent one layer down (fisher#46):
+///         two stores over one file with the same <c>DatabaseSchemaName</c> are refused for exactly
+///         this reason.
+///     </para>
+///     <para>
+///         <b>⚠️ Conjoined event tenancy is required unconditionally, even for a store that never
+///         appends an event, and that is a decision rather than an oversight.</b> The conditional rule
+///         — require it only when the store uses events — cannot be decided honestly: the event tables
+///         are created by every migration whether or not anything writes to them, and an append does
+///         not need its event type registered, so "does this store use events" has no reliable answer
+///         at configuration time. A rule that guessed would refuse some safe stores and admit some
+///         unsafe ones. The unconditional rule costs a documents-only sharded store one line and an
+///         unused column, and it is teachable: <em>sharing a file means conjoined</em>.
+///     </para>
+///     <para>
+///         <b>Two checkpoints, because one cannot be complete.</b>
+///         <see cref="AssertTenantsSharingAFileCanBeToldApart" /> runs in <c>DocumentStore</c>'s
+///         constructor and covers everything registered at configuration time, which is the common
+///         case and the one worth reporting early by name. Document mappings are created lazily,
+///         though, so a type nothing registered is invisible there —
+///         <see cref="AssertDocumentTypeCanBeToldApart" /> runs where such a type first becomes real,
+///         at table provisioning, beside the <c>AutoCreate.None</c> check that is already there.
+///     </para>
+///     <para>
+///         <b>The check cannot live in <c>DocumentSchema.MappingFor</c></b>, which is the placement
+///         that suggests itself and is wrong: <c>Schema.For&lt;T&gt;().MultiTenanted()</c> creates the
+///         mapping and <em>then</em> sets the flag, so a refusal at creation would fire before the line
+///         that satisfies it could run. The same trap fisher#218 had to move
+///         <c>AssertEveryMappingHasIdentity</c> out of <c>DocumentMapping</c>'s constructor for.
+///     </para>
+/// </remarks>
+internal static class SharedFileTenancyGuard
+{
+    /// <summary>
+    ///     The configuration-time check: every shared file, against the event store and every document
+    ///     type the schema has mapped so far.
+    /// </summary>
+    internal static void AssertTenantsSharingAFileCanBeToldApart(StoreOptions options, ITenancy tenancy)
+    {
+        var shared = tenancy.SharedFiles();
+
+        if (shared.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var file in shared)
+        {
+            AssertEventsCanBeToldApart(options, file);
+
+            foreach (var mapping in options.Schema.AllMappings())
+            {
+                AssertDocumentTypeCanBeToldApart(mapping, file);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     The first-use check for one document type, for a mapping the configuration-time sweep could
+    ///     not have seen.
+    /// </summary>
+    /// <remarks>
+    ///     Cheap enough to run per provisioning: the list is computed once when the tenancy is built
+    ///     and stashed on <see cref="StoreOptions.SharedTenantFiles" />, so an ordinary store pays a
+    ///     field read and a count.
+    /// </remarks>
+    internal static void AssertDocumentTypeCanBeToldApart(IReadOnlyList<SharedTenantFile> shared,
+        DocumentMapping mapping)
+    {
+        foreach (var file in shared)
+        {
+            AssertDocumentTypeCanBeToldApart(mapping, file);
+        }
+    }
+
+    private static void AssertEventsCanBeToldApart(StoreOptions options, SharedTenantFile file)
+    {
+        if (options.Events.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Tenants {Name(file)} are configured to share the database file '{file.DataSource}', but the "
+            + "event store is not conjoined — fi_streams and fi_events have no tenant_id to tell them "
+            + "apart, so those tenants would write the same rows and read each other's. Set "
+            + "options.Events.TenancyStyle = TenancyStyle.Conjoined to share a file, or give each tenant "
+            + "a connection string of its own. See fisher#257.");
+    }
+
+    private static void AssertDocumentTypeCanBeToldApart(DocumentMapping mapping, SharedTenantFile file)
+    {
+        if (mapping.IsConjoined)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Tenants {Name(file)} are configured to share the database file '{file.DataSource}', but the "
+            + $"document type '{mapping.DocumentType.FullName}' is not multi-tenanted — its table has no "
+            + "tenant_id, so one row per id is all those tenants get between them and each would "
+            + "overwrite and read the others'. Declare it with "
+            + $"options.Schema.For<{mapping.DocumentType.Name}>().MultiTenanted(), or with "
+            + "[MultiTenanted] on the type, or give each tenant a connection string of its own. See "
+            + "fisher#257.");
+    }
+
+    private static string Name(SharedTenantFile file)
+        => string.Join(", ", file.TenantIds.Select(x => $"'{x}'"));
+}

--- a/src/Fisher/StoreOptions.cs
+++ b/src/Fisher/StoreOptions.cs
@@ -294,6 +294,18 @@ public class StoreOptions
     internal Storage.TenantDatabases? TenantDatabases { get; private set; }
 
     /// <summary>
+    ///     The files more than one tenant shares, stashed here by <see cref="DocumentStore" />'s
+    ///     constructor once the tenancy is built (fisher#257).
+    /// </summary>
+    /// <remarks>
+    ///     Written back onto the options for the same reason <see cref="StorageDatabase" /> is: a
+    ///     session holds the options and the database but not the store, and the guard's per-type
+    ///     checkpoint runs from the session's table provisioning. Empty for every store that is not
+    ///     sharded, which is what keeps that checkpoint a field read and a count.
+    /// </remarks>
+    internal IReadOnlyList<Storage.SharedTenantFile> SharedTenantFiles { get; set; } = [];
+
+    /// <summary>
     ///     A database file per tenant, with the set of tenants asked for rather than declared
     ///     (fisher#58).
     /// </summary>


### PR DESCRIPTION
Closes #257.

#252 established that **sharded** tenancy works — several tenants co-located in one file — and made `SeparateDatabaseTenancy` build one `FisherDatabase` per file to support it. What it deliberately left out is the guard against getting it wrong.

Two tenants on one file with no `tenant_id` to be told apart by are not two tenants; they are **one tenant with two names**, writing the same rows, while the configuration says otherwise. It is silent in the #51 direction: every read returns plausible data, each tenant sees a superset that looks like its own plus some, and the first visible symptom is one tenant's row in another's report. Same rule as #46's refusal of two stores over one file with one `DatabaseSchemaName`, a layer down.

**A shared file now requires conjoined event tenancy *and* `MultiTenanted()` on every document type.**

## ⚠️ Conjoined event tenancy is required even for a store that never appends an event

A decision rather than over-reach, and `a_documents_only_store_still_has_to_say_conjoined` pins it as one. The conditional rule — require it only when the store uses events — **cannot be decided honestly**: the event tables are created by every migration whether anything writes to them or not, and an append does not need its event type registered, so *"does this store use events"* has no reliable answer at configuration time. A rule that guessed would refuse some safe stores and admit some unsafe ones. The unconditional rule costs a documents-only sharded store one line and an unused column, and it is teachable: **sharing a file means conjoined**.

## Two checkpoints, because one cannot be complete

| Where | Covers |
|---|---|
| `DocumentStore`'s constructor | everything registered at configuration time — beside `AssertEveryMappingHasIdentity`, and for its reason: the first moment the configuration is final |
| Table provisioning, read **and** write | a document type nothing registered, at the first moment it exists (#74's two entry points) |

Verified by removing each: **two tests fail without the second, three without the first.**

⚠️ **The check cannot live in `DocumentSchema.MappingFor`**, which is the placement that suggests itself and is wrong: `Schema.For<T>().MultiTenanted()` creates the mapping and *then* sets the flag, so a refusal at creation fires before the line that satisfies it could run — the trap #218 moved `AssertEveryMappingHasIdentity` out of `DocumentMapping`'s constructor for.

## `ITenancy.SharedFiles()` is a default interface method

Returning empty, because `ITenancy` is **public and implementable outside this repository** — an abstract member would be a breaking change, which is the reason #172 adapted onto `IDatabaseSource` rather than widening this interface. The empty default is also the safe one: a tenancy Fisher does not know about is read as sharing nothing, so the guard refuses nothing it cannot see.

## What is deliberately *not* refused

`a_file_per_tenant_is_untouched` and `a_single_database_store_is_untouched` are what stop this becoming a regression for the configuration #47 exists for. A tenant with a file to itself needs neither flag — the file boundary *is* the isolation — and a guard that fired there would refuse ordinary database-per-tenant.

Also out of scope, and worth saying: `DynamicTenancy` tenants appear at runtime, so a construction-time sweep cannot be exhaustive over them. Its files are resolved by convention (`DirectoryTenantSource` maps a tenant to a path) so sharing is not the default shape there, and `SharedFiles()`'s empty default means the guard simply says nothing rather than guessing. If runtime sharding becomes a thing people do, the checkpoint is at tenant resolution and it is its own issue.

## Verification

- `dotnet test fisher.slnx` green on both TFMs — **2,137 tests**, 8 of them new.
- Both checkpoints verified load-bearing by removal.
- `scripts/check_scoreboard.py` agrees with the run; `check_no_leaked_databases.py` clean.
- `npm run docs-build` clean; the multi-tenancy page's sharding warning now describes a refusal rather than an instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)