### PR TITLE
Bump JasperFx to 2.69.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -871,6 +871,20 @@ implements `ISubscriptionRunner<ISubscription>`.
 - **There is no inline equivalent**, deliberately: "inline" would just be code in the caller's own
   unit of work. A subscription needs the daemon running — `AddAsyncDaemon()` hosts it with everything
   else.
+- ⚠️ **Fisher's daemon is built with an `ILogger`, never an `ILoggerFactory`, and that turned out to
+  matter.** jasperfx#827 (fixed in 2.69.1) was `JasperFxSubscriptionBase.BuildExecution`'s two
+  overloads disagreeing: the `ILoggerFactory` one passed the *database* where
+  `SubscriptionExecution<T>` resolves its `ISubscriptionRunner<T>` off the *store*, so construction
+  threw and **no subscription could start on that path, on any store**.
+  `JasperFxAsyncDaemon.buildAgentForShard` takes it whenever the daemon was built with a factory —
+  which is the hosted path everywhere except here, because `FisherDaemonHostedService` calls
+  `BuildProjectionDaemonsAsync(_logger)`. **Verified rather than assumed**: the regression test was run
+  against the 2.69.0 pin and passed.
+  - **What was missing was the coverage, not the behaviour.** Every subscription test built its daemon
+    by hand, and so does `SubscriptionCompliance` — which is why nothing on any store exercised the
+    other overload. `subscriptions_under_the_hosted_daemon` is the fact that a subscription runs under
+    `AddAsyncDaemon()` at all, and it is what would catch Fisher if the daemon ever moved to the
+    logger-factory constructor.
 
 One test-shaped trap worth recording, because it presented as an intermittent: **`WaitForNonStale`
 does not imply the post-commit listener has run.** The progression row is written *inside* the batch's
@@ -2648,10 +2662,16 @@ because the same reader feeds both. What is Fisher's is two registrations.
   store-derived Event Model that needs a Postgres or SQL Server container to demonstrate is one nobody
   exercises while writing the feature. Every fact in `event_model_source` runs against a throwaway
   SQLite file.
-- ⚠️ **A View slice's `ConsumedEvents` carries `Archived` and `Compacted<T>`**, because `AppliedEvents`
-  is derived from `IAggregateProjection.AllEventTypes` and every aggregation projection handles those
-  whether or not the aggregate declares an `Apply`. Nothing here is Fisher's to change; pinned rather
-  than asserted around, and reported upstream as jasperfx#829.
+- **A View slice's `ConsumedEvents` is what the aggregate declares an `Apply` for, and nothing else** —
+  but only since JasperFx 2.69.1. It used to carry `Archived` and `Compacted<T>` too, because
+  `AppliedEvents` is derived from `IAggregateProjection.AllEventTypes` and every aggregation projection
+  handles those whether the aggregate declares an `Apply` or not: correct about what the projection
+  *handles*, and two orange stickies for events the application never wrote on a canvas. Reported as
+  jasperfx#829 and filtered upstream in `ProjectionEventModelSource.ToSlice` rather than in the reader
+  that fills `AppliedEvents`, since a monitoring console asking "what does this projection handle"
+  wants both and only the canvas question is narrow.
+  **Pinning the exact set rather than asserting around it is what made the fix visible on the bump**,
+  which is the argument for pinning an upstream behaviour you have just filed an issue about.
 
 **There is no `event-model` CLI command in JasperFx 2.69.0**, so jasperfx#825's third acceptance item
 is covered at the seam a command would read — `EventModelDiscovery.AssembleAsync` over a plain Fisher
@@ -4768,7 +4788,7 @@ coalescing on purpose. Do not present it as a performance feature.
 
 ### Compliance suites
 
-**Fisher enrolls 55 of the 56 suites `JasperFx.Events.ComplianceTests` 2.69.0 ships — 572 tests.**
+**Fisher enrolls 55 of the 56 suites `JasperFx.Events.ComplianceTests` 2.69.1 ships — 572 tests.**
 `JasperFx.Events.ComplianceTests` is referenced unconditionally — the old `$(EnableComplianceTests)`
 gate is gone. See HANDOFF.md for the live scoreboard, which is machine-checked against a real run by
 `scripts/check_scoreboard.py`; what follows is the history and the mechanics.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
         <!-- Core Critter Stack dependencies. JasperFx and Weasel move in lockstep: Weasel 9.23.x
              carries a JasperFx 2.37.x floor, so bump both together rather than letting one resolve
              transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.69.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.69.0" />
+        <PackageVersion Include="JasperFx" Version="2.69.1" />
+        <PackageVersion Include="JasperFx.Events" Version="2.69.1" />
         <!-- The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Fisher.Tests so JasperFx's aggregate source generator binds
              Fisher's own session types. See src/Fisher.Tests/Compliance. -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.0" />
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.1" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.1" />
 
         <!-- Weasel.Sqlite: schema management, table definitions, migrations, PRAGMA-applying data
              source. Weasel.Storage: the dialect-neutral closed-shape document + event storage

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,9 +12,9 @@ equivalent for and never will.
 [CLAUDE.md](CLAUDE.md) has the architecture and the SQLite traps. This document is the compliance
 scoreboard and the things that are true right now but not obvious from either.
 
-**2137 tests green on net9.0 and net10.0** — 2082 in
+**2138 tests green on net9.0 and net10.0** — 2083 in
 `Fisher.Tests`, 36 in `Fisher.AspNetCore.Tests` and 19 in `Fisher.EntityFrameworkCore.Tests`. 572 of
-them are shared cross-store compliance tests — 489 event sourcing and 83 document. On JasperFx **2.69.0** / Weasel **9.32.0**.
+them are shared cross-store compliance tests — 489 event sourcing and 83 document. On JasperFx **2.69.1** / Weasel **9.32.0**.
 
 ## The high-water opt-out, audited (#199)
 
@@ -662,7 +662,7 @@ Three of the seven turned up a real defect or a wrong premise, which is the usef
 
 ## Where we are against the compliance suites
 
-`JasperFx.Events.ComplianceTests` 2.69.0 ships 56 suites; Fisher enrolls **55 of them, 572 tests**.
+`JasperFx.Events.ComplianceTests` 2.69.1 ships 56 suites; Fisher enrolls **55 of them, 572 tests**.
 Fisher passes **572 of them, across all
 55 suites**. Every suite compiles; every one is also subclassed and running. The five that did not
 pass on the 2.65.0 pin were the upstream ones described at the top of this file, and 2.66.0 closed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ process**. There is no server to install, nothing to provision, and nothing to k
 > `Fisher.AspNetCore` and `Fisher.EntityFrameworkCore` companion packages all work and are tested.
 >
 > Fisher passes **all 55 suites and 572 tests** it enrolls from `JasperFx.Events.ComplianceTests`,
-> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,082.
+> the shared cross-store suite Marten and Polecat also enroll in, alongside its own 2,083.
 >
 > That suite pins **API portability, not behavioural equivalence** — code written against one store
 > compiles and runs against another. It does not pin that the three behave identically, and they do

--- a/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
+++ b/src/Fisher.Tests/Compliance/fisher_event_store_compliance.cs
@@ -9,7 +9,7 @@ namespace Fisher.Tests.Compliance;
  * these tests cannot drift between the products.
  *
  * Suites were added one at a time as Fisher grew into them, and fifty-five are enrolled from
- * JasperFx.Events.ComplianceTests 2.69.0, which itself ships fifty-six concrete suites across
+ * JasperFx.Events.ComplianceTests 2.69.1, which itself ships fifty-six concrete suites across
  * fifty-five files -- MultiDatabaseExplorerCompliance is one file holding two arms. One is not
  * enrolled: SingleTenantedEventSlicingCompliance, for the precondition reason set out below.
  *

--- a/src/Fisher.Tests/Configuration/event_model_source.cs
+++ b/src/Fisher.Tests/Configuration/event_model_source.cs
@@ -36,6 +36,13 @@ namespace Fisher.Tests.Configuration;
 ///         wiring can get wrong on a store that implements <c>IEventStore</c> explicitly and hands out
 ///         ancillary stores as <c>DispatchProxy</c> markers.
 ///     </para>
+///     <para>
+///         <b>Wiring it is also what found jasperfx#829</b>, fixed in JasperFx 2.69.1: a View slice's
+///         consumed events carried <c>Archived</c> and <c>Compacted&lt;T&gt;</c>, because
+///         <c>AppliedEvents</c> is what the projection <em>handles</em> rather than what the aggregate
+///         declares an <c>Apply</c> for. Pinning the exact set here rather than asserting around it is
+///         what made the fix visible on the bump.
+///     </para>
 /// </remarks>
 public class event_model_source : IAsyncLifetime
 {
@@ -83,17 +90,22 @@ public class event_model_source : IAsyncLifetime
         slice.ReadModelTypes.Select(x => x.Name).ShouldBe([nameof(ModelLedger)]);
         slice.ProjectionTypes.ShouldNotBeEmpty();
 
-        var consumed = slice.ConsumedEvents.Select(x => x.Name).ToArray();
-        consumed.ShouldContain(nameof(Credited));
-        consumed.ShouldContain(nameof(Debited));
-
-        // ⚠️ JasperFx's own lifecycle events come with them, because AppliedEvents is derived from
-        // IAggregateProjection.AllEventTypes and every aggregation projection handles these two
-        // whether or not the aggregate declares an Apply for them. Pinned rather than filtered:
-        // nothing here is Fisher's to change -- the same reader feeds AggregateDescriptor.AppliedEvents
-        // -- and a canvas showing stickies for events the application never wrote is worth knowing
-        // about rather than quietly asserting around. Reported upstream as jasperfx#829.
-        consumed.ShouldContain("Archived");
+        // Exactly the two the aggregate declares an Apply for -- no more.
+        //
+        // ⚠️ This asserted the OPPOSITE until JasperFx 2.69.1, and the flip is the point rather than
+        // an edit. JasperFxSingleStreamProjectionBase.determineEventTypes() concatenates Archived and
+        // Compacted<T> onto every non-empty apply set whether or not the aggregate declares an Apply
+        // for them, so this slice reported four event types -- correct about what the projection
+        // HANDLES, and not what a canvas means by the events a read model consumes: two orange
+        // stickies for events the application never wrote and no command slice emits, linking to
+        // nothing. Reported as jasperfx#829 and filtered upstream in ProjectionEventModelSource.ToSlice
+        // rather than in the reader that fills AppliedEvents, since a monitoring console asking "what
+        // does this projection handle" wants both and only the CANVAS question is narrow.
+        //
+        // Pinned as an exact set rather than two ShouldContains, which is what made the flip visible
+        // on the bump instead of silently passing either way.
+        slice.ConsumedEvents.Select(x => x.Name).OrderBy(x => x, StringComparer.Ordinal)
+            .ShouldBe([nameof(Credited), nameof(Debited)]);
     }
 
     /// <summary>
@@ -170,7 +182,7 @@ public class event_model_source : IAsyncLifetime
 
         var ancillary = model.Slices.Single(x => x.Name == nameof(Manifest));
         ancillary.Pattern.ShouldBe(SlicePattern.View);
-        ancillary.ConsumedEvents.Select(x => x.Name).ShouldContain(nameof(Filed));
+        ancillary.ConsumedEvents.Select(x => x.Name).ShouldBe([nameof(Filed)]);
         ancillary.ReadModelTypes.Select(x => x.Name).ShouldBe([nameof(Manifest)]);
     }
 

--- a/src/Fisher.Tests/Events/subscriptions.cs
+++ b/src/Fisher.Tests/Events/subscriptions.cs
@@ -5,6 +5,8 @@ using JasperFx;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Fisher.Tests.Events;
 
@@ -245,5 +247,123 @@ public class subscriptions : IAsyncLifetime
             ISubscriptionController controller, IDocumentSession operations,
             CancellationToken cancellationToken)
             => Task.FromResult<IDaemonChangeListener>(NullDaemonChangeListener.Instance);
+    }
+}
+
+/// <summary>
+///     A subscription running under the <em>hosted</em> daemon — <c>AddAsyncDaemon()</c>, which is the
+///     route the documentation names and the only one an application actually takes.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Written for jasperfx#827 and kept for a better reason: Fisher turned out to be immune,
+///         and the immunity is one line deep.</b> That bug was
+///         <c>JasperFxSubscriptionBase.BuildExecution</c>'s two overloads disagreeing — the
+///         <c>ILoggerFactory</c> one passed the <em>database</em> where
+///         <c>SubscriptionExecution&lt;T&gt;</c> resolves its <c>ISubscriptionRunner&lt;T&gt;</c> off
+///         the <em>store</em>, so construction threw <c>ArgumentOutOfRangeException</c> and no
+///         subscription could start on that path. <c>JasperFxAsyncDaemon.buildAgentForShard</c> takes
+///         it whenever the daemon was built with a logger factory.
+///     </para>
+///     <para>
+///         <b>Fisher never reaches it, because Fisher's daemon is built with an <c>ILogger</c> — on the
+///         hosted path too.</b> <c>FisherDaemonHostedService</c> calls
+///         <c>BuildProjectionDaemonsAsync(_logger)</c>, so the correct overload is the only one this
+///         store has ever taken. <b>Verified rather than assumed</b>: this test was run against the
+///         2.69.0 pin and passed, which is what turned "Fisher was broken and is now fixed" into "the
+///         hosted path was untested here and happens to be safe".
+///     </para>
+///     <para>
+///         <b>The gap it closes is therefore Fisher's own coverage, not Fisher's behaviour.</b> Every
+///         subscription test above builds its daemon by hand, and so does
+///         <c>SubscriptionCompliance</c> — which is why nothing on any store exercised the other
+///         overload. So there was no fact anywhere saying a subscription runs under
+///         <c>AddAsyncDaemon()</c>, which is the route the documentation names and the only one an
+///         application takes. This is that fact, and it is what would catch Fisher if the daemon ever
+///         moved to the logger-factory constructor.
+///     </para>
+///     <para>
+///         Deliberately end-to-end and unglamorous — start the host, append, wait for the
+///         subscription's own signal — because the failure mode it guards against is <em>starting</em>,
+///         and any assertion reaching the events at all would catch it.
+///     </para>
+/// </remarks>
+public class subscriptions_under_the_hosted_daemon : IAsyncLifetime
+{
+    private readonly TemporaryDatabase _database = TemporaryDatabase.Create("hosted-subscription");
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        _database.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private CancellationToken Token => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task a_subscription_starts_and_sees_events_under_add_async_daemon()
+    {
+        var subscription = new HostedRecordingSubscription();
+
+        using var host = await Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
+            .ConfigureServices(services => services.AddFisher(options =>
+                {
+                    options.ConnectionString = _database.ConnectionString;
+                    options.AutoCreateSchemaObjects = AutoCreate.All;
+                    options.Projections.Subscribe(subscription);
+                })
+                .ApplyAllDatabaseChangesOnStartup()
+                .AddAsyncDaemon())
+            .StartAsync(Token);
+
+        try
+        {
+            var store = host.Services.GetRequiredService<IDocumentStore>();
+
+            await using (var session = store.LightweightSession())
+            {
+                session.Events.StartStream<Quest>(Guid.NewGuid(),
+                    new QuestStarted("Chart the Minch"), new QuestStarted("Chart the Solent"));
+                await session.SaveChangesAsync(Token);
+            }
+
+            // Waited on the subscription's own signal rather than on non-staleness: the progression
+            // row is written inside the batch's transaction, so non-stale becomes true strictly before
+            // anything the subscription did is observable. Same trap fisher#232 records one seam over.
+            await subscription.SawTwo.Task.WaitAsync(TimeSpan.FromSeconds(30), Token);
+
+            subscription.Seen.Count.ShouldBe(2);
+        }
+        finally
+        {
+            await host.StopAsync(Token);
+        }
+    }
+
+    private sealed class HostedRecordingSubscription : SubscriptionBase
+    {
+        public ConcurrentQueue<IEvent> Seen { get; } = new();
+
+        public TaskCompletionSource SawTwo { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override Task<IDaemonChangeListener> ProcessEventsAsync(EventRange page,
+            ISubscriptionController controller, IDocumentSession operations,
+            CancellationToken cancellationToken)
+        {
+            foreach (var @event in page.Events)
+            {
+                Seen.Enqueue(@event);
+            }
+
+            if (Seen.Count >= 2)
+            {
+                SawTwo.TrySetResult();
+            }
+
+            return Task.FromResult<IDaemonChangeListener>(NullDaemonChangeListener.Instance);
+        }
     }
 }


### PR DESCRIPTION
Two fixes in 2.69.1, and Fisher's relationship to them is opposite in each case.

## jasperfx#829 — the issue this repository filed

A View slice's `ConsumedEvents` no longer carries `Archived` and `Compacted<T>`. That is [JasperFx/jasperfx#829](https://github.com/JasperFx/jasperfx/issues/829), filed from here while wiring `ProjectionEventModelSource` in (#251), and the fix landed as option (2) of the three it laid out: filtered in `ProjectionEventModelSource.ToSlice` rather than in the reader that fills `AppliedEvents` — a monitoring console asking *"what does this projection handle"* wants both, and only the **canvas** question is narrow.

`event_model_source.a_registered_projection_becomes_a_view_slice` asserted the **old** behaviour, deliberately, and was **the only test in the repository to fail on the bump**. That is the pin doing its job. It is now an exact set rather than two `ShouldContain`s, which is what made the flip visible instead of passing either way.

## jasperfx#827 — ⚠️ Fisher was immune, and I checked rather than assumed

`JasperFxSubscriptionBase`'s two `BuildExecution` overloads disagreed: the `ILoggerFactory` one passed the *database* where `SubscriptionExecution<T>` resolves its `ISubscriptionRunner<T>` off the *store*. Construction threw `ArgumentOutOfRangeException`, so **no subscription could start on that path, on any store** — and `JasperFxAsyncDaemon.buildAgentForShard` takes it whenever the daemon was built with a logger factory, which is the hosted path.

**Fisher never reaches it.** Fisher's daemon is built with an `ILogger` on the hosted path too — `FisherDaemonHostedService` calls `BuildProjectionDaemonsAsync(_logger)` — so the correct overload is the only one this store has ever taken.

I wrote the regression test first and **ran it against the 2.69.0 pin, where it passed**. That is what turned "Fisher was broken and is now fixed" into "the hosted path was untested here and happens to be safe", and the test's own doc comment says so rather than claiming a bug Fisher never had.

### What that half actually closes is Fisher's coverage

Every subscription test in this repo builds its daemon by hand, and so does `SubscriptionCompliance` — which is precisely why nothing on **any** store exercised the other overload. So there was no fact anywhere saying a subscription runs under `AddAsyncDaemon()` at all, which is the route the documentation names and the only one an application takes. `subscriptions_under_the_hosted_daemon` is that fact, and it is what would catch Fisher if the daemon ever moved to the logger-factory constructor.

## Scope

The compliance package is **byte-identical** between 2.69.0 and 2.69.1 — I diffed the whole `contentFiles` tree, not just the suite list — so no suite or seam moved: **55 suites, 572 tests, unchanged**.

## Verification

- `dotnet test fisher.slnx` green on both TFMs — **2,138 tests**, one new.
- `scripts/check_scoreboard.py` agrees with the run; `check_no_leaked_databases.py` clean; `npm run docs-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)